### PR TITLE
Add a prow_config.yaml file to configure our prow jobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/kubeflow/tf-operator/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/tf-operator?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/tf-operator)](https://goreportcard.com/report/github.com/kubeflow/tf-operator)
 [Prow Test Dashboard](https://k8s-testgrid.appspot.com/sig-big-data)
-[Prow Jobs](https://prow.k8s.io/?repo=tensorflow%2Fk8s)
+[Prow Jobs](https://prow.k8s.io/?repo=kubeflow%2Ftf-operator)
 
 ## Overview
 

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,0 +1,6 @@
+# This file configures the workflows to trigger in our Prow jobs.
+# see kubeflow/testing/py/run_e2e_workflow.py
+workflows:
+  - app_dir: kubeflow/tf-operator/test/workflows
+    component: workflows
+    name": tfjob-e2e

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -3,4 +3,4 @@
 workflows:
   - app_dir: kubeflow/tf-operator/test/workflows
     component: workflows
-    name": tfjob-e2e
+    name: tfjob-e2e

--- a/py/prow.py
+++ b/py/prow.py
@@ -27,8 +27,8 @@ from py import util  # pylint: disable=no-name-in-module
 
 # Default repository organization and name.
 # This should match the values used in Go imports.
-GO_REPO_OWNER = "tensorflow"
-GO_REPO_NAME = "k8s"
+GO_REPO_OWNER = "kubeflow"
+GO_REPO_NAME = "tf-operator"
 
 GCS_REGEX = re.compile("gs://([^/]*)/(.*)")
 

--- a/py/py_checks.py
+++ b/py/py_checks.py
@@ -51,7 +51,7 @@ def run_lint(args):
           util.run(["pylint", "--rcfile=" + rc_file, full_path],
                     cwd=args.src_dir)
         except subprocess.CalledProcessError:
-          failed_files.append(full_path.strip(args.src_dir))
+          failed_files.append(full_path.strip[len(args.src_dir):])
 
   if failed_files:
     failed_files.sort()

--- a/py/release.py
+++ b/py/release.py
@@ -25,8 +25,8 @@ from py import util
 # Repo org and name can be set via environment variables when running
 # on PROW. But we choose sensible defaults so that we can run locally without
 # setting defaults.
-REPO_ORG = os.getenv("REPO_OWNER", "tensorflow")
-REPO_NAME = os.getenv("REPO_NAME", "k8s")
+REPO_ORG = os.getenv("REPO_OWNER", "kubeflow")
+REPO_NAME = os.getenv("REPO_NAME", "tf-operator")
 
 RESULTS_BUCKET = "mlkube-testing-results"
 JOB_NAME = "tf-k8s-postsubmit"

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -16,8 +16,8 @@ class ReleaseTest(unittest.TestCase):
   def test_build_postsubmit(self, mock_build_and_push, mock_clone,    # pylint: disable=no-self-use
                             _mock_install, _mock_os, _mock_makedirs):
     # Make sure REPO_OWNER and REPO_NAME aren't changed by the environment
-    release.REPO_ORG = "tensorflow"
-    release.REPO_NAME = "k8s"
+    release.REPO_ORG = "kubeflow"
+    release.REPO_NAME = "tf-operator"
 
     parser = release.build_parser()
     args = parser.parse_args(["postsubmit", "--src_dir=/top/src_dir"])
@@ -27,7 +27,7 @@ class ReleaseTest(unittest.TestCase):
       '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
       mock.ANY)
     mock_clone.assert_called_once_with(
-      '/top/src_dir/git_tensorflow_k8s', 'tensorflow', 'k8s', None, None)
+      '/top/src_dir/git_tensorflow_k8s', 'kubeflow', 'tf-operator', None, None)
 
   @mock.patch("py.release.os.makedirs")
   @mock.patch("py.release.os.symlink")
@@ -44,7 +44,7 @@ class ReleaseTest(unittest.TestCase):
       '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
       mock.ANY)
     mock_clone.assert_called_once_with(
-      "/top/src_dir/git_tensorflow_k8s", "tensorflow", "k8s", "22",
+      "/top/src_dir/git_tensorflow_k8s", "kubeflow", "tf-operator", "22",
       ["pull/10/head:pr"])
 
   def test_update_values(self):

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -78,12 +78,14 @@ def run_test(args):
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
         name, namespace)
   except Exception as e: # pylint: disable-msg=broad-except
-    logging.error("There was a problem running the job; Exception {0}; ".format(
-      e))
+    # TODO(jlewi): I'm observing flakes where the exception has message "status"
+    # in an effort to try to nail down this exception we print out more
+    # information about the exception.
+    logging.error("There was a problem running the job; Exception %s", e)
     logging.error("There was a problem running the job; Exception "
-                  "message: {0} ".format(e.message))
-    logging.error("Exception type: {0}".format(e.__class__))
-    logging.error("Exception args {0}".format(e.args))
+                  "message: %s", e.message)
+    logging.error("Exception type: %s", e.__class__)
+    logging.error("Exception args: %s", e.args)
     # We want to catch all exceptions because we want the test as failed.
     t.failure = e.message
   finally:

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -87,7 +87,8 @@ def run_test(args):
     logging.error("Exception type: %s", e.__class__)
     logging.error("Exception args: %s", e.args)
     # We want to catch all exceptions because we want the test as failed.
