### PR TITLE
Fixes go vet errors

### DIFF
--- a/cmd/tf-operator/app/server.go
+++ b/cmd/tf-operator/app/server.go
@@ -124,8 +124,6 @@ func Run(opt *options.ServerOption) error {
 		},
 	})
 
-	panic("unreachable")
-
 	return nil
 }
 

--- a/dashboard/backend/handler/api_handler.go
+++ b/dashboard/backend/handler/api_handler.go
@@ -1,4 +1,4 @@
-// handler is a package handling API requests for managing TFJobs.
+//Package handler is a package handling API requests for managing TFJobs.
 // The primary purpose of handler is implementing the functionality needed by the TFJobs dashboard.
 package handler
 
@@ -33,12 +33,12 @@ type TFJobDetail struct {
 
 // TFJobList is a list of TFJobs
 type TFJobList struct {
-	tfJobs []v1alpha1.TFJob `json:"TFJobs"`
+	TFJobs []v1alpha1.TFJob `json:"TFJobs"`
 }
 
-// NamepsaceList is a list of namespaces
+// NamespaceList is a list of namespaces
 type NamespaceList struct {
-	namespaces []v1.Namespace `json:"namespaces"`
+	Namespaces []v1.Namespace `json:"Namespaces"`
 }
 
 // CreateHTTPAPIHandler creates the restful Container and defines the routes the API will serve
@@ -98,8 +98,8 @@ func CreateHTTPAPIHandler(client client.ClientManager) (http.Handler, error) {
 
 	apiV1Ws.Route(
 		apiV1Ws.GET("/namespace").
-		To(apiHandler.handleGetNamespaces).
-		Writes(NamespaceList{}))
+			To(apiHandler.handleGetNamespaces).
+			Writes(NamespaceList{}))
 
 	wsContainer.Add(apiV1Ws)
 	return wsContainer, nil
@@ -192,8 +192,8 @@ func (apiHandler *APIHandler) handleDeploy(request *restful.Request, response *r
 			response.WriteError(http.StatusInternalServerError, nsErr)
 		}
 	} else if err != nil {
-			log.Warningf("failed to deploy TFJob %v under namespace %v: %v", tfJob.Name, tfJob.Namespace, err)
-			response.WriteError(http.StatusInternalServerError, err)
+		log.Warningf("failed to deploy TFJob %v under namespace %v: %v", tfJob.Name, tfJob.Namespace, err)
+		response.WriteError(http.StatusInternalServerError, err)
 	}
 
 	j, err := clt.KubeflowV1alpha1().TFJobs(tfJob.Namespace).Create(tfJob)


### PR DESCRIPTION
Addressing https://github.com/kubeflow/tf-operator/issues/395.

There are some errors in our code but it won't caught by the compilers

```commandline
$ go vet $(go list ./... | grep -v /vendor/)
```
Output:
```
cmd/tf-operator/app/server.go:129: unreachable code
exit status 1
dashboard/backend/handler/api_handler.go:36: struct field tfJobs has json tag but is not exported
dashboard/backend/handler/api_handler.go:41: struct field namespaces has json tag but is not exported
exit status 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/397)
<!-- Reviewable:end -->
