### PR TITLE
Fix bug with jobs not working if you recreate a job with same name as previous job

### DIFF
--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -1,17 +1,107 @@
 """Test runner runs a TFJob test."""
 
 import argparse
+import datetime
+import httplib
 import logging
 import os
 import time
 import uuid
 
 from kubernetes import client as k8s_client
+from kubernetes.client import rest
+
 from google.cloud import storage  # pylint: disable=no-name-in-module
 from py import test_util
 from py import util
 from py import tf_job_client
 
+
+def wait_for_delete(client, namespace, name,
+                    timeout=datetime.timedelta(minutes=5),
+                    polling_interval=datetime.timedelta(seconds=30),
+                    status_callback=None):
+  """Wait for the specified job to be deleted.
+
+  Args:
+    client: K8s api client.
+    namespace: namespace for the job.
+    name: Name of the job.
+    timeout: How long to wait for the job.
+    polling_interval: How often to poll for the status of the job.
+    status_callback: (Optional): Callable. If supplied this callable is
+      invoked after we poll the job. Callable takes a single argument which
+      is the job.
+  """
+  crd_api = k8s_client.CustomObjectsApi(client)
+  end_time = datetime.datetime.now() + timeout
+  while True:
+    try:
+      results = crd_api.get_namespaced_custom_object(
+        tf_job_client.TF_JOB_GROUP, tf_job_client.TF_JOB_VERSION, namespace,
+        tf_job_client.TF_JOB_PLURAL, name)
+    except rest.ApiException as e:
+      if e.status == httplib.NOT_FOUND:
+        return
+      raise
+    if status_callback:
+      status_callback(results)
+
+    if datetime.datetime.now() + polling_interval > end_time:
+      raise util.TimeoutError(
+        "Timeout waiting for job {0} in namespace {1} to finish.".format(
+          name, namespace))
+
+    time.sleep(polling_interval.seconds)
+
+def get_labels(name, runtime_id, replica_type=None, replica_index=None):
+  """Return labels.
+  """
+  labels = {
+          "kubeflow.org": "",
+                "tf_job_name": name,
+                "runtime_id": runtime_id,
+        }
+  if replica_type:
+    labels["job_type"] = replica_type
+
+  if replica_index:
+    labels["task_index"] =  replica_index
+  return labels
+
+def to_selector(labels):
+  parts = []
+  for k, v in labels.iteritems():
+    parts.append("{0}={1}".format(k, v))
+
+  return ",".join(parts)
+
+def list_pods(client, namespace, label_selector):
+  core = k8s_client.CoreV1Api()
+  try:
+    pods = core.list_namespaced_pod(namespace, label_selector=label_selector)
+    return pods
+  except ApiException as e:
+    message = ""
+    if e.message:
+      message = e.message
+    if e.body:
+      try:
+        body = json.loads(e.body)
+      except ValueError:
+        # There was a problem parsing the body of the response as json.
+        logging.error(
+          ("Exception when calling DefaultApi->"
+             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
+            e.body)
+        raise
+      message = body.get("message")
+
+    logging.error(
+      ("Exception when calling DefaultApi->"
+         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+        message)
+    raise e
 
 def run_test(args):
   """Run a test."""
@@ -56,16 +146,71 @@ def run_test(args):
   start = time.time()
 
   try:
-    util.run(["ks", "apply", env, "-c", args.component],
-              cwd=args.app_dir)
+    # We repeat the test multiple times.
+    # This ensures that if we delete the job we can create a new job with the
+    # same name.
 
-    logging.info("Created job %s in namespaces %s", name, namespace)
-    results = tf_job_client.wait_for_job(api_client, namespace, name,
-                                         status_callback=tf_job_client.log_status)
+    # TODO(jlewi): We should make this an argument.
+    num_trials = 2
 
-    if results.get("status", {}).get("state", {}).lower() != "succeeded":
-      t.failure = "Job {0} in namespace {1} in state {2}".format(
-        name, namespace, results.get("status", {}).get("state", None))
+    uids = set()
+    for trial in range(num_trials):
+      logging.info("Trial %s", trial)
+      util.run(["ks", "apply", env, "-c", args.component],
+               cwd=args.app_dir)
+
+      logging.info("Created job %s in namespaces %s", name, namespace)
+      results = tf_job_client.wait_for_job(api_client, namespace, name,
+                                           status_callback=tf_job_client.log_status)
+
+      if results.get("status", {}).get("state", {}).lower() != "succeeded":
+        t.failure = "Trial {0} Job {1} in namespace {2} in state {3}".format(
+          trial, name, namespace, results.get("status", {}).get("state", None))
+        logging.error(t.failure)
+        break
+
+      runtime_id = results.get("spec", {}).get("RuntimeId")
+      logging.info("Trial %s Job %s in namespace %s runtime ID %s",
+                   trial, name, namespace, runtime_id)
+
+      # TODO(jlewi): We should check that pods were created for each replica
+      pod_labels = get_labels(name, runtime_id)
+      pod_selector = to_selector(pod_labels)
+      pods = list_pods(api_client, namespace, pod_selector)
+
+      logging.info("Trial %s selector: %s matched %s pods", trial, pod_selector,
+                   len(pods.items))
+
+      if not pods.items:
+        t.failure = ("Trial {0} Job {1} in namespace {2} no pods found for "
+                     " selector {3}").format(
+                     trial, name, namespace, pod_selector)
+        logging.error(t.failure)
+        break
+
+      tf_job_client.delete_tf_job(api_client, namespace, name)
+
+      wait_for_delete(api_client, namespace, name,
+                      status_callback=tf_job_client.log_status)
+
+      # Verify the pods have been deleted.
+      pods = list_pods(api_client, namespace, pod_selector)
+
+      logging.info("Trial %s selector: %s matched %s pods", trial, pod_selector,
+                       len(pods.items))
+
+      if pods.items:
+        t.failure = ("Trial {0} Job {1} in namespace {2} pods found for "
+                         " selector {3}; pods\n{4}").format(
+                           trial, name, namespace, pod_selector, pods)
+        logging.error(t.failure)
+        break
+
+      logging.info("Trial {0} all pods deleted.", trial)
+
+      # Verify resources were actually deleted. tf_job_client uses foreground
+      # deletion so there shouldn't be any resources for the job left
+      # once the job is gone.
 
     # TODO(jlewi):
     #  Here are some validation checks to run:
@@ -76,7 +221,8 @@ def run_test(args):
     # run.
   except util.TimeoutError:
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
-        name, namespace)
+      name, namespace)
+    logging.error(t.failure)
   except Exception as e: # pylint: disable-msg=broad-except
     # TODO(jlewi): I'm observing flakes where the exception has message "status"
     # in an effort to try to nail down this exception we print out more


### PR DESCRIPTION
* This appears to be a bug with the informer forgetting about active jobs.
* I think the root cause is that delete events are processed directly
  as opposed to using the work queue. This causes race conditions because
  the work queue is what ensures only on thread is processing a given job
  at a time.

* Since we no longer explicitly handle delete events we rely on garbage
  collection and owner references to delete the pods.

* We add testing to our test runner to verify pods are garbage collected.

* We update test_runner.py to try recreating jobs with the same name.
  In general this doesn't reproduce the original bug.

Related to #322 (to need to push a new image to fix).
Fix #310

Related to #373

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/399)
<!-- Reviewable:end -->