-    t.failure = e.message
+    t.failure = ("Exception occured; type {0} message {1}".format(
+      e.__class__, e.message))
   finally:
     t.time = time.time() - start
     if args.junit_path:

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -78,7 +78,10 @@ def run_test(args):
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
         name, namespace)
   except Exception as e: # pylint: disable-msg=broad-except
-    logging.error("There was a problem running the job; %s", e)
+    logging.error("There was a problem running the job; Exception %s; "
+                  "Exception message: %s",
+                  "Exception args: %s",
+                  "Exception type: %s", e, e.message, e.args, e.__class__)
     # We want to catch all exceptions because we want the test as failed.
     t.failure = e.message
   finally:

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -78,7 +78,8 @@ def run_test(args):
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
         name, namespace)
   except Exception as e: # pylint: disable-msg=broad-except
-    # We want to catch all exceptions because we warm the test as failed.
+    logging.error("There was a problem running the job; %s", e)
+    # We want to catch all exceptions because we want the test as failed.
     t.failure = e.message
   finally:
     t.time = time.time() - start

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -63,9 +63,9 @@ def run_test(args):
     results = tf_job_client.wait_for_job(api_client, namespace, name,
                                          status_callback=tf_job_client.log_status)
 
-    if results["status"]["state"].lower() != "succeeded":
+    if results.get("status", {}).get("state", {}).lower() != "succeeded":
       t.failure = "Job {0} in namespace {1} in state {2}".format(
-        name, namespace, results["status"]["state"])
+        name, namespace, results.get("status", {}).get("state", None))
 
     # TODO(jlewi):
     #  Here are some validation checks to run:

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -78,9 +78,11 @@ def run_test(args):
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
         name, namespace)
   except Exception as e: # pylint: disable-msg=broad-except
-    logging.error("There was a problem running the job; Exception %s; "
-                  "Exception message: %s",
-                  "Exception type: %s", e, e.message, e.__class__)
+    logging.error("There was a problem running the job; Exception {0}; ".format(
+      e))
+    logging.error("There was a problem running the job; Exception "
+                  "message: {0} ".format(e.message))
+    logging.error("Exception type: {0}".format(e.__class__))
     logging.error("Exception args {0}".format(e.args))
     # We want to catch all exceptions because we want the test as failed.
     t.failure = e.message

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -80,8 +80,8 @@ def run_test(args):
   except Exception as e: # pylint: disable-msg=broad-except
     logging.error("There was a problem running the job; Exception %s; "
                   "Exception message: %s",
-                  "Exception args: %s",
-                  "Exception type: %s", e, e.message, e.args, e.__class__)
+                  "Exception type: %s", e, e.message, e.__class__)
+    logging.error("Exception args {0}".format(e.args))
     # We want to catch all exceptions because we want the test as failed.
     t.failure = e.message
   finally:

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -85,7 +85,8 @@ def wait_for_job(client, namespace, name,
     if status_callback:
       status_callback(results)
 
-    if results["status"]["phase"] == "Done":
+    # If we poll the CRD quick enough status won't have been set yet.
+    if results.get("status", {}).get("phase", {}) == "Done":
       return results
 
     if datetime.datetime.now() + polling_interval > end_time:

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -55,10 +55,10 @@ def create_tf_job(client, spec):
 def log_status(tf_job):
   """A callback to use with wait_for_job."""
   logging.info("Job %s in namespace %s; phase=%s, state=%s,",
-           tf_job["metadata"]["name"],
-           tf_job["metadata"]["namespace"],
-           tf_job["status"]["phase"],
-           tf_job["status"]["state"])
+           tf_job.get("metadata", {}).get("name"),
+           tf_job.get("metadata", {}).get("namespace"),
+           tf_job.get("status", {}).get("phase"),
+           tf_job.get("status", {}).get("state"))
 
 def wait_for_job(client, namespace, name,
                  timeout=datetime.timedelta(minutes=5),

--- a/py/util.py
+++ b/py/util.py
@@ -25,8 +25,8 @@ from kubernetes.client import rest
 # This should match the values used in Go imports.
 # We default to environment variables so that it can be set correctly when
 # running under prow.
-MASTER_REPO_OWNER = os.getenv("REPO_OWNER", "tensorflow")
-MASTER_REPO_NAME = os.getenv("REPO_NAME", "k8s")
+MASTER_REPO_OWNER = os.getenv("REPO_OWNER", "kubeflow")
+MASTER_REPO_NAME = os.getenv("REPO_NAME", "tf-operator")
 
 # TODO(jlewi): Should we stream the output by polling the subprocess?
 # look at run_and_stream in build_and_push.

--- a/test/workflows/components/params.libsonnet
+++ b/test/workflows/components/params.libsonnet
@@ -8,7 +8,7 @@
     // Each object below should correspond to a component in the components/ directory
     workflows: {
       bucket: "mlkube-testing_temp",
-      name: "jlewi-tf-k8s-presubmit-test-374-6e32",
+      name: "some-very-very-very-very-very-long-name-jlewi-tf-k8s-presubmit-test-374-6e32",
       namespace: "kubeflow-test-infra",
       prow_env: "JOB_NAME=tf-k8s-presubmit-test,JOB_TYPE=presubmit,PULL_NUMBER=374,REPO_NAME=k8s,REPO_OWNER=tensorflow,BUILD_NUMBER=6e32",
     },

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -145,7 +145,8 @@
             },
           ],  // volumes
           // onExit specifies the template that should always run when the workflow completes.
