### PR TITLE
RFC: Add a new field SchedulerName to the controller config file format

### DIFF
--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -184,6 +184,10 @@ type ControllerConfig struct {
 
 	// Path to the file containing the grpc server source
 	GrpcServerFilePath string
+
+	// SchedulerName will be assigned to v1.Pod.Spec.SchedulerName for specifying a scheduler
+	// which handles the pods of tf-operator
+	SchedulerName string
 }
 
 // AcceleratorVolume represents a host path that must be mounted into

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -177,6 +177,10 @@ func (s *TFReplicaSet) Create(config *tfv1alpha1.ControllerConfig) error {
 		// Make a copy of the template because we will modify it below. .
 		newPodSpecTemplate := s.Spec.Template.DeepCopy()
 
+		if newPodSpecTemplate.Spec.SchedulerName == "" {
+			newPodSpecTemplate.Spec.SchedulerName = config.SchedulerName
+		}
+
 		newJ := &batch.Job{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name:   s.jobName(index),

--- a/pkg/trainer/tensorboard.go
+++ b/pkg/trainer/tensorboard.go
@@ -39,9 +39,10 @@ type TBReplicaSet struct {
 	ClientSet kubernetes.Interface
 	Job       *TrainingJob
 	Spec      tfv1alpha1.TensorBoardSpec
+	Config    *tfv1alpha1.ControllerConfig
 }
 
-func NewTBReplicaSet(clientSet kubernetes.Interface, s tfv1alpha1.TensorBoardSpec, job *TrainingJob) (*TBReplicaSet, error) {
+func NewTBReplicaSet(clientSet kubernetes.Interface, s tfv1alpha1.TensorBoardSpec, job *TrainingJob, config *tfv1alpha1.ControllerConfig) (*TBReplicaSet, error) {
 	if s.LogDir == "" {
 		return nil, errors.New("tbReplicaSpec.LogDir must be specified")
 	}
@@ -50,6 +51,7 @@ func NewTBReplicaSet(clientSet kubernetes.Interface, s tfv1alpha1.TensorBoardSpe
 		ClientSet: clientSet,
 		Job:       job,
 		Spec:      s,
+		Config:    config,
 	}, nil
 }
 
@@ -174,6 +176,10 @@ func (s *TBReplicaSet) getDeploymentSpecTemplate(image string) v1.PodTemplateSpe
 	ps := &v1.PodSpec{
 		Containers: []v1.Container{*c},
 		Volumes:    make([]v1.Volume, 0),
+	}
+
+	if s.Config.SchedulerName != "" {
+		ps.SchedulerName = s.Config.SchedulerName
 	}
 
 	ps.Volumes = append(ps.Volumes, s.Spec.Volumes...)


### PR DESCRIPTION
This commit adds a new field SchedulerName to the controller config
file format. The purpose of the field is specifying the scheduler name
of the pods created by tf-operator and let the scheduler (which
wouldn't be the default scheduler) handle them. It would be convenient
for letting kube-batchd (a component of kube-arbitrator) handle the
pods.

/cc @ScorpioCPH how do you think about this? This PR would conflict with your ongoing one https://github.com/kubeflow/tf-operator/pull/344 so I'll wait merging of your PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/398)
<!-- Reviewable:end -->