-          onExit: "exit-handler",
+          // DO NOT SUBMIT this is a hack to leave it up for debugging.
+          // onExit: "exit-handler",
           templates: [
             {
               name: "e2e",

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -194,12 +194,13 @@
             {
               name: "exit-handler",
               steps: [
-                [
-                  {
-                    name: "teardown-cluster",
-                    template: "teardown-cluster",
-                  },
-                ],
+                // DO NOT SUBMIT. We leave cluster up to facilitate debugging.
+                //[
+                //  {
+                //    name: "teardown-cluster",
+                //    template: "teardown-cluster",
+                //  },
+                //],
                 [{
                   name: "copy-artifacts",
                   template: "copy-artifacts",

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -50,7 +50,14 @@
 
       local project = "mlkube-testing";
       // GKE cluster to use
-      local cluster = name;
+      // We need to truncate the cluster to no more than 40 characters because
+      // cluster names can be a max of 40 characters.
+      // We expect the suffix of the cluster name to be unique salt.
+      local cluster = 
+        if std.length(name) > 40 then
+          std.substr(s, std.length(name) - 40, 40)
+        else 
+        name;
       local zone = "us-east1-d";
       local chart = srcDir + "/bin/tf-job-operator-chart-0.2.1-" + versionTag + ".tgz";
       {

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -289,7 +289,7 @@
               "--project=" + project,
               "--app_dir=" + srcDir + "/test/workflows",
               "--component=gpu_tfjob",
-              "--params=name=simple-tfjob,namespace=default",
+              "--params=name=gpu-tfjob,namespace=default",
               "--junit_path=" + artifactsDir + "/junit_gpu-tests.xml",
             ]),  // run gpu_tests
             $.parts(namespace, name).e2e(prow_env, bucket).buildTemplate("create-pr-symlink", [

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -53,9 +53,12 @@
       // We need to truncate the cluster to no more than 40 characters because
       // cluster names can be a max of 40 characters.
       // We expect the suffix of the cluster name to be unique salt.
+      // We prepend a z because cluster name must start with an alphanumeric character
+      // and if we cut the prefix we might end up starting with "-" or other invalid
+      // character for first character.
       local cluster = 
         if std.length(name) > 40 then
-          std.substr(name, std.length(name) - 40, 40)
+          "z" + std.substr(name, std.length(name) - 39, 39)
         else 
         name;
       local zone = "us-east1-d";

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -194,13 +194,11 @@
             {
               name: "exit-handler",
               steps: [
-                // DO NOT SUBMIT. We leave cluster up to facilitate debugging.
-                //[
-                //  {
-                //    name: "teardown-cluster",
-                //    template: "teardown-cluster",
-                //  },
-                //],
+                [{
+                  name: "teardown-cluster",
+                  template: "teardown-cluster",
+                  
+                },],
                 [{
                   name: "copy-artifacts",
                   template: "copy-artifacts",

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -55,7 +55,7 @@
       // We expect the suffix of the cluster name to be unique salt.
       local cluster = 
         if std.length(name) > 40 then
-          std.substr(s, std.length(name) - 40, 40)
+          std.substr(name, std.length(name) - 40, 40)
         else 
         name;
       local zone = "us-east1-d";

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -145,8 +145,7 @@
             },
           ],  // volumes
           // onExit specifies the template that should always run when the workflow completes.
-          // DO NOT SUBMIT this is a hack to leave it up for debugging.
-          // onExit: "exit-handler",
+          onExit: "exit-handler",
           templates: [
             {
               name: "e2e",


### PR DESCRIPTION
* See kubeflow/testing#12
* Our prow jobs will trigger a script that will process prow_config.yaml
  and figure out which workflows to run.
* This will allow us to easily run multiple workflows as part of our E2E tests.

* Fix one source of flakiness in TFJob test
   * If we get the status right after creating the TFJob the status might not be set yet
   * This was causing wait_for_tfjob to exit with KeyError exception which caused the test
      to fail with a very cryptic error message
   * We fix this by explicitly allowing for status not being set yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/388)
<!-- Reviewable:end -->
