### PR TITLE
use yapf to format python code

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+based_on_style = google
+indent_width: 2
+continuation_indent_width: 2

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,4 +1,3 @@
-
 ## Directories Layout
 
 ```sh
@@ -75,8 +74,6 @@ $ tree -d -I 'vendor|bin|.git'
 │   └── templates
 │       └── tests
 └── version
-
-
 ```
 
 ## Building the Operator
@@ -164,11 +161,12 @@ On ubuntu the default go package appears to be gccgo-go which has problems see [
 
 ### Python
 
-* Use two spaces for indents in keeping with Python style
+* Use [yapf](https://github.com/google/yapf) to format Python code
+* `yapf` style is configured in `.style.yapf` file
 * To autoformat code
 
   ```sh
-  autopep8 -i --indent-size=2 path/to/module.py
+  yapf -i py/**/*.py
   ```
 
 * To sort imports

--- a/py/build_and_push_image.py
+++ b/py/build_and_push_image.py
@@ -11,16 +11,17 @@ import tempfile
 
 import jinja2
 
+
 def GetGitHash(root_dir=None):
   # The image tag is based on the githash.
-  git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
-                                     cwd=root_dir).decode("utf-8")
+  git_hash = subprocess.check_output(
+    ["git", "rev-parse", "--short", "HEAD"], cwd=root_dir).decode("utf-8")
   git_hash = git_hash.strip()
 
-  modified_files = subprocess.check_output(["git", "ls-files", "--modified"],
-                                           cwd=root_dir)
+  modified_files = subprocess.check_output(
+    ["git", "ls-files", "--modified"], cwd=root_dir)
   untracked_files = subprocess.check_output(
-      ["git", "ls-files", "--others", "--exclude-standard"], cwd=root_dir)
+    ["git", "ls-files", "--others", "--exclude-standard"], cwd=root_dir)
   if modified_files or untracked_files:
     diff = subprocess.check_output(["git", "diff"], cwd=root_dir)
 
@@ -31,10 +32,11 @@ def GetGitHash(root_dir=None):
 
   return git_hash
 
+
 def run_and_stream(cmd):
   logging.info("Running %s", " ".join(cmd))
-  process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT)
+  process = subprocess.Popen(
+    cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
   while process.poll() is None:
     process.stdout.flush()
@@ -49,8 +51,13 @@ def run_and_stream(cmd):
     raise ValueError("cmd: {0} exited with code {1}".format(
       " ".join(cmd), process.returncode))
 
-def build_and_push(dockerfile_template, image, modes=None,
-                   skip_push=False, base_images=None, project=None):
+
+def build_and_push(dockerfile_template,
+                   image,
+                   modes=None,
+                   skip_push=False,
+                   base_images=None,
+                   project=None):
   """Build and push images based on a Dockerfile template.
 
   Args:
@@ -83,7 +90,8 @@ def build_and_push(dockerfile_template, image, modes=None,
   images = {}
   for mode in modes:
     dockerfile_contents = jinja2.Environment(loader=loader).get_template(
-      os.path.basename(dockerfile_template)).render(base_image=base_images[mode])
+      os.path.basename(dockerfile_template)).render(
+        base_image=base_images[mode])
     context_dir = tempfile.mkdtemp(prefix="tmpTFJobSampleContentxt")
     logging.info("context_dir: %s", context_dir)
     shutil.rmtree(context_dir)
@@ -108,9 +116,12 @@ def build_and_push(dockerfile_template, image, modes=None,
           run_and_stream(["docker", "--", "push", full_image])
           logging.info("Pushed image: %s", full_image)
     else:
-      run_and_stream(["gcloud", "container", "builds", "submit", context_dir,
-                      "--tag=" + full_image, "--project=" + project])
+      run_and_stream([
+        "gcloud", "container", "builds", "submit", context_dir,
+        "--tag=" + full_image, "--project=" + project
+      ])
   return images
+
 
 def main():
   logging.getLogger().setLevel(logging.INFO)
@@ -119,32 +130,32 @@ def main():
 
   parser.add_argument(
     "--image",
-      default="gcr.io/tf-on-k8s-dogfood",
-      type=str,
-      help="The image path to use; mode will be applied as a suffix.")
+    default="gcr.io/tf-on-k8s-dogfood",
+    type=str,
+    help="The image path to use; mode will be applied as a suffix.")
 
   parser.add_argument(
-    "--dockerfile",
-      required=True,
-      type=str,
-      help="The path to the Dockerfile")
+    "--dockerfile", required=True, type=str, help="The path to the Dockerfile")
 
   # TODO(jlewi): Should we make this a list so we can build both images with one command.
   parser.add_argument(
     '--mode',
-      default=["cpu", "gpu"],
-        dest="modes",
-        action="append",
-        help='Which image to build; options are cpu or gpu')
+    default=["cpu", "gpu"],
+    dest="modes",
+    action="append",
+    help='Which image to build; options are cpu or gpu')
 
   parser.add_argument(
     '--gcb_project',
-      default=None,
-      help=("(Optional) if specified build the images using GCB and this "
-            "project."))
+    default=None,
+    help=("(Optional) if specified build the images using GCB and this "
+          "project."))
 
-  parser.add_argument("--no-push", dest="should_push", action="store_false",
-                      help="Do not push the image once build is finished.")
+  parser.add_argument(
+    "--no-push",
+    dest="should_push",
+    action="store_false",
+    help="Do not push the image once build is finished.")
 
   args = parser.parse_args()
 
@@ -153,8 +164,13 @@ def main():
     "gpu": "gcr.io/tensorflow/tensorflow:1.3.0-gpu",
   }
 
-  build_and_push(args.dockerfile, args.modes, not args.should_push, base_images,
-                 project=args.gcb_project)
+  build_and_push(
+    args.dockerfile,
+    args.modes,
+    not args.should_push,
+    base_images,
+    project=args.gcb_project)
+
 
 if __name__ == "__main__":
   main()

--- a/py/build_and_push_image.py
+++ b/py/build_and_push_image.py
@@ -15,13 +15,13 @@ import jinja2
 def GetGitHash(root_dir=None):
   # The image tag is based on the githash.
   git_hash = subprocess.check_output(
-      ["git", "rev-parse", "--short", "HEAD"], cwd=root_dir).decode("utf-8")
+    ["git", "rev-parse", "--short", "HEAD"], cwd=root_dir).decode("utf-8")
   git_hash = git_hash.strip()
 
   modified_files = subprocess.check_output(
-      ["git", "ls-files", "--modified"], cwd=root_dir)
+    ["git", "ls-files", "--modified"], cwd=root_dir)
   untracked_files = subprocess.check_output(
-      ["git", "ls-files", "--others", "--exclude-standard"], cwd=root_dir)
+    ["git", "ls-files", "--others", "--exclude-standard"], cwd=root_dir)
   if modified_files or untracked_files:
     diff = subprocess.check_output(["git", "diff"], cwd=root_dir)
 
@@ -36,7 +36,7 @@ def GetGitHash(root_dir=None):
 def run_and_stream(cmd):
   logging.info("Running %s", " ".join(cmd))
   process = subprocess.Popen(
-      cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
   while process.poll() is None:
     process.stdout.flush()
@@ -49,7 +49,7 @@ def run_and_stream(cmd):
 
   if process.returncode != 0:
     raise ValueError("cmd: {0} exited with code {1}".format(
-        " ".join(cmd), process.returncode))
+      " ".join(cmd), process.returncode))
 
 
 def build_and_push(dockerfile_template,
@@ -90,7 +90,7 @@ def build_and_push(dockerfile_template,
   images = {}
   for mode in modes:
     dockerfile_contents = jinja2.Environment(loader=loader).get_template(
-        os.path.basename(dockerfile_template)).render(
+      os.path.basename(dockerfile_template)).render(
         base_image=base_images[mode])
     context_dir = tempfile.mkdtemp(prefix="tmpTFJobSampleContentxt")
     logging.info("context_dir: %s", context_dir)
@@ -117,8 +117,8 @@ def build_and_push(dockerfile_template,
           logging.info("Pushed image: %s", full_image)
     else:
       run_and_stream([
-          "gcloud", "container", "builds", "submit", context_dir,
-          "--tag=" + full_image, "--project=" + project
+        "gcloud", "container", "builds", "submit", context_dir,
+        "--tag=" + full_image, "--project=" + project
       ])
   return images
 
@@ -126,50 +126,50 @@ def build_and_push(dockerfile_template,
 def main():
   logging.getLogger().setLevel(logging.INFO)
   parser = argparse.ArgumentParser(
-      description="Build Docker images based off of TensorFlow.")
+    description="Build Docker images based off of TensorFlow.")
 
   parser.add_argument(
-      "--image",
-      default="gcr.io/tf-on-k8s-dogfood",
-      type=str,
-      help="The image path to use; mode will be applied as a suffix.")
+    "--image",
+    default="gcr.io/tf-on-k8s-dogfood",
+    type=str,
+    help="The image path to use; mode will be applied as a suffix.")
 
   parser.add_argument(
-      "--dockerfile", required=True, type=str, help="The path to the Dockerfile")
+    "--dockerfile", required=True, type=str, help="The path to the Dockerfile")
 
   # TODO(jlewi): Should we make this a list so we can build both images with one command.
   parser.add_argument(
-      '--mode',
-      default=["cpu", "gpu"],
-      dest="modes",
-      action="append",
-      help='Which image to build; options are cpu or gpu')
+    '--mode',
+    default=["cpu", "gpu"],
+    dest="modes",
+    action="append",
+    help='Which image to build; options are cpu or gpu')
 
   parser.add_argument(
-      '--gcb_project',
-      default=None,
-      help=("(Optional) if specified build the images using GCB and this "
-            "project."))
+    '--gcb_project',
+    default=None,
+    help=("(Optional) if specified build the images using GCB and this "
+          "project."))
 
   parser.add_argument(
-      "--no-push",
-      dest="should_push",
-      action="store_false",
-      help="Do not push the image once build is finished.")
+    "--no-push",
+    dest="should_push",
+    action="store_false",
+    help="Do not push the image once build is finished.")
 
   args = parser.parse_args()
 
   base_images = {
-      "cpu": "gcr.io/tensorflow/tensorflow:1.3.0",
-      "gpu": "gcr.io/tensorflow/tensorflow:1.3.0-gpu",
+    "cpu": "gcr.io/tensorflow/tensorflow:1.3.0",
+    "gpu": "gcr.io/tensorflow/tensorflow:1.3.0-gpu",
   }
 
   build_and_push(
-      args.dockerfile,
-      args.modes,
-      not args.should_push,
-      base_images,
-      project=args.gcb_project)
+    args.dockerfile,
+    args.modes,
+    not args.should_push,
+    base_images,
+    project=args.gcb_project)
 
 
 if __name__ == "__main__":

--- a/py/deploy.py
+++ b/py/deploy.py
@@ -19,6 +19,7 @@ from google.cloud import storage  # pylint: disable=no-name-in-module
 from py import test_util
 from py import util
 
+
 def setup(args):
   """Setup a GKE cluster for TensorFlow jobs.
 
@@ -35,18 +36,18 @@ def setup(args):
 
   cluster_request = {
     "cluster": {
-        "name": cluster_name,
-          "description": "A GKE cluster for TF.",
-          "initialNodeCount": 1,
-          "nodeConfig": {
-            "machineType": machine_type,
-              "oauthScopes": [
-                "https://www.googleapis.com/auth/cloud-platform",
-                ],
-              },
-          # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
-          "initialClusterVersion": "1.8.5-gke.0",
-      }
+      "name": cluster_name,
+      "description": "A GKE cluster for TF.",
+      "initialNodeCount": 1,
+      "nodeConfig": {
+        "machineType": machine_type,
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/cloud-platform",
+        ],
+      },
+      # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
+      "initialClusterVersion": "1.8.5-gke.0",
+    }
   }
 
   if args.accelerators:
@@ -56,9 +57,12 @@ def setup(args):
     cluster_request["cluster"]["nodeConfig"]["accelerators"] = []
     for accelerator_spec in args.accelerators:
       accelerator_type, accelerator_count = accelerator_spec.split("=", 1)
-      cluster_request["cluster"]["nodeConfig"]["accelerators"].append(
-        {"acceleratorCount": accelerator_count,
-         "acceleratorType": accelerator_type, })
+      cluster_request["cluster"]["nodeConfig"]["accelerators"].append({
+        "acceleratorCount":
+        accelerator_count,
+        "acceleratorType":
+        accelerator_type,
+      })
 
   util.create_cluster(gke, project, zone, cluster_request)
 
@@ -88,9 +92,10 @@ def setup(args):
   t = test_util.TestCase()
   try:
     start = time.time()
-    util.run(["helm", "install", chart, "-n", "tf-job", "--namespace=default",
-              "--wait", "--replace",
-              "--set", "rbac.install=true,cloud=gke"])
+    util.run([
+      "helm", "install", chart, "-n", "tf-job", "--namespace=default", "--wait",
+      "--replace", "--set", "rbac.install=true,cloud=gke"
+    ])
     util.wait_for_deployment(api_client, "default", "tf-job-operator")
   except subprocess.CalledProcessError as e:
     t.failure = "helm install failed;\n" + (e.output or "")
@@ -101,6 +106,7 @@ def setup(args):
     t.name = "helm-tfjob-install"
     t.class_name = "GKE"
     test_util.create_junit_xml_file([t], args.junit_path, gcs_client)
+
 
 def test(args):
   """Run the tests."""
@@ -128,6 +134,7 @@ def test(args):
     t.class_name = "GKE"
     test_util.create_junit_xml_file([t], args.junit_path, gcs_client)
 
+
 def teardown(args):
   """Teardown the resources."""
   gke = discovery.build("container", "v1")
@@ -137,6 +144,7 @@ def teardown(args):
   zone = args.zone
   util.delete_cluster(gke, cluster_name, project, zone)
 
+
 def add_common_args(parser):
   """Add common command line arguments to a parser.
 
@@ -144,15 +152,9 @@ def add_common_args(parser):
     parser: The parser to add command line arguments to.
   """
   parser.add_argument(
-    "--project",
-    default=None,
-    type=str,
-    help=("The project to use."))
+    "--project", default=None, type=str, help=("The project to use."))
   parser.add_argument(
-    "--cluster",
-    default=None,
-    type=str,
-    help=("The name of the cluster."))
+    "--cluster", default=None, type=str, help=("The name of the cluster."))
   parser.add_argument(
     "--zone",
     default="us-east1-d",
@@ -165,22 +167,21 @@ def add_common_args(parser):
     type=str,
     help="Where to write the junit xml file with the results.")
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
 
   util.maybe_activate_service_account()
 
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Setup clusters for testing.")
+  parser = argparse.ArgumentParser(description="Setup clusters for testing.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
   # setup
   #
   parser_setup = subparsers.add_parser(
-    "setup",
-      help="Setup a cluster for testing.")
+    "setup", help="Setup a cluster for testing.")
 
   parser_setup.add_argument(
     "--accelerator",
@@ -192,17 +193,12 @@ def main():  # pylint: disable=too-many-locals
   add_common_args(parser_setup)
 
   parser_setup.add_argument(
-    "--chart",
-    type=str,
-    required=True,
-    help="The path for the helm chart.")
+    "--chart", type=str, required=True, help="The path for the helm chart.")
 
   #############################################################################
   # test
   #
-  parser_test = subparsers.add_parser(
-    "test",
-    help="Run the tests.")
+  parser_test = subparsers.add_parser("test", help="Run the tests.")
 
   parser_test.set_defaults(func=test)
   add_common_args(parser_test)
@@ -211,14 +207,14 @@ def main():  # pylint: disable=too-many-locals
   # teardown
   #
   parser_teardown = subparsers.add_parser(
-    "teardown",
-    help="Teardown the cluster.")
+    "teardown", help="Teardown the cluster.")
   parser_teardown.set_defaults(func=teardown)
   add_common_args(parser_teardown)
 
   # parse the args and call whatever function was selected
   args = parser.parse_args()
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/deploy.py
+++ b/py/deploy.py
@@ -35,19 +35,19 @@ def setup(args):
   machine_type = "n1-standard-8"
 
   cluster_request = {
-      "cluster": {
-          "name": cluster_name,
-          "description": "A GKE cluster for TF.",
-          "initialNodeCount": 1,
-          "nodeConfig": {
-              "machineType": machine_type,
-              "oauthScopes": [
-                  "https://www.googleapis.com/auth/cloud-platform",
-              ],
-          },
-          # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
-          "initialClusterVersion": "1.8.5-gke.0",
-      }
+    "cluster": {
+      "name": cluster_name,
+      "description": "A GKE cluster for TF.",
+      "initialNodeCount": 1,
+      "nodeConfig": {
+        "machineType": machine_type,
+        "oauthScopes": [
+          "https://www.googleapis.com/auth/cloud-platform",
+        ],
+      },
+      # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
+      "initialClusterVersion": "1.8.5-gke.0",
+    }
   }
 
   if args.accelerators:
@@ -58,10 +58,10 @@ def setup(args):
     for accelerator_spec in args.accelerators:
       accelerator_type, accelerator_count = accelerator_spec.split("=", 1)
       cluster_request["cluster"]["nodeConfig"]["accelerators"].append({
-          "acceleratorCount":
-          accelerator_count,
-          "acceleratorType":
-          accelerator_type,
+        "acceleratorCount":
+        accelerator_count,
+        "acceleratorType":
+        accelerator_type,
       })
 
   util.create_cluster(gke, project, zone, cluster_request)
@@ -93,8 +93,8 @@ def setup(args):
   try:
     start = time.time()
     util.run([
-        "helm", "install", chart, "-n", "tf-job", "--namespace=default", "--wait",
-        "--replace", "--set", "rbac.install=true,cloud=gke"
+      "helm", "install", chart, "-n", "tf-job", "--namespace=default", "--wait",
+      "--replace", "--set", "rbac.install=true,cloud=gke"
     ])
     util.wait_for_deployment(api_client, "default", "tf-job-operator")
   except subprocess.CalledProcessError as e:
@@ -152,20 +152,20 @@ def add_common_args(parser):
     parser: The parser to add command line arguments to.
   """
   parser.add_argument(
-      "--project", default=None, type=str, help=("The project to use."))
+    "--project", default=None, type=str, help=("The project to use."))
   parser.add_argument(
-      "--cluster", default=None, type=str, help=("The name of the cluster."))
+    "--cluster", default=None, type=str, help=("The name of the cluster."))
   parser.add_argument(
-      "--zone",
-      default="us-east1-d",
-      type=str,
-      help=("The zone for the cluster."))
+    "--zone",
+    default="us-east1-d",
+    type=str,
+    help=("The zone for the cluster."))
 
   parser.add_argument(
-      "--junit_path",
-      default="",
-      type=str,
-      help="Where to write the junit xml file with the results.")
+    "--junit_path",
+    default="",
+    type=str,
+    help="Where to write the junit xml file with the results.")
 
 
 def main():  # pylint: disable=too-many-locals
@@ -181,19 +181,19 @@ def main():  # pylint: disable=too-many-locals
   # setup
   #
   parser_setup = subparsers.add_parser(
-      "setup", help="Setup a cluster for testing.")
+    "setup", help="Setup a cluster for testing.")
 
   parser_setup.add_argument(
-      "--accelerator",
-      dest="accelerators",
-      action="append",
-      help="Accelerator to add to the cluster. Should be of the form type=count.")
+    "--accelerator",
+    dest="accelerators",
+    action="append",
+    help="Accelerator to add to the cluster. Should be of the form type=count.")
 
   parser_setup.set_defaults(func=setup)
   add_common_args(parser_setup)
 
   parser_setup.add_argument(
-      "--chart", type=str, required=True, help="The path for the helm chart.")
+    "--chart", type=str, required=True, help="The path for the helm chart.")
 
   #############################################################################
   # test
@@ -207,7 +207,7 @@ def main():  # pylint: disable=too-many-locals
   # teardown
   #
   parser_teardown = subparsers.add_parser(
-      "teardown", help="Teardown the cluster.")
+    "teardown", help="Teardown the cluster.")
   parser_teardown.set_defaults(func=teardown)
   add_common_args(parser_teardown)
 

--- a/py/prow.py
+++ b/py/prow.py
@@ -32,6 +32,7 @@ GO_REPO_NAME = "tf-operator"
 
 GCS_REGEX = re.compile("gs://([^/]*)/(.*)")
 
+
 def get_gcs_output():
   """Return the GCS directory where test outputs should be written to."""
   job_name = os.getenv("JOB_NAME")
@@ -42,24 +43,25 @@ def get_gcs_output():
   if pull_number:
     output = ("gs://kubernetes-jenkins/pr-logs/pull/{owner}_{repo}/"
               "{pull_number}/{job}/{build}").format(
-                  owner=GO_REPO_OWNER, repo=GO_REPO_NAME,
-                  pull_number=pull_number,
-                  job=job_name,
-                  build=os.getenv("BUILD_NUMBER"))
+        owner=GO_REPO_OWNER,
+        repo=GO_REPO_NAME,
+        pull_number=pull_number,
+        job=job_name,
+        build=os.getenv("BUILD_NUMBER"))
     return output
   elif os.getenv("REPO_OWNER"):
     # It is a postsubmit job
     output = ("gs://kubernetes-jenkins/logs/{owner}_{repo}/"
               "{job}/{build}").format(
-                  owner=GO_REPO_OWNER, repo=GO_REPO_NAME,
-                  job=job_name,
-                  build=os.getenv("BUILD_NUMBER"))
+        owner=GO_REPO_OWNER,
+        repo=GO_REPO_NAME,
+        job=job_name,
+        build=os.getenv("BUILD_NUMBER"))
     return output
 
   # Its a periodic job
   output = ("gs://kubernetes-jenkins/logs/{job}/{build}").format(
-      job=job_name,
-      build=os.getenv("BUILD_NUMBER"))
+      job=job_name, build=os.getenv("BUILD_NUMBER"))
   return output
 
 
@@ -72,8 +74,7 @@ def get_symlink_output(pull_number, job_name, build_number):
     return ""
   output = ("gs://kubernetes-jenkins/pr-logs/directory/"
             "{job}/{build}.txt").format(
-                job=job_name,
-                build=build_number)
+      job=job_name, build=build_number)
   return output
 
 
@@ -95,7 +96,8 @@ def create_started(gcs_client, output_dir, sha):
       "timestamp": int(time.time()),
       "repos": {
           # List all repos used and their versions.
-          GO_REPO_OWNER + "/" + GO_REPO_NAME: sha,
+          GO_REPO_OWNER + "/" + GO_REPO_NAME:
+          sha,
       },
   }
 
@@ -177,6 +179,7 @@ def upload_outputs(gcs_client, output_dir, build_log):
     blob = bucket.blob(os.path.join(path, "build-log.txt"))
     blob.upload_from_filename(build_log)
 
+
 def get_commit_from_env():
   """Get the commit to test from prow environment variables."""
   # If this is a presubmit PULL_PULL_SHA will be set see:
@@ -190,6 +193,7 @@ def get_commit_from_env():
     sha = os.getenv("PULL_BASE_SHA", "")
 
   return sha
+
 
 def create_latest(gcs_client, job_name, sha):
   """Create a file in GCS with information about the latest passing postsubmit.
@@ -215,6 +219,7 @@ def _get_actual_junit_files(bucket, prefix):
   for b in bucket.list_blobs(prefix=os.path.join(prefix, "junit")):
     actual_junit.add(os.path.basename(b.name))
   return actual_junit
+
 
 def check_no_errors(gcs_client, artifacts_dir, junit_files):
   """Check that all the XML files exist and there were no errors.
@@ -257,6 +262,7 @@ def check_no_errors(gcs_client, artifacts_dir, junit_files):
     no_errors = False
   return no_errors
 
+
 def finalize_prow_job(args):
   """Finalize a prow job.
 
@@ -272,35 +278,38 @@ def finalize_prow_job(args):
 
   create_finished(gcs_client, output_dir, no_errors)
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Steps related to prow.")
+  parser = argparse.ArgumentParser(description="Steps related to prow.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
   # Finalize prow job.
   parser_finished = subparsers.add_parser(
-    "finalize_job",
-    help="Finalize the prow job.")
+      "finalize_job", help="Finalize the prow job.")
 
-  parser_finished.add_argument("--junit_files",
-                               default="", type=str,
-                               help=("A comma separated list of the names of "
-                                     "the expected junit files."))
+  parser_finished.add_argument(
+      "--junit_files",
+      default="",
+      type=str,
+      help=("A comma separated list of the names of "
+            "the expected junit files."))
   parser_finished.set_defaults(func=finalize_prow_job)
 
   # parse the args and call whatever function was selected
   args = parser.parse_args()
 
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/prow.py
+++ b/py/prow.py
@@ -43,25 +43,25 @@ def get_gcs_output():
   if pull_number:
     output = ("gs://kubernetes-jenkins/pr-logs/pull/{owner}_{repo}/"
               "{pull_number}/{job}/{build}").format(
-        owner=GO_REPO_OWNER,
-        repo=GO_REPO_NAME,
-        pull_number=pull_number,
-        job=job_name,
-        build=os.getenv("BUILD_NUMBER"))
+                owner=GO_REPO_OWNER,
+                repo=GO_REPO_NAME,
+                pull_number=pull_number,
+                job=job_name,
+                build=os.getenv("BUILD_NUMBER"))
     return output
   elif os.getenv("REPO_OWNER"):
     # It is a postsubmit job
     output = ("gs://kubernetes-jenkins/logs/{owner}_{repo}/"
               "{job}/{build}").format(
-        owner=GO_REPO_OWNER,
-        repo=GO_REPO_NAME,
-        job=job_name,
-        build=os.getenv("BUILD_NUMBER"))
+                owner=GO_REPO_OWNER,
+                repo=GO_REPO_NAME,
+                job=job_name,
+                build=os.getenv("BUILD_NUMBER"))
     return output
 
   # Its a periodic job
   output = ("gs://kubernetes-jenkins/logs/{job}/{build}").format(
-      job=job_name, build=os.getenv("BUILD_NUMBER"))
+    job=job_name, build=os.getenv("BUILD_NUMBER"))
   return output
 
 
@@ -74,7 +74,7 @@ def get_symlink_output(pull_number, job_name, build_number):
     return ""
   output = ("gs://kubernetes-jenkins/pr-logs/directory/"
             "{job}/{build}.txt").format(
-      job=job_name, build=build_number)
+              job=job_name, build=build_number)
   return output
 
 
@@ -93,12 +93,12 @@ def create_started(gcs_client, output_dir, sha):
   # https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
   # For a list of fields expected by gubernator
   started = {
-      "timestamp": int(time.time()),
-      "repos": {
-          # List all repos used and their versions.
-          GO_REPO_OWNER + "/" + GO_REPO_NAME:
-          sha,
-      },
+    "timestamp": int(time.time()),
+    "repos": {
+      # List all repos used and their versions.
+      GO_REPO_OWNER + "/" + GO_REPO_NAME:
+      sha,
+    },
   }
 
   PULL_REFS = os.getenv("PULL_REFS", "")
@@ -131,12 +131,12 @@ def create_finished(gcs_client, output_dir, success):
   if success:
     result = "SUCCESS"
   finished = {
-      "timestamp": int(time.time()),
-      "result": result,
-      # Dictionary of extra key value pairs to display to the user.
-      # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
-      # we are running in. We'd have to plumb this in from bootstrap.
-      "metadata": {},
+    "timestamp": int(time.time()),
+    "result": result,
+    # Dictionary of extra key value pairs to display to the user.
+    # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
+    # we are running in. We'd have to plumb this in from bootstrap.
+    "metadata": {},
   }
 
   m = GCS_REGEX.match(output_dir)
@@ -206,9 +206,9 @@ def create_latest(gcs_client, job_name, sha):
   logging.info("Creating GCS output: bucket: %s, path: %s.", bucket_name, path)
 
   data = {
-      "status": "passing",
-      "job": job_name,
-      "sha": sha,
+    "status": "passing",
+    "job": job_name,
+    "sha": sha,
   }
   blob = bucket.blob(path)
   blob.upload_from_string(json.dumps(data))
@@ -282,10 +282,10 @@ def finalize_prow_job(args):
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
   logging.basicConfig(
-      level=logging.INFO,
-      format=('%(levelname)s|%(asctime)s'
-              '|%(pathname)s|%(lineno)d| %(message)s'),
-      datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
   )
 
   # create the top-level parser
@@ -295,14 +295,14 @@ def main():  # pylint: disable=too-many-locals
   #############################################################################
   # Finalize prow job.
   parser_finished = subparsers.add_parser(
-      "finalize_job", help="Finalize the prow job.")
+    "finalize_job", help="Finalize the prow job.")
 
   parser_finished.add_argument(
-      "--junit_files",
-      default="",
-      type=str,
-      help=("A comma separated list of the names of "
-            "the expected junit files."))
+    "--junit_files",
+    default="",
+    type=str,
+    help=("A comma separated list of the names of "
+          "the expected junit files."))
   parser_finished.set_defaults(func=finalize_prow_job)
 
   # parse the args and call whatever function was selected

--- a/py/prow.py
+++ b/py/prow.py
@@ -32,6 +32,7 @@ GO_REPO_NAME = "tf-operator"
 
 GCS_REGEX = re.compile("gs://([^/]*)/(.*)")
 
+
 def get_gcs_output():
   """Return the GCS directory where test outputs should be written to."""
   job_name = os.getenv("JOB_NAME")
@@ -42,24 +43,25 @@ def get_gcs_output():
   if pull_number:
     output = ("gs://kubernetes-jenkins/pr-logs/pull/{owner}_{repo}/"
               "{pull_number}/{job}/{build}").format(
-                  owner=GO_REPO_OWNER, repo=GO_REPO_NAME,
-                  pull_number=pull_number,
-                  job=job_name,
-                  build=os.getenv("BUILD_NUMBER"))
+                owner=GO_REPO_OWNER,
+                repo=GO_REPO_NAME,
+                pull_number=pull_number,
+                job=job_name,
+                build=os.getenv("BUILD_NUMBER"))
     return output
   elif os.getenv("REPO_OWNER"):
     # It is a postsubmit job
     output = ("gs://kubernetes-jenkins/logs/{owner}_{repo}/"
               "{job}/{build}").format(
-                  owner=GO_REPO_OWNER, repo=GO_REPO_NAME,
-                  job=job_name,
-                  build=os.getenv("BUILD_NUMBER"))
+                owner=GO_REPO_OWNER,
+                repo=GO_REPO_NAME,
+                job=job_name,
+                build=os.getenv("BUILD_NUMBER"))
     return output
 
   # Its a periodic job
   output = ("gs://kubernetes-jenkins/logs/{job}/{build}").format(
-      job=job_name,
-      build=os.getenv("BUILD_NUMBER"))
+    job=job_name, build=os.getenv("BUILD_NUMBER"))
   return output
 
 
@@ -72,8 +74,7 @@ def get_symlink_output(pull_number, job_name, build_number):
     return ""
   output = ("gs://kubernetes-jenkins/pr-logs/directory/"
             "{job}/{build}.txt").format(
-                job=job_name,
-                build=build_number)
+              job=job_name, build=build_number)
   return output
 
 
@@ -92,11 +93,12 @@ def create_started(gcs_client, output_dir, sha):
   # https://github.com/kubernetes/test-infra/tree/master/gubernator#job-artifact-gcs-layout
   # For a list of fields expected by gubernator
   started = {
-      "timestamp": int(time.time()),
-      "repos": {
-          # List all repos used and their versions.
-          GO_REPO_OWNER + "/" + GO_REPO_NAME: sha,
-      },
+    "timestamp": int(time.time()),
+    "repos": {
+      # List all repos used and their versions.
+      GO_REPO_OWNER + "/" + GO_REPO_NAME:
+      sha,
+    },
   }
 
   PULL_REFS = os.getenv("PULL_REFS", "")
@@ -129,12 +131,12 @@ def create_finished(gcs_client, output_dir, success):
   if success:
     result = "SUCCESS"
   finished = {
-      "timestamp": int(time.time()),
-      "result": result,
-      # Dictionary of extra key value pairs to display to the user.
-      # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
-      # we are running in. We'd have to plumb this in from bootstrap.
-      "metadata": {},
+    "timestamp": int(time.time()),
+    "result": result,
+    # Dictionary of extra key value pairs to display to the user.
+    # TODO(jlewi): Perhaps we should add the GCR path of the Docker image
+    # we are running in. We'd have to plumb this in from bootstrap.
+    "metadata": {},
   }
 
   m = GCS_REGEX.match(output_dir)
@@ -177,6 +179,7 @@ def upload_outputs(gcs_client, output_dir, build_log):
     blob = bucket.blob(os.path.join(path, "build-log.txt"))
     blob.upload_from_filename(build_log)
 
+
 def get_commit_from_env():
   """Get the commit to test from prow environment variables."""
   # If this is a presubmit PULL_PULL_SHA will be set see:
@@ -191,6 +194,7 @@ def get_commit_from_env():
 
   return sha
 
+
 def create_latest(gcs_client, job_name, sha):
   """Create a file in GCS with information about the latest passing postsubmit.
   """
@@ -202,9 +206,9 @@ def create_latest(gcs_client, job_name, sha):
   logging.info("Creating GCS output: bucket: %s, path: %s.", bucket_name, path)
 
   data = {
-      "status": "passing",
-      "job": job_name,
-      "sha": sha,
+    "status": "passing",
+    "job": job_name,
+    "sha": sha,
   }
   blob = bucket.blob(path)
   blob.upload_from_string(json.dumps(data))
@@ -215,6 +219,7 @@ def _get_actual_junit_files(bucket, prefix):
   for b in bucket.list_blobs(prefix=os.path.join(prefix, "junit")):
     actual_junit.add(os.path.basename(b.name))
   return actual_junit
+
 
 def check_no_errors(gcs_client, artifacts_dir, junit_files):
   """Check that all the XML files exist and there were no errors.
@@ -257,6 +262,7 @@ def check_no_errors(gcs_client, artifacts_dir, junit_files):
     no_errors = False
   return no_errors
 
+
 def finalize_prow_job(args):
   """Finalize a prow job.
 
@@ -272,35 +278,38 @@ def finalize_prow_job(args):
 
   create_finished(gcs_client, output_dir, no_errors)
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Steps related to prow.")
+  parser = argparse.ArgumentParser(description="Steps related to prow.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
   # Finalize prow job.
   parser_finished = subparsers.add_parser(
-    "finalize_job",
-    help="Finalize the prow job.")
+    "finalize_job", help="Finalize the prow job.")
 
-  parser_finished.add_argument("--junit_files",
-                               default="", type=str,
-                               help=("A comma separated list of the names of "
-                                     "the expected junit files."))
+  parser_finished.add_argument(
+    "--junit_files",
+    default="",
+    type=str,
+    help=("A comma separated list of the names of "
+          "the expected junit files."))
   parser_finished.set_defaults(func=finalize_prow_job)
 
   # parse the args and call whatever function was selected
   args = parser.parse_args()
 
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/prow_test.py
+++ b/py/prow_test.py
@@ -17,9 +17,9 @@ class TestProw(unittest.TestCase):
     blob = prow.create_finished(gcs_client, "gs://bucket/output", True)
 
     expected = {
-        "timestamp": 1000,
-        "result": "SUCCESS",
-        "metadata": {},
+      "timestamp": 1000,
+      "result": "SUCCESS",
+      "metadata": {},
     }
     blob.upload_from_string.assert_called_once_with(json.dumps(expected))
 
@@ -31,18 +31,18 @@ class TestProw(unittest.TestCase):
     blob = prow.create_started(gcs_client, "gs://bucket/output", "abcd")
 
     expected = {
-        "timestamp": 1000,
-        "repos": {
-            "kubeflow/tf-operator": "abcd",
-        },
+      "timestamp": 1000,
+      "repos": {
+        "kubeflow/tf-operator": "abcd",
+      },
     }
     blob.upload_from_string.assert_called_once_with(json.dumps(expected))
 
   def testGetSymlinkOutput(self):
     location = prow.get_symlink_output("10", "mlkube-build-presubmit", "20")
     self.assertEquals(
-        "gs://kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit/20.txt",
-        location)
+      "gs://kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit/20.txt",
+      location)
 
   def testCreateSymlinkOutput(self):  # pylint: disable=no-self-use
     """Test create started for periodic job."""
@@ -62,7 +62,7 @@ class TestProw(unittest.TestCase):
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
     self.assertTrue(
-        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
@@ -75,7 +75,7 @@ class TestProw(unittest.TestCase):
     mock_get_failures.return_value = 1
     junit_files = ["junit_1.xml"]
     self.assertFalse(
-        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
@@ -89,7 +89,7 @@ class TestProw(unittest.TestCase):
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
     self.assertFalse(
-        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
 
 if __name__ == "__main__":

--- a/py/prow_test.py
+++ b/py/prow_test.py
@@ -8,6 +8,7 @@ from py import prow
 
 
 class TestProw(unittest.TestCase):
+
   @mock.patch("prow.time.time")
   def testCreateFinished(self, mock_time):  # pylint: disable=no-self-use
     """Test create finished"""
@@ -60,8 +61,8 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_1.xml"])
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
-    self.assertTrue(prow.check_no_errors(gcs_client, artifacts_dir,
-                                         junit_files))
+    self.assertTrue(
+        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
@@ -73,12 +74,13 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_1.xml"])
     mock_get_failures.return_value = 1
     junit_files = ["junit_1.xml"]
-    self.assertFalse(prow.check_no_errors(gcs_client, artifacts_dir,
-                                          junit_files))
+    self.assertFalse(
+        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
-  def testCheckNoErrorsFailureExtraJunit(self, mock_get_junit, mock_get_failures):
+  def testCheckNoErrorsFailureExtraJunit(self, mock_get_junit,
+                                         mock_get_failures):
     # Verify that check no errors returns false when there are extra
     # junit files
     gcs_client = mock.MagicMock(spec=storage.Client)
@@ -86,7 +88,9 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_0.xml", "junit_1.xml"])
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
-    self.assertFalse(prow.check_no_errors(gcs_client, artifacts_dir,
-                                          junit_files))
+    self.assertFalse(
+        prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/py/prow_test.py
+++ b/py/prow_test.py
@@ -8,6 +8,7 @@ from py import prow
 
 
 class TestProw(unittest.TestCase):
+
   @mock.patch("prow.time.time")
   def testCreateFinished(self, mock_time):  # pylint: disable=no-self-use
     """Test create finished"""
@@ -16,9 +17,9 @@ class TestProw(unittest.TestCase):
     blob = prow.create_finished(gcs_client, "gs://bucket/output", True)
 
     expected = {
-        "timestamp": 1000,
-        "result": "SUCCESS",
-        "metadata": {},
+      "timestamp": 1000,
+      "result": "SUCCESS",
+      "metadata": {},
     }
     blob.upload_from_string.assert_called_once_with(json.dumps(expected))
 
@@ -30,18 +31,18 @@ class TestProw(unittest.TestCase):
     blob = prow.create_started(gcs_client, "gs://bucket/output", "abcd")
 
     expected = {
-        "timestamp": 1000,
-        "repos": {
-            "kubeflow/tf-operator": "abcd",
-        },
+      "timestamp": 1000,
+      "repos": {
+        "kubeflow/tf-operator": "abcd",
+      },
     }
     blob.upload_from_string.assert_called_once_with(json.dumps(expected))
 
   def testGetSymlinkOutput(self):
     location = prow.get_symlink_output("10", "mlkube-build-presubmit", "20")
     self.assertEqual(
-        "gs://kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit/20.txt",
-        location)
+      "gs://kubernetes-jenkins/pr-logs/directory/mlkube-build-presubmit/20.txt",
+      location)
 
   def testCreateSymlinkOutput(self):  # pylint: disable=no-self-use
     """Test create started for periodic job."""
@@ -60,8 +61,8 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_1.xml"])
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
-    self.assertTrue(prow.check_no_errors(gcs_client, artifacts_dir,
-                                         junit_files))
+    self.assertTrue(
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
@@ -73,12 +74,13 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_1.xml"])
     mock_get_failures.return_value = 1
     junit_files = ["junit_1.xml"]
-    self.assertFalse(prow.check_no_errors(gcs_client, artifacts_dir,
-                                          junit_files))
+    self.assertFalse(
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
 
   @mock.patch("py.prow.test_util.get_num_failures")
   @mock.patch("py.prow._get_actual_junit_files")
-  def testCheckNoErrorsFailureExtraJunit(self, mock_get_junit, mock_get_failures):
+  def testCheckNoErrorsFailureExtraJunit(self, mock_get_junit,
+                                         mock_get_failures):
     # Verify that check no errors returns false when there are extra
     # junit files
     gcs_client = mock.MagicMock(spec=storage.Client)
@@ -86,7 +88,9 @@ class TestProw(unittest.TestCase):
     mock_get_junit.return_value = set(["junit_0.xml", "junit_1.xml"])
     mock_get_failures.return_value = 0
     junit_files = ["junit_1.xml"]
-    self.assertFalse(prow.check_no_errors(gcs_client, artifacts_dir,
-                                          junit_files))
+    self.assertFalse(
+      prow.check_no_errors(gcs_client, artifacts_dir, junit_files))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/py/py_checks.py
+++ b/py/py_checks.py
@@ -25,12 +25,12 @@ def run_lint(args):
   # TODO(jlewi): Perhaps we should get a list of submodules and exclude
   # them automatically?
   dir_excludes = [
-      "dashboard/frontend/node_modules",
-      "kubeflow_testing",
-      "vendor",
+    "dashboard/frontend/node_modules",
+    "kubeflow_testing",
+    "vendor",
   ]
   full_dir_excludes = [
-      os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes
+    os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes
   ]
   includes = ["*.py"]
   failed_files = []
@@ -52,7 +52,7 @@ def run_lint(args):
         full_path = os.path.join(root, f)
         try:
           util.run(
-              ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
+            ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
         except subprocess.CalledProcessError:
           failed_files.append(full_path.strip[len(args.src_dir):])
 
@@ -73,7 +73,7 @@ def run_lint(args):
   test_case.time = time.time() - start_time
   if failed_files:
     test_case.failure = "Files with lint issues: {0}".format(
-        ", ".join(failed_files))
+      ", ".join(failed_files))
 
   gcs_client = None
   if args.junit_path.startswith("gs://"):
@@ -100,7 +100,7 @@ def run_tests(args):
   # When we use ARGO each step will run in its own pod and we can set the
   # PYTHONPATH environment variable as needed for that pod.
   env["PYTHONPATH"] = (
-      args.src_dir + ":" + os.path.join(args.src_dir, "kubeflow_testing", "py"))
+    args.src_dir + ":" + os.path.join(args.src_dir, "kubeflow_testing", "py"))
 
   num_failed = 0
   for root, dirs, files in os.walk(args.src_dir, topdown=True):
@@ -144,33 +144,33 @@ def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-      "--src_dir",
-      default=os.getcwd(),
-      type=str,
-      help=("The root directory of the source tree. Defaults to current "
-            "directory."))
+    "--src_dir",
+    default=os.getcwd(),
+    type=str,
+    help=("The root directory of the source tree. Defaults to current "
+          "directory."))
 
   parser.add_argument(
-      "--project",
-      default=None,
-      type=str,
-      help=("(Optional). The project to use with the GCS client."))
+    "--project",
+    default=None,
+    type=str,
+    help=("(Optional). The project to use with the GCS client."))
 
   parser.add_argument(
-      "--junit_path",
-      default=None,
-      type=str,
-      help=("(Optional). The GCS location to write the junit file with the "
-            "results."))
+    "--junit_path",
+    default=None,
+    type=str,
+    help=("(Optional). The GCS location to write the junit file with the "
+          "results."))
 
 
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
   logging.basicConfig(
-      level=logging.INFO,
-      format=('%(levelname)s|%(asctime)s'
-              '|%(pathname)s|%(lineno)d| %(message)s'),
-      datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
   )
   # create the top-level parser
   parser = argparse.ArgumentParser(description="Run python code checks.")

--- a/py/py_checks.py
+++ b/py/py_checks.py
@@ -24,16 +24,19 @@ def run_lint(args):
   # kubeflow_testing is imported as a submodule so we should exclude it
   # TODO(jlewi): Perhaps we should get a list of submodules and exclude
   # them automatically?
-  dir_excludes = ["dashboard/frontend/node_modules", "kubeflow_testing",
-                  "test/test-app",
-                  "vendor",]
-  full_dir_excludes = [os.path.join(os.path.abspath(args.src_dir), f) for f in
-                       dir_excludes]
+  dir_excludes = [
+    "dashboard/frontend/node_modules",
+    "kubeflow_testing",
+    "test/test-app",
+    "vendor",
+  ]
+  full_dir_excludes = [
+    os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes
+  ]
   includes = ["*.py"]
   failed_files = []
   rc_file = os.path.join(args.src_dir, ".pylintrc")
-  for root, dirs, files in os.walk(os.path.abspath(args.src_dir),
-                                   topdown=True):
+  for root, dirs, files in os.walk(os.path.abspath(args.src_dir), topdown=True):
     # excludes can be done with fnmatch.filter and complementary set,
     # but it's more annoying to read.
     exclude = False
@@ -49,8 +52,8 @@ def run_lint(args):
       for f in fnmatch.filter(files, pat):
         full_path = os.path.join(root, f)
         try:
-          util.run(["pylint", "--rcfile=" + rc_file, full_path],
-                    cwd=args.src_dir)
+          util.run(
+            ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
         except subprocess.CalledProcessError:
           failed_files.append(full_path[len(args.src_dir):])
 
@@ -61,7 +64,6 @@ def run_lint(args):
   else:
     logging.info("No lint issues.")
 
-
   if not args.junit_path:
     logging.info("No --junit_path.")
     return
@@ -71,7 +73,8 @@ def run_lint(args):
   test_case.name = "pylint"
   test_case.time = time.time() - start_time
   if failed_files:
-    test_case.failure = "Files with lint issues: {0}".format(", ".join(failed_files))
+    test_case.failure = "Files with lint issues: {0}".format(
+      ", ".join(failed_files))
 
   gcs_client = None
   if args.junit_path.startswith("gs://"):
@@ -97,8 +100,8 @@ def run_tests(args):
   # the PYTHONPATH here and just inheriting it from the environment.
   # When we use ARGO each step will run in its own pod and we can set the
   # PYTHONPATH environment variable as needed for that pod.
-  env["PYTHONPATH"] = (args.src_dir + ":" +
-                       os.path.join(args.src_dir, "kubeflow_testing", "py"))
+  env["PYTHONPATH"] = (
+    args.src_dir + ":" + os.path.join(args.src_dir, "kubeflow_testing", "py"))
 
   num_failed = 0
   for root, dirs, files in os.walk(args.src_dir, topdown=True):
@@ -127,7 +130,6 @@ def run_tests(args):
   else:
     logging.info("No lint issues.")
 
-
   if not args.junit_path:
     logging.info("No --junit_path.")
     return
@@ -144,10 +146,10 @@ def add_common_args(parser):
 
   parser.add_argument(
     "--src_dir",
-      default=os.getcwd(),
-      type=str,
-      help=("The root directory of the source tree. Defaults to current "
-            "directory."))
+    default=os.getcwd(),
+    type=str,
+    help=("The root directory of the source tree. Defaults to current "
+          "directory."))
 
   parser.add_argument(
     "--project",
@@ -162,16 +164,17 @@ def add_common_args(parser):
     help=("(Optional). The GCS location to write the junit file with the "
           "results."))
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
+  )
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-      description="Run python code checks.")
+  parser = argparse.ArgumentParser(description="Run python code checks.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
@@ -198,6 +201,7 @@ def main():  # pylint: disable=too-many-locals
   args = parser.parse_args()
   args.func(args)
   logging.info("Finished")
+
 
 if __name__ == "__main__":
   main()

--- a/py/py_checks.py
+++ b/py/py_checks.py
@@ -24,15 +24,18 @@ def run_lint(args):
   # kubeflow_testing is imported as a submodule so we should exclude it
   # TODO(jlewi): Perhaps we should get a list of submodules and exclude
   # them automatically?
-  dir_excludes = ["dashboard/frontend/node_modules", "kubeflow_testing",
-                  "vendor",]
-  full_dir_excludes = [os.path.join(os.path.abspath(args.src_dir), f) for f in
-                       dir_excludes]
+  dir_excludes = [
+      "dashboard/frontend/node_modules",
+      "kubeflow_testing",
+      "vendor",
+  ]
+  full_dir_excludes = [
+      os.path.join(os.path.abspath(args.src_dir), f) for f in dir_excludes
+  ]
   includes = ["*.py"]
   failed_files = []
   rc_file = os.path.join(args.src_dir, ".pylintrc")
-  for root, dirs, files in os.walk(os.path.abspath(args.src_dir),
-                                   topdown=True):
+  for root, dirs, files in os.walk(os.path.abspath(args.src_dir), topdown=True):
     # excludes can be done with fnmatch.filter and complementary set,
     # but it's more annoying to read.
     exclude = False
@@ -48,8 +51,8 @@ def run_lint(args):
       for f in fnmatch.filter(files, pat):
         full_path = os.path.join(root, f)
         try:
-          util.run(["pylint", "--rcfile=" + rc_file, full_path],
-                    cwd=args.src_dir)
+          util.run(
+              ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
         except subprocess.CalledProcessError:
           failed_files.append(full_path.strip[len(args.src_dir):])
 
@@ -60,7 +63,6 @@ def run_lint(args):
   else:
     logging.info("No lint issues.")
 
-
   if not args.junit_path:
     logging.info("No --junit_path.")
     return
@@ -70,7 +72,8 @@ def run_lint(args):
   test_case.name = "pylint"
   test_case.time = time.time() - start_time
   if failed_files:
-    test_case.failure = "Files with lint issues: {0}".format(", ".join(failed_files))
+    test_case.failure = "Files with lint issues: {0}".format(
+        ", ".join(failed_files))
 
   gcs_client = None
   if args.junit_path.startswith("gs://"):
@@ -96,8 +99,8 @@ def run_tests(args):
   # the PYTHONPATH here and just inheriting it from the environment.
   # When we use ARGO each step will run in its own pod and we can set the
   # PYTHONPATH environment variable as needed for that pod.
-  env["PYTHONPATH"] = (args.src_dir + ":" +
-                       os.path.join(args.src_dir, "kubeflow_testing", "py"))
+  env["PYTHONPATH"] = (
+      args.src_dir + ":" + os.path.join(args.src_dir, "kubeflow_testing", "py"))
 
   num_failed = 0
   for root, dirs, files in os.walk(args.src_dir, topdown=True):
@@ -126,7 +129,6 @@ def run_tests(args):
   else:
     logging.info("No lint issues.")
 
-
   if not args.junit_path:
     logging.info("No --junit_path.")
     return
@@ -142,35 +144,36 @@ def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-    "--src_dir",
+      "--src_dir",
       default=os.getcwd(),
       type=str,
       help=("The root directory of the source tree. Defaults to current "
             "directory."))
 
   parser.add_argument(
-    "--project",
-    default=None,
-    type=str,
-    help=("(Optional). The project to use with the GCS client."))
+      "--project",
+      default=None,
+      type=str,
+      help=("(Optional). The project to use with the GCS client."))
 
   parser.add_argument(
-    "--junit_path",
-    default=None,
-    type=str,
-    help=("(Optional). The GCS location to write the junit file with the "
-          "results."))
+      "--junit_path",
+      default=None,
+      type=str,
+      help=("(Optional). The GCS location to write the junit file with the "
+            "results."))
+
 
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-      description="Run python code checks.")
+  parser = argparse.ArgumentParser(description="Run python code checks.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
@@ -197,6 +200,7 @@ def main():  # pylint: disable=too-many-locals
   args = parser.parse_args()
   args.func(args)
   logging.info("Finished")
+
 
 if __name__ == "__main__":
   main()

--- a/py/release.py
+++ b/py/release.py
@@ -36,6 +36,7 @@ GCB_PROJECT = "tf-on-k8s-releasing"
 # Directory to checkout the source.
 REPO_DIR = "git_tensorflow_k8s"
 
+
 def get_latest_green_presubmit(gcs_client):
   """Find the commit corresponding to the latest passing postsubmit."""
   bucket = gcs_client.get_bucket(RESULTS_BUCKET)
@@ -99,6 +100,7 @@ def get_last_release(bucket):
   data = json.loads(contents)
   return data.get("sha", "").strip()
 
+
 def create_latest(bucket, sha, target):
   """Create a file in GCS with information about the latest release.
 
@@ -112,14 +114,17 @@ def create_latest(bucket, sha, target):
   logging.info("Creating GCS output: %s", util.to_gcs_uri(bucket.name, path))
 
   data = {
-      "sha": sha.strip(),
-      "target": target,
+    "sha": sha.strip(),
+    "target": target,
   }
   blob = bucket.blob(path)
   blob.upload_from_string(json.dumps(data))
 
 
-def build_operator_image(root_dir, registry, project=None, should_push=True,
+def build_operator_image(root_dir,
+                         registry,
+                         project=None,
+                         should_push=True,
                          version_tag=None):
   """Build the main docker image for the TFJob CRD.
   Args:
@@ -141,31 +146,32 @@ def build_operator_image(root_dir, registry, project=None, should_push=True,
   commit = build_and_push_image.GetGitHash(root_dir)
 
   targets = [
-      "github.com/kubeflow/tf-operator/cmd/tf-operator",
-      "github.com/kubeflow/tf-operator/test/e2e",
-      "github.com/kubeflow/tf-operator/dashboard/backend",
+    "github.com/kubeflow/tf-operator/cmd/tf-operator",
+    "github.com/kubeflow/tf-operator/test/e2e",
+    "github.com/kubeflow/tf-operator/dashboard/backend",
   ]
   for t in targets:
     if t == "github.com/kubeflow/tf-operator/cmd/tf-operator":
-      util.run(["go", "install", "-ldflags",
-                "-X github.com/kubeflow/tf-operator/version.GitSHA={}".format(commit),
-                t])
+      util.run([
+        "go", "install", "-ldflags",
+        "-X github.com/kubeflow/tf-operator/version.GitSHA={}".format(commit), t
+      ])
     util.run(["go", "install", t])
 
   # Dashboard's frontend:
   # Resolving dashboard's front-end dependencies
-  util.run(["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "install"])
+  util.run(
+    ["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "install"])
   # Building dashboard's front-end
   util.run(["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "build"])
 
   # List of paths to copy relative to root.
   sources = [
-      "build/images/tf_operator/Dockerfile",
-      "examples/tf_sample/tf_sample/tf_smoke.py",
-      os.path.join(go_path, "bin/tf-operator"),
-      os.path.join(go_path, "bin/e2e"),
-      os.path.join(go_path, "bin/backend"),
-      "dashboard/frontend/build"
+    "build/images/tf_operator/Dockerfile",
+    "examples/tf_sample/tf_sample/tf_smoke.py",
+    os.path.join(go_path, "bin/tf-operator"),
+    os.path.join(go_path, "bin/e2e"),
+    os.path.join(go_path, "bin/backend"), "dashboard/frontend/build"
   ]
 
   for s in sources:
@@ -189,12 +195,15 @@ def build_operator_image(root_dir, registry, project=None, should_push=True,
   latest_image = image_base + ":latest"
 
   if project:
-    util.run(["gcloud", "container", "builds", "submit", context_dir,
-              "--tag=" + image, "--project=" + project])
+    util.run([
+      "gcloud", "container", "builds", "submit", context_dir, "--tag=" + image,
+      "--project=" + project
+    ])
 
     # Add the latest tag.
-    util.run(["gcloud", "container", "images", "add-tag", "--quiet", image,
-              latest_image])
+    util.run([
+      "gcloud", "container", "images", "add-tag", "--quiet", image, latest_image
+    ])
 
   else:
     util.run(["docker", "build", "-t", image, context_dir])
@@ -215,8 +224,13 @@ def build_operator_image(root_dir, registry, project=None, should_push=True,
   }
   return output
 
-def build_and_push_artifacts(go_dir, src_dir, registry, publish_path=None,
-                             gcb_project=None, build_info_path=None,
+
+def build_and_push_artifacts(go_dir,
+                             src_dir,
+                             registry,
+                             publish_path=None,
+                             gcb_project=None,
+                             build_info_path=None,
                              version_tag=None):
   """Build and push the artifacts.
 
@@ -241,14 +255,15 @@ def build_and_push_artifacts(go_dir, src_dir, registry, publish_path=None,
   if not os.path.exists(bin_dir):
     os.makedirs(bin_dir)
 
-  build_info = build_operator_image(src_dir, registry, project=gcb_project,
-                                    version_tag=version_tag)
+  build_info = build_operator_image(
+    src_dir, registry, project=gcb_project, version_tag=version_tag)
 
   # Copy the chart to a temporary directory because we will modify some
   # of its YAML files.
   chart_build_dir = tempfile.mkdtemp(prefix="tmpTFJobChartBuild")
-  shutil.copytree(os.path.join(src_dir, "tf-job-operator-chart"),
-                  os.path.join(chart_build_dir, "tf-job-operator-chart"))
+  shutil.copytree(
+    os.path.join(src_dir, "tf-job-operator-chart"),
+    os.path.join(chart_build_dir, "tf-job-operator-chart"))
   version = build_info["image"].split(":")[-1]
   values_file = os.path.join(chart_build_dir, "tf-job-operator-chart",
                              "values.yaml")
@@ -264,8 +279,12 @@ def build_and_push_artifacts(go_dir, src_dir, registry, publish_path=None,
     logging.info("Delete previous build: %s", m)
     os.unlink(m)
 
-  util.run(["helm", "package", "--save=false", "--destination=" + bin_dir,
-            "./tf-job-operator-chart"], cwd=chart_build_dir)
+  util.run(
+    [
+      "helm", "package", "--save=false", "--destination=" + bin_dir,
+      "./tf-job-operator-chart"
+    ],
+    cwd=chart_build_dir)
 
   matches = glob.glob(os.path.join(bin_dir, "tf-job-operator-chart*.tgz"))
 
@@ -308,6 +327,7 @@ def build_and_push_artifacts(go_dir, src_dir, registry, publish_path=None,
 
   write_build_info(build_info, paths, project=gcb_project)
 
+
 def write_build_info(build_info, paths, project=None):
   """Write the build info files.
   """
@@ -329,11 +349,13 @@ def write_build_info(build_info, paths, project=None):
       with open(p, mode='w') as hf:
         hf.write(contents)
 
+
 def build(args):
   """Build the code."""
   if not args.src_dir:
     logging.info("--src_dir not set")
-    args.src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    args.src_dir = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), ".."))
   logging.info("Use --src_dir=%s", args.src_dir)
 
   go_dir = os.getenv("GOPATH")
@@ -360,7 +382,7 @@ def build(args):
 
     if target != args.src_dir:
       message = "{0} is a symbolic link to {1}; but --src_dir={2}".format(
-                 go_src_dir, target, args.src_dir)
+        go_src_dir, target, args.src_dir)
       logging.error(message)
       raise ValueError(message)
   elif go_src_dir != args.src_dir:
@@ -379,6 +401,7 @@ def build(args):
   # being set in the environment.
   build_and_push(go_dir, args.src_dir, args)
 
+
 def build_and_push(go_dir, src_dir, args):
   if args.dryrun:
     logging.info("dryrun...")
@@ -393,11 +416,15 @@ def build_and_push(go_dir, src_dir, args):
       }
       write_build_info(build_info, paths, project=args.project)
     return
-  build_and_push_artifacts(go_dir, src_dir, registry=args.registry,
-                           publish_path=args.releases_path,
-                           gcb_project=args.project,
-                           build_info_path=args.build_info_path,
-                           version_tag=args.version_tag)
+  build_and_push_artifacts(
+    go_dir,
+    src_dir,
+    registry=args.registry,
+    publish_path=args.releases_path,
+    gcb_project=args.project,
+    build_info_path=args.build_info_path,
+    version_tag=args.version_tag)
+
 
 def build_local(args):
   """Build the artifacts from the local copy of the code."""
@@ -411,20 +438,25 @@ def build_local(args):
 
   if not os.path.exists(go_src_dir):
     logging.info("Directory %s  doesn't exist.")
-    logging.info("Creating symbolic link %s pointing to %s", go_src_dir, src_dir)
+    logging.info("Creating symbolic link %s pointing to %s", go_src_dir,
+                 src_dir)
     os.symlink(src_dir, go_src_dir)
 
   build_and_push(go_dir, src_dir, args)
 
+
 def clone_repo(args):
   args.clone_func(args)
+
 
 def clone_pr(args):
   branches = ["pull/{0}/head:pr".format(args.pr)]
   util.clone_repo(args.src_dir, REPO_ORG, REPO_NAME, args.commit, branches)
 
+
 def clone_postsubmit(args):
   util.clone_repo(args.src_dir, REPO_ORG, REPO_NAME, args.commit)
+
 
 # TODO(jlewi): Delete this function once
 # https://github.com/kubeflow/tf-operator/issues/189 is fixed.
@@ -448,11 +480,13 @@ def build_commit(args, branches):
   util.install_go_deps(clone_dir)
   build_and_push(go_dir, src_dir, args)
 
+
 # TODO(jlewi): Delete this function once
 # https://github.com/kubeflow/tf-operator/issues/189 is fixed.
 def build_postsubmit(args):
   """Build the artifacts from a postsubmit."""
   build_commit(args, None)
+
 
 # TODO(jlewi): Delete this function once
 # https://github.com/kubeflow/tf-operator/issues/189 is fixed.
@@ -461,12 +495,14 @@ def build_pr(args):
   branches = ["pull/{0}/head:pr".format(args.pr)]
   build_commit(args, branches)
 
+
 def clone_lastgreen(args):
   gcs_client = storage.Client()
   sha = get_latest_green_presubmit(gcs_client)
 
   util.clone_repo(args.src_dir, util.MASTER_REPO_OWNER, util.MASTER_REPO_NAME,
                   sha)
+
 
 def build_new_release(args):  # pylint: disable=too-many-locals
   """Find the latest release and build the artifacts if they are newer then
@@ -494,14 +530,15 @@ def build_new_release(args):  # pylint: disable=too-many-locals
 
   build(args)
 
+
 def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
     "--registry",
-      default="gcr.io/mlkube-testing",
-      type=str,
-      help="The docker registry to use.")
+    default="gcr.io/mlkube-testing",
+    type=str,
+    help="The docker registry to use.")
 
   parser.add_argument(
     "--project",
@@ -530,16 +567,19 @@ def add_common_args(parser):
     help=("A string used as the image tag. If not supplied defaults to a "
           "value based on the git commit."))
 
-  parser.add_argument("--dryrun", dest="dryrun", action="store_true",
-                      help="Do a dry run.")
-  parser.add_argument("--no-dryrun", dest="dryrun", action="store_false",
-                      help="Don't do a dry run.")
+  parser.add_argument(
+    "--dryrun", dest="dryrun", action="store_true", help="Do a dry run.")
+  parser.add_argument(
+    "--no-dryrun",
+    dest="dryrun",
+    action="store_false",
+    help="Don't do a dry run.")
   parser.set_defaults(dryrun=False)
+
 
 def build_parser():
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Build the release artifacts.")
+  parser = argparse.ArgumentParser(description="Build the release artifacts.")
   subparsers = parser.add_subparsers()
 
   #############################################################################
@@ -549,8 +589,7 @@ def build_parser():
   # This mode builds the artifacts from the local copy of the code.
 
   parser_clone = subparsers.add_parser(
-    "clone",
-    help="Clone and checkout the repository.")
+    "clone", help="Clone and checkout the repository.")
 
   parser_clone.add_argument(
     "--src_dir",
@@ -561,8 +600,7 @@ def build_parser():
   clone_subparsers = parser_clone.add_subparsers()
 
   last_green = clone_subparsers.add_parser(
-    "lastgreen",
-    help="Clone the last green postsubmit.")
+    "lastgreen", help="Clone the last green postsubmit.")
 
   last_green.add_argument(
     "--commit",
@@ -572,15 +610,10 @@ def build_parser():
 
   last_green.set_defaults(clone_func=clone_lastgreen)
 
-  pr = clone_subparsers.add_parser(
-    "pr",
-    help="Clone the pull request.")
+  pr = clone_subparsers.add_parser("pr", help="Clone the pull request.")
 
   pr.add_argument(
-    "--pr",
-    default=None,
-    required=True,
-    help="The pull request to check out..")
+    "--pr", default=None, required=True, help="The pull request to check out..")
 
   pr.add_argument(
     "--commit",
@@ -591,8 +624,7 @@ def build_parser():
   pr.set_defaults(clone_func=clone_pr)
 
   postsubmit = clone_subparsers.add_parser(
-    "postsubmit",
-    help="Clone a postsubmit.")
+    "postsubmit", help="Clone a postsubmit.")
 
   postsubmit.add_argument(
     "--commit",
@@ -625,16 +657,14 @@ def build_parser():
   # This mode builds the artifacts from the local copy of the code.
 
   parser_local = subparsers.add_parser(
-    "local",
-    help="Build the artifacts from the local copy of the code.")
+    "local", help="Build the artifacts from the local copy of the code.")
 
   add_common_args(parser_local)
   parser_local.set_defaults(func=build_local)
 
   # Build a particular postsubmit hash.
   parser_postsubmit = subparsers.add_parser(
-    "postsubmit",
-    help="Build the artifacts from a postsubmit.")
+    "postsubmit", help="Build the artifacts from a postsubmit.")
   parser_postsubmit.set_defaults(func=build_postsubmit)
 
   add_common_args(parser_postsubmit)
@@ -642,14 +672,14 @@ def build_parser():
   parser_postsubmit.add_argument(
     "--commit",
     default=None,
-      type=str,
-      help="Optional a particular commit to checkout and build.")
+    type=str,
+    help="Optional a particular commit to checkout and build.")
 
   parser_postsubmit.add_argument(
     "--src_dir",
     default=None,
-      type=str,
-      help="(Optional) Directory to checkout the source to.")
+    type=str,
+    help="(Optional) Directory to checkout the source to.")
 
   ############################################################################
   # Build new release
@@ -670,39 +700,37 @@ def build_parser():
   ############################################################################
   # Pull Request
   parser_pr = subparsers.add_parser(
-    "pr",
-    help=("Build the artifacts from the specified pull request. "))
+    "pr", help=("Build the artifacts from the specified pull request. "))
 
   add_common_args(parser_pr)
 
   parser_pr.add_argument(
-    "--pr",
-    required=True,
-      type=str,
-      help="The PR to build.")
+    "--pr", required=True, type=str, help="The PR to build.")
 
   parser_pr.add_argument(
     "--commit",
     default=None,
-      type=str,
-      help="Optional a particular commit to checkout and build.")
+    type=str,
+    help="Optional a particular commit to checkout and build.")
 
   parser_pr.add_argument(
     "--src_dir",
     default=None,
-      type=str,
-      help="(Optional) Directory to checkout the source to.")
+    type=str,
+    help="(Optional) Directory to checkout the source to.")
 
   parser_pr.set_defaults(func=build_pr)
   return parser
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   util.maybe_activate_service_account()
 
@@ -712,6 +740,7 @@ def main():  # pylint: disable=too-many-locals
   args = parser.parse_args()
   # TODO: this line fails in Python 3 because library API change.
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/release.py
+++ b/py/release.py
@@ -114,8 +114,8 @@ def create_latest(bucket, sha, target):
   logging.info("Creating GCS output: %s", util.to_gcs_uri(bucket.name, path))
 
   data = {
-      "sha": sha.strip(),
-      "target": target,
+    "sha": sha.strip(),
+    "target": target,
   }
   blob = bucket.blob(path)
   blob.upload_from_string(json.dumps(data))
@@ -146,33 +146,32 @@ def build_operator_image(root_dir,
   commit = build_and_push_image.GetGitHash(root_dir)
 
   targets = [
-      "github.com/kubeflow/tf-operator/cmd/tf-operator",
-      "github.com/kubeflow/tf-operator/test/e2e",
-      "github.com/kubeflow/tf-operator/dashboard/backend",
+    "github.com/kubeflow/tf-operator/cmd/tf-operator",
+    "github.com/kubeflow/tf-operator/test/e2e",
+    "github.com/kubeflow/tf-operator/dashboard/backend",
   ]
   for t in targets:
     if t == "github.com/kubeflow/tf-operator/cmd/tf-operator":
       util.run([
-          "go", "install", "-ldflags",
-          "-X github.com/kubeflow/tf-operator/version.GitSHA={}".format(
-              commit), t
+        "go", "install", "-ldflags",
+        "-X github.com/kubeflow/tf-operator/version.GitSHA={}".format(commit), t
       ])
     util.run(["go", "install", t])
 
   # Dashboard's frontend:
   # Resolving dashboard's front-end dependencies
   util.run(
-      ["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "install"])
+    ["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "install"])
   # Building dashboard's front-end
   util.run(["yarn", "--cwd", "{}/dashboard/frontend".format(root_dir), "build"])
 
   # List of paths to copy relative to root.
   sources = [
-      "build/images/tf_operator/Dockerfile",
-      "examples/tf_sample/tf_sample/tf_smoke.py",
-      os.path.join(go_path, "bin/tf-operator"),
-      os.path.join(go_path, "bin/e2e"),
-      os.path.join(go_path, "bin/backend"), "dashboard/frontend/build"
+    "build/images/tf_operator/Dockerfile",
+    "examples/tf_sample/tf_sample/tf_smoke.py",
+    os.path.join(go_path, "bin/tf-operator"),
+    os.path.join(go_path, "bin/e2e"),
+    os.path.join(go_path, "bin/backend"), "dashboard/frontend/build"
   ]
 
   for s in sources:
@@ -197,13 +196,13 @@ def build_operator_image(root_dir,
 
   if project:
     util.run([
-        "gcloud", "container", "builds", "submit", context_dir, "--tag=" + image,
-        "--project=" + project
+      "gcloud", "container", "builds", "submit", context_dir, "--tag=" + image,
+      "--project=" + project
     ])
 
     # Add the latest tag.
     util.run([
-        "gcloud", "container", "images", "add-tag", "--quiet", image, latest_image
+      "gcloud", "container", "images", "add-tag", "--quiet", image, latest_image
     ])
 
   else:
@@ -220,8 +219,8 @@ def build_operator_image(root_dir,
       logging.info("Pushed image: %s", latest_image)
 
   output = {
-      "image": image,
-      "commit": commit,
+    "image": image,
+    "commit": commit,
   }
   return output
 
@@ -257,14 +256,14 @@ def build_and_push_artifacts(go_dir,
     os.makedirs(bin_dir)
 
   build_info = build_operator_image(
-      src_dir, registry, project=gcb_project, version_tag=version_tag)
+    src_dir, registry, project=gcb_project, version_tag=version_tag)
 
   # Copy the chart to a temporary directory because we will modify some
   # of its YAML files.
   chart_build_dir = tempfile.mkdtemp(prefix="tmpTFJobChartBuild")
   shutil.copytree(
-      os.path.join(src_dir, "tf-job-operator-chart"),
-      os.path.join(chart_build_dir, "tf-job-operator-chart"))
+    os.path.join(src_dir, "tf-job-operator-chart"),
+    os.path.join(chart_build_dir, "tf-job-operator-chart"))
   version = build_info["image"].split(":")[-1]
   values_file = os.path.join(chart_build_dir, "tf-job-operator-chart",
                              "values.yaml")
@@ -281,25 +280,25 @@ def build_and_push_artifacts(go_dir,
     os.unlink(m)
 
   util.run(
-      [
-          "helm", "package", "--save=false", "--destination=" + bin_dir,
-          "./tf-job-operator-chart"
-      ],
-      cwd=chart_build_dir)
+    [
+      "helm", "package", "--save=false", "--destination=" + bin_dir,
+      "./tf-job-operator-chart"
+    ],
+    cwd=chart_build_dir)
 
   matches = glob.glob(os.path.join(bin_dir, "tf-job-operator-chart*.tgz"))
 
   if len(matches) != 1:
     raise ValueError(
-        "Expected 1 chart archive to match but found {0}".format(matches))
+      "Expected 1 chart archive to match but found {0}".format(matches))
 
   chart_archive = matches[0]
 
   release_path = version
 
   targets = [
-      os.path.join(release_path, os.path.basename(chart_archive)),
-      "latest/tf-job-operator-chart-latest.tgz",
+    os.path.join(release_path, os.path.basename(chart_archive)),
+    "latest/tf-job-operator-chart-latest.tgz",
   ]
 
   if publish_path:
@@ -356,7 +355,7 @@ def build(args):
   if not args.src_dir:
     logging.info("--src_dir not set")
     args.src_dir = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), ".."))
+      os.path.join(os.path.dirname(__file__), ".."))
   logging.info("Use --src_dir=%s", args.src_dir)
 
   go_dir = os.getenv("GOPATH")
@@ -383,12 +382,11 @@ def build(args):
 
     if target != args.src_dir:
       message = "{0} is a symbolic link to {1}; but --src_dir={2}".format(
-          go_src_dir, target, args.src_dir)
+        go_src_dir, target, args.src_dir)
       logging.error(message)
       raise ValueError(message)
   elif go_src_dir != args.src_dir:
-    message = "{0} doesn't equal --src_dir={1}".format(
-        go_src_dir, args.src_dir)
+    message = "{0} doesn't equal --src_dir={1}".format(go_src_dir, args.src_dir)
     logging.error(message)
     raise ValueError(message)
 
@@ -412,20 +410,20 @@ def build_and_push(go_dir, src_dir, args):
     if args.build_info_path:
       paths = [args.build_info_path]
       build_info = {
-          "image": "gcr.io/dryrun/dryrun:latest",
-          "commit": "1234abcd",
-          "helm_package": "gs://dryrun/dryrun.latest.",
+        "image": "gcr.io/dryrun/dryrun:latest",
+        "commit": "1234abcd",
+        "helm_package": "gs://dryrun/dryrun.latest.",
       }
       write_build_info(build_info, paths, project=args.project)
     return
   build_and_push_artifacts(
-      go_dir,
-      src_dir,
-      registry=args.registry,
-      publish_path=args.releases_path,
-      gcb_project=args.project,
-      build_info_path=args.build_info_path,
-      version_tag=args.version_tag)
+    go_dir,
+    src_dir,
+    registry=args.registry,
+    publish_path=args.releases_path,
+    gcb_project=args.project,
+    build_info_path=args.build_info_path,
+    version_tag=args.version_tag)
 
 
 def build_local(args):
@@ -537,45 +535,45 @@ def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-      "--registry",
-      default="gcr.io/mlkube-testing",
-      type=str,
-      help="The docker registry to use.")
+    "--registry",
+    default="gcr.io/mlkube-testing",
+    type=str,
+    help="The docker registry to use.")
 
   parser.add_argument(
-      "--project",
-      default=None,
-      type=str,
-      help=("If specified use Google Container Builder and this project to "
-            "build artifacts."))
+    "--project",
+    default=None,
+    type=str,
+    help=("If specified use Google Container Builder and this project to "
+          "build artifacts."))
 
   parser.add_argument(
-      "--releases_path",
-      default=None,
-      required=False,
-      type=str,
-      help="The GCS location where artifacts should be pushed.")
+    "--releases_path",
+    default=None,
+    required=False,
+    type=str,
+    help="The GCS location where artifacts should be pushed.")
 
   parser.add_argument(
-      "--build_info_path",
-      default="",
-      type=str,
-      help="(Optional). The GCS location to write build info to.")
+    "--build_info_path",
+    default="",
+    type=str,
+    help="(Optional). The GCS location to write build info to.")
 
   parser.add_argument(
-      "--version_tag",
-      default=None,
-      type=str,
-      help=("A string used as the image tag. If not supplied defaults to a "
-            "value based on the git commit."))
+    "--version_tag",
+    default=None,
+    type=str,
+    help=("A string used as the image tag. If not supplied defaults to a "
+          "value based on the git commit."))
 
   parser.add_argument(
-      "--dryrun", dest="dryrun", action="store_true", help="Do a dry run.")
+    "--dryrun", dest="dryrun", action="store_true", help="Do a dry run.")
   parser.add_argument(
-      "--no-dryrun",
-      dest="dryrun",
-      action="store_false",
-      help="Don't do a dry run.")
+    "--no-dryrun",
+    dest="dryrun",
+    action="store_false",
+    help="Don't do a dry run.")
   parser.set_defaults(dryrun=False)
 
 
@@ -591,48 +589,48 @@ def build_parser():
   # This mode builds the artifacts from the local copy of the code.
 
   parser_clone = subparsers.add_parser(
-      "clone", help="Clone and checkout the repository.")
+    "clone", help="Clone and checkout the repository.")
 
   parser_clone.add_argument(
-      "--src_dir",
-      required=True,
-      type=str,
-      help="Directory to checkout the source to.")
+    "--src_dir",
+    required=True,
+    type=str,
+    help="Directory to checkout the source to.")
 
   clone_subparsers = parser_clone.add_subparsers()
 
   last_green = clone_subparsers.add_parser(
-      "lastgreen", help="Clone the last green postsubmit.")
+    "lastgreen", help="Clone the last green postsubmit.")
 
   last_green.add_argument(
-      "--commit",
-      default=None,
-      type=str,
-      help="Optional a particular commit to checkout.")
+    "--commit",
+    default=None,
+    type=str,
+    help="Optional a particular commit to checkout.")
 
   last_green.set_defaults(clone_func=clone_lastgreen)
 
   pr = clone_subparsers.add_parser("pr", help="Clone the pull request.")
 
   pr.add_argument(
-      "--pr", default=None, required=True, help="The pull request to check out..")
+    "--pr", default=None, required=True, help="The pull request to check out..")
 
   pr.add_argument(
-      "--commit",
-      default=None,
-      type=str,
-      help="Optional a particular commit to checkout.")
+    "--commit",
+    default=None,
+    type=str,
+    help="Optional a particular commit to checkout.")
 
   pr.set_defaults(clone_func=clone_pr)
 
   postsubmit = clone_subparsers.add_parser(
-      "postsubmit", help="Clone a postsubmit.")
+    "postsubmit", help="Clone a postsubmit.")
 
   postsubmit.add_argument(
-      "--commit",
-      default=None,
-      type=str,
-      help="Optional a particular commit to checkout.")
+    "--commit",
+    default=None,
+    type=str,
+    help="Optional a particular commit to checkout.")
 
   postsubmit.set_defaults(clone_func=clone_postsubmit)
 
@@ -643,11 +641,11 @@ def build_parser():
   build_subparser = subparsers.add_parser("build", help="Build the artifacts.")
 
   build_subparser.add_argument(
-      "--src_dir",
-      default=None,
-      type=str,
-      help=("Directory containing the source. If not set determined "
-            "automatically."))
+    "--src_dir",
+    default=None,
+    type=str,
+    help=("Directory containing the source. If not set determined "
+          "automatically."))
 
   add_common_args(build_subparser)
   build_subparser.set_defaults(func=build)
@@ -659,42 +657,42 @@ def build_parser():
   # This mode builds the artifacts from the local copy of the code.
 
   parser_local = subparsers.add_parser(
-      "local", help="Build the artifacts from the local copy of the code.")
+    "local", help="Build the artifacts from the local copy of the code.")
 
   add_common_args(parser_local)
   parser_local.set_defaults(func=build_local)
 
   # Build a particular postsubmit hash.
   parser_postsubmit = subparsers.add_parser(
-      "postsubmit", help="Build the artifacts from a postsubmit.")
+    "postsubmit", help="Build the artifacts from a postsubmit.")
   parser_postsubmit.set_defaults(func=build_postsubmit)
 
   add_common_args(parser_postsubmit)
 
   parser_postsubmit.add_argument(
-      "--commit",
-      default=None,
-      type=str,
-      help="Optional a particular commit to checkout and build.")
+    "--commit",
+    default=None,
+    type=str,
+    help="Optional a particular commit to checkout and build.")
 
   parser_postsubmit.add_argument(
-      "--src_dir",
-      default=None,
-      type=str,
-      help="(Optional) Directory to checkout the source to.")
+    "--src_dir",
+    default=None,
+    type=str,
+    help="(Optional) Directory to checkout the source to.")
 
   ############################################################################
   # Build new release
   build_new = subparsers.add_parser(
-      "build_new_release",
-      help=("Build a new release. Only builds it if its newer than current "
-            "release."))
+    "build_new_release",
+    help=("Build a new release. Only builds it if its newer than current "
+          "release."))
 
   build_new.add_argument(
-      "--src_dir",
-      default=None,
-      type=str,
-      help=("Directory containing the source. "))
+    "--src_dir",
+    default=None,
+    type=str,
+    help=("Directory containing the source. "))
 
   add_common_args(build_new)
   build_new.set_defaults(func=build_new_release)
@@ -702,24 +700,24 @@ def build_parser():
   ############################################################################
   # Pull Request
   parser_pr = subparsers.add_parser(
-      "pr", help=("Build the artifacts from the specified pull request. "))
+    "pr", help=("Build the artifacts from the specified pull request. "))
 
   add_common_args(parser_pr)
 
   parser_pr.add_argument(
-      "--pr", required=True, type=str, help="The PR to build.")
+    "--pr", required=True, type=str, help="The PR to build.")
 
   parser_pr.add_argument(
-      "--commit",
-      default=None,
-      type=str,
-      help="Optional a particular commit to checkout and build.")
+    "--commit",
+    default=None,
+    type=str,
+    help="Optional a particular commit to checkout and build.")
 
   parser_pr.add_argument(
-      "--src_dir",
-      default=None,
-      type=str,
-      help="(Optional) Directory to checkout the source to.")
+    "--src_dir",
+    default=None,
+    type=str,
+    help="(Optional) Directory to checkout the source to.")
 
   parser_pr.set_defaults(func=build_pr)
   return parser
@@ -728,10 +726,10 @@ def build_parser():
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
   logging.basicConfig(
-      level=logging.INFO,
-      format=('%(levelname)s|%(asctime)s'
-              '|%(pathname)s|%(lineno)d| %(message)s'),
-      datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
   )
 
   util.maybe_activate_service_account()

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -8,13 +8,19 @@ from py import release
 
 
 class ReleaseTest(unittest.TestCase):
+
   @mock.patch("py.release.os.makedirs")
   @mock.patch("py.release.os.symlink")
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_postsubmit(self, mock_build_and_push, mock_clone,    # pylint: disable=no-self-use
-                            _mock_install, _mock_os, _mock_makedirs):
+  def test_build_postsubmit(
+          self,
+          mock_build_and_push,
+          mock_clone,  # pylint: disable=no-self-use
+          _mock_install,
+          _mock_os,
+          _mock_makedirs):
     # Make sure REPO_OWNER and REPO_NAME aren't changed by the environment
     release.REPO_ORG = "kubeflow"
     release.REPO_NAME = "tf-operator"
@@ -24,28 +30,29 @@ class ReleaseTest(unittest.TestCase):
     release.build_postsubmit(args)
 
     mock_build_and_push.assert_called_once_with(
-      '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
-      mock.ANY)
-    mock_clone.assert_called_once_with(
-      '/top/src_dir/git_tensorflow_k8s', 'kubeflow', 'tf-operator', None, None)
+        '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
+        mock.ANY)
+    mock_clone.assert_called_once_with('/top/src_dir/git_tensorflow_k8s',
+                                       'kubeflow', 'tf-operator', None, None)
 
   @mock.patch("py.release.os.makedirs")
   @mock.patch("py.release.os.symlink")
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install, _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
+  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install,
+                    _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
     parser = release.build_parser()
-    args = parser.parse_args(["pr", "--pr=10", "--commit=22",
-                              "--src_dir=/top/src_dir"])
+    args = parser.parse_args(
+        ["pr", "--pr=10", "--commit=22", "--src_dir=/top/src_dir"])
     release.build_pr(args)
 
     mock_build_and_push.assert_called_once_with(
-      '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
-      mock.ANY)
-    mock_clone.assert_called_once_with(
-      "/top/src_dir/git_tensorflow_k8s", "kubeflow", "tf-operator", "22",
-      ["pull/10/head:pr"])
+        '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
+        mock.ANY)
+    mock_clone.assert_called_once_with("/top/src_dir/git_tensorflow_k8s",
+                                       "kubeflow", "tf-operator", "22",
+                                       ["pull/10/head:pr"])
 
   def test_update_values(self):
     with tempfile.NamedTemporaryFile(delete=False) as hf:

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -8,13 +8,19 @@ from py import release
 
 
 class ReleaseTest(unittest.TestCase):
+
   @mock.patch("py.release.os.makedirs")
   @mock.patch("py.release.os.symlink")
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_postsubmit(self, mock_build_and_push, mock_clone,    # pylint: disable=no-self-use
-                            _mock_install, _mock_os, _mock_makedirs):
+  def test_build_postsubmit(
+      self,
+      mock_build_and_push,
+      mock_clone,  # pylint: disable=no-self-use
+      _mock_install,
+      _mock_os,
+      _mock_makedirs):
     # Make sure REPO_OWNER and REPO_NAME aren't changed by the environment
     release.REPO_ORG = "kubeflow"
     release.REPO_NAME = "tf-operator"
@@ -26,26 +32,27 @@ class ReleaseTest(unittest.TestCase):
     mock_build_and_push.assert_called_once_with(
       '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
       mock.ANY)
-    mock_clone.assert_called_once_with(
-      '/top/src_dir/git_tensorflow_k8s', 'kubeflow', 'tf-operator', None, None)
+    mock_clone.assert_called_once_with('/top/src_dir/git_tensorflow_k8s',
+                                       'kubeflow', 'tf-operator', None, None)
 
   @mock.patch("py.release.os.makedirs")
   @mock.patch("py.release.os.symlink")
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install, _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
+  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install,
+                    _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
     parser = release.build_parser()
-    args = parser.parse_args(["pr", "--pr=10", "--commit=22",
-                              "--src_dir=/top/src_dir"])
+    args = parser.parse_args(
+      ["pr", "--pr=10", "--commit=22", "--src_dir=/top/src_dir"])
     release.build_pr(args)
 
     mock_build_and_push.assert_called_once_with(
       '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
       mock.ANY)
-    mock_clone.assert_called_once_with(
-      "/top/src_dir/git_tensorflow_k8s", "kubeflow", "tf-operator", "22",
-      ["pull/10/head:pr"])
+    mock_clone.assert_called_once_with("/top/src_dir/git_tensorflow_k8s",
+                                       "kubeflow", "tf-operator", "22",
+                                       ["pull/10/head:pr"])
 
   def test_update_values(self):
     with tempfile.NamedTemporaryFile(delete=False) as hf:
@@ -87,10 +94,10 @@ appVersion: 0.1.0
     with open(chart_file) as hf:
       output = yaml.load(hf)
     expected = {
-        "name": "tf-job-operator-chart",
-        "home": "https://github.com/kubeflow/tf-operator",
-        "version": "0.1.0-v20171019",
-        "appVersion": "0.1.0-v20171019",
+      "name": "tf-job-operator-chart",
+      "home": "https://github.com/kubeflow/tf-operator",
+      "version": "0.1.0-v20171019",
+      "appVersion": "0.1.0-v20171019",
     }
     self.assertEqual(expected, output)
 

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -15,12 +15,12 @@ class ReleaseTest(unittest.TestCase):
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
   def test_build_postsubmit(
-          self,
-          mock_build_and_push,
-          mock_clone,  # pylint: disable=no-self-use
-          _mock_install,
-          _mock_os,
-          _mock_makedirs):
+      self,
+      mock_build_and_push,
+      mock_clone,  # pylint: disable=no-self-use
+      _mock_install,
+      _mock_os,
+      _mock_makedirs):
     # Make sure REPO_OWNER and REPO_NAME aren't changed by the environment
     release.REPO_ORG = "kubeflow"
     release.REPO_NAME = "tf-operator"
@@ -30,8 +30,8 @@ class ReleaseTest(unittest.TestCase):
     release.build_postsubmit(args)
 
     mock_build_and_push.assert_called_once_with(
-        '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
-        mock.ANY)
+      '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
+      mock.ANY)
     mock_clone.assert_called_once_with('/top/src_dir/git_tensorflow_k8s',
                                        'kubeflow', 'tf-operator', None, None)
 
@@ -44,12 +44,12 @@ class ReleaseTest(unittest.TestCase):
                     _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
     parser = release.build_parser()
     args = parser.parse_args(
-        ["pr", "--pr=10", "--commit=22", "--src_dir=/top/src_dir"])
+      ["pr", "--pr=10", "--commit=22", "--src_dir=/top/src_dir"])
     release.build_pr(args)
 
     mock_build_and_push.assert_called_once_with(
-        '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
-        mock.ANY)
+      '/top/src_dir/go', '/top/src_dir/go/src/github.com/kubeflow/tf-operator',
+      mock.ANY)
     mock_clone.assert_called_once_with("/top/src_dir/git_tensorflow_k8s",
                                        "kubeflow", "tf-operator", "22",
                                        ["pull/10/head:pr"])
@@ -94,10 +94,10 @@ appVersion: 0.1.0
     with open(chart_file) as hf:
       output = yaml.load(hf)
     expected = {
-        "name": "tf-job-operator-chart",
-        "home": "https://github.com/kubeflow/tf-operator",
-        "version": "0.1.0-v20171019",
-        "appVersion": "0.1.0-v20171019",
+      "name": "tf-job-operator-chart",
+      "home": "https://github.com/kubeflow/tf-operator",
+      "version": "0.1.0-v20171019",
+      "appVersion": "0.1.0-v20171019",
     }
     self.assertEquals(expected, output)
 

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -18,7 +18,9 @@ from py import util
 from py import tf_job_client
 
 
-def wait_for_delete(client, namespace, name,
+def wait_for_delete(client,
+                    namespace,
+                    name,
                     timeout=datetime.timedelta(minutes=5),
                     polling_interval=datetime.timedelta(seconds=30),
                     status_callback=None):
@@ -39,8 +41,8 @@ def wait_for_delete(client, namespace, name,
   while True:
     try:
       results = crd_api.get_namespaced_custom_object(
-        tf_job_client.TF_JOB_GROUP, tf_job_client.TF_JOB_VERSION, namespace,
-        tf_job_client.TF_JOB_PLURAL, name)
+          tf_job_client.TF_JOB_GROUP, tf_job_client.TF_JOB_VERSION, namespace,
+          tf_job_client.TF_JOB_PLURAL, name)
     except rest.ApiException as e:
       if e.status == httplib.NOT_FOUND:
         return
@@ -50,19 +52,20 @@ def wait_for_delete(client, namespace, name,
 
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.TimeoutError(
-        "Timeout waiting for job {0} in namespace {1} to finish.".format(
-          name, namespace))
+          "Timeout waiting for job {0} in namespace {1} to finish.".format(
+              name, namespace))
 
     time.sleep(polling_interval.seconds)
+
 
 def get_labels(name, runtime_id, replica_type=None, replica_index=None):
   """Return labels.
   """
   labels = {
-          "kubeflow.org": "",
-                "tf_job_name": name,
-                "runtime_id": runtime_id,
-        }
+      "kubeflow.org": "",
+      "tf_job_name": name,
+      "runtime_id": runtime_id,
+  }
   if replica_type:
     labels["job_type"] = replica_type
 
@@ -70,12 +73,14 @@ def get_labels(name, runtime_id, replica_type=None, replica_index=None):
     labels["task_index"] = replica_index
   return labels
 
+
 def to_selector(labels):
   parts = []
   for k, v in labels.iteritems():
     parts.append("{0}={1}".format(k, v))
 
   return ",".join(parts)
+
 
 def list_pods(client, namespace, label_selector):
   core = k8s_client.CoreV1Api(client)
@@ -92,19 +97,18 @@ def list_pods(client, namespace, label_selector):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-          ("Exception when calling DefaultApi->"
-             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-            e.body)
+            ("Exception when calling DefaultApi->"
+             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-      ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-        message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
 
-def run_test(args): # pylint: disable=too-many-branches,too-many-statements
+
+def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
   """Run a test."""
   gcs_client = storage.Client(project=args.project)
   project = args.project
@@ -131,8 +135,9 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
     if k == "namespace":
       namespace = v
-    util.run(["ks", "param", "set", "--env=" + env, args.component, k, v],
-             cwd=args.app_dir)
+    util.run(
+        ["ks", "param", "set", "--env=" + env, args.component, k, v],
+        cwd=args.app_dir)
 
   if not name:
     raise ValueError("name must be provided as a parameter.")
@@ -156,22 +161,22 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
     for trial in range(num_trials):
       logging.info("Trial %s", trial)
-      util.run(["ks", "apply", env, "-c", args.component],
-               cwd=args.app_dir)
+      util.run(["ks", "apply", env, "-c", args.component], cwd=args.app_dir)
 
       logging.info("Created job %s in namespaces %s", name, namespace)
-      results = tf_job_client.wait_for_job(api_client, namespace, name,
-                                           status_callback=tf_job_client.log_status)
+      results = tf_job_client.wait_for_job(
+          api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       if results.get("status", {}).get("state", {}).lower() != "succeeded":
         t.failure = "Trial {0} Job {1} in namespace {2} in state {3}".format(
-          trial, name, namespace, results.get("status", {}).get("state", None))
+            trial, name, namespace,
+            results.get("status", {}).get("state", None))
         logging.error(t.failure)
         break
 
       runtime_id = results.get("spec", {}).get("RuntimeId")
-      logging.info("Trial %s Job %s in namespace %s runtime ID %s",
-                   trial, name, namespace, runtime_id)
+      logging.info("Trial %s Job %s in namespace %s runtime ID %s", trial, name,
+                   namespace, runtime_id)
 
       # TODO(jlewi): We should check that pods were created for each replica
       pod_labels = get_labels(name, runtime_id)
@@ -183,15 +188,15 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
       if not pods.items:
         t.failure = ("Trial {0} Job {1} in namespace {2} no pods found for "
-                     " selector {3}").format(
-                     trial, name, namespace, pod_selector)
+                     " selector {3}").format(trial, name, namespace,
+                                             pod_selector)
         logging.error(t.failure)
         break
 
       tf_job_client.delete_tf_job(api_client, namespace, name)
 
-      wait_for_delete(api_client, namespace, name,
-                      status_callback=tf_job_client.log_status)
+      wait_for_delete(
+          api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       # Verify the pods have been deleted. tf_job_client uses foreground
       # deletion so there shouldn't be any resources for the job left
@@ -199,17 +204,16 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
       pods = list_pods(api_client, namespace, pod_selector)
 
       logging.info("Trial %s selector: %s matched %s pods", trial, pod_selector,
-                       len(pods.items))
+                   len(pods.items))
 
       if pods.items:
         t.failure = ("Trial {0} Job {1} in namespace {2} pods found for "
-                         " selector {3}; pods\n{4}").format(
-                           trial, name, namespace, pod_selector, pods)
+                     " selector {3}; pods\n{4}").format(trial, name, namespace,
+                                                        pod_selector, pods)
         logging.error(t.failure)
         break
 
       logging.info("Trial %s all pods deleted.", trial)
-
 
     # TODO(jlewi):
     #  Here are some validation checks to run:
@@ -220,9 +224,9 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
     # run.
   except util.TimeoutError:
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
-      name, namespace)
+        name, namespace)
     logging.error(t.failure)
-  except Exception as e: # pylint: disable-msg=broad-except
+  except Exception as e:  # pylint: disable-msg=broad-except
     # TODO(jlewi): I'm observing flakes where the exception has message "status"
     # in an effort to try to nail down this exception we print out more
     # information about the exception.
@@ -233,79 +237,74 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
     logging.error("Exception args: %s", e.args)
     # We want to catch all exceptions because we want the test as failed.
     t.failure = ("Exception occured; type {0} message {1}".format(
-      e.__class__, e.message))
+        e.__class__, e.message))
   finally:
     t.time = time.time() - start
     if args.junit_path:
       test_util.create_junit_xml_file([t], args.junit_path, gcs_client)
 
+
 def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-    "--project",
-    default=None,
-    type=str,
-    help=("The project to use."))
+      "--project", default=None, type=str, help=("The project to use."))
 
   parser.add_argument(
-    "--cluster",
-    default=None,
-    type=str,
-    help=("The name of the cluster."))
+      "--cluster", default=None, type=str, help=("The name of the cluster."))
 
   parser.add_argument(
-    "--app_dir",
-    default=None,
-    type=str,
-    help="Directory containing the ksonnet app.")
+      "--app_dir",
+      default=None,
+      type=str,
+      help="Directory containing the ksonnet app.")
 
   parser.add_argument(
-    "--component",
-    default=None,
-    type=str,
-    help="The ksonnet component of the job to run.")
+      "--component",
+      default=None,
+      type=str,
+      help="The ksonnet component of the job to run.")
 
   parser.add_argument(
-    "--params",
-    default=None,
-    type=str,
-    help="Comma separated list of key value pairs to set on the component.")
+      "--params",
+      default=None,
+      type=str,
+      help="Comma separated list of key value pairs to set on the component.")
 
   parser.add_argument(
-    "--zone",
-    default="us-east1-d",
-    type=str,
-    help=("The zone for the cluster."))
+      "--zone",
+      default="us-east1-d",
+      type=str,
+      help=("The zone for the cluster."))
 
   parser.add_argument(
-    "--junit_path",
-    default="",
-    type=str,
-    help="Where to write the junit xml file with the results.")
+      "--junit_path",
+      default="",
+      type=str,
+      help="Where to write the junit xml file with the results.")
+
 
 def build_parser():
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Run a TFJob test.")
+  parser = argparse.ArgumentParser(description="Run a TFJob test.")
   subparsers = parser.add_subparsers()
 
-  parser_test = subparsers.add_parser(
-    "test",
-    help="Run a tfjob test.")
+  parser_test = subparsers.add_parser("test", help="Run a tfjob test.")
 
   add_common_args(parser_test)
   parser_test.set_defaults(func=run_test)
 
   return parser
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   util.maybe_activate_service_account()
 
@@ -314,6 +313,7 @@ def main():  # pylint: disable=too-many-locals
   # parse the args and call whatever function was selected
   args = parser.parse_args()
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -41,8 +41,8 @@ def wait_for_delete(client,
   while True:
     try:
       results = crd_api.get_namespaced_custom_object(
-          tf_job_client.TF_JOB_GROUP, tf_job_client.TF_JOB_VERSION, namespace,
-          tf_job_client.TF_JOB_PLURAL, name)
+        tf_job_client.TF_JOB_GROUP, tf_job_client.TF_JOB_VERSION, namespace,
+        tf_job_client.TF_JOB_PLURAL, name)
     except rest.ApiException as e:
       if e.status == httplib.NOT_FOUND:
         return
@@ -52,8 +52,8 @@ def wait_for_delete(client,
 
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.TimeoutError(
-          "Timeout waiting for job {0} in namespace {1} to finish.".format(
-              name, namespace))
+        "Timeout waiting for job {0} in namespace {1} to finish.".format(
+          name, namespace))
 
     time.sleep(polling_interval.seconds)
 
@@ -62,9 +62,9 @@ def get_labels(name, runtime_id, replica_type=None, replica_index=None):
   """Return labels.
   """
   labels = {
-      "kubeflow.org": "",
-      "tf_job_name": name,
-      "runtime_id": runtime_id,
+    "kubeflow.org": "",
+    "tf_job_name": name,
+    "runtime_id": runtime_id,
   }
   if replica_type:
     labels["job_type"] = replica_type
@@ -97,8 +97,8 @@ def list_pods(client, namespace, label_selector):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-            ("Exception when calling DefaultApi->"
-             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
@@ -136,8 +136,8 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
     if k == "namespace":
       namespace = v
     util.run(
-        ["ks", "param", "set", "--env=" + env, args.component, k, v],
-        cwd=args.app_dir)
+      ["ks", "param", "set", "--env=" + env, args.component, k, v],
+      cwd=args.app_dir)
 
   if not name:
     raise ValueError("name must be provided as a parameter.")
@@ -165,12 +165,12 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
 
       logging.info("Created job %s in namespaces %s", name, namespace)
       results = tf_job_client.wait_for_job(
-          api_client, namespace, name, status_callback=tf_job_client.log_status)
+        api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       if results.get("status", {}).get("state", {}).lower() != "succeeded":
         t.failure = "Trial {0} Job {1} in namespace {2} in state {3}".format(
-            trial, name, namespace,
-            results.get("status", {}).get("state", None))
+          trial, name, namespace,
+          results.get("status", {}).get("state", None))
         logging.error(t.failure)
         break
 
@@ -196,7 +196,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
       tf_job_client.delete_tf_job(api_client, namespace, name)
 
       wait_for_delete(
-          api_client, namespace, name, status_callback=tf_job_client.log_status)
+        api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       # Verify the pods have been deleted. tf_job_client uses foreground
       # deletion so there shouldn't be any resources for the job left
@@ -224,7 +224,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
     # run.
   except util.TimeoutError:
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
-        name, namespace)
+      name, namespace)
     logging.error(t.failure)
   except Exception as e:  # pylint: disable-msg=broad-except
     # TODO(jlewi): I'm observing flakes where the exception has message "status"
@@ -237,7 +237,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
     logging.error("Exception args: %s", e.args)
     # We want to catch all exceptions because we want the test as failed.
     t.failure = ("Exception occured; type {0} message {1}".format(
-        e.__class__, e.message))
+      e.__class__, e.message))
   finally:
     t.time = time.time() - start
     if args.junit_path:
@@ -248,40 +248,40 @@ def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-      "--project", default=None, type=str, help=("The project to use."))
+    "--project", default=None, type=str, help=("The project to use."))
 
   parser.add_argument(
-      "--cluster", default=None, type=str, help=("The name of the cluster."))
+    "--cluster", default=None, type=str, help=("The name of the cluster."))
 
   parser.add_argument(
-      "--app_dir",
-      default=None,
-      type=str,
-      help="Directory containing the ksonnet app.")
+    "--app_dir",
+    default=None,
+    type=str,
+    help="Directory containing the ksonnet app.")
 
   parser.add_argument(
-      "--component",
-      default=None,
-      type=str,
-      help="The ksonnet component of the job to run.")
+    "--component",
+    default=None,
+    type=str,
+    help="The ksonnet component of the job to run.")
 
   parser.add_argument(
-      "--params",
-      default=None,
-      type=str,
-      help="Comma separated list of key value pairs to set on the component.")
+    "--params",
+    default=None,
+    type=str,
+    help="Comma separated list of key value pairs to set on the component.")
 
   parser.add_argument(
-      "--zone",
-      default="us-east1-d",
-      type=str,
-      help=("The zone for the cluster."))
+    "--zone",
+    default="us-east1-d",
+    type=str,
+    help=("The zone for the cluster."))
 
   parser.add_argument(
-      "--junit_path",
-      default="",
-      type=str,
-      help="Where to write the junit xml file with the results.")
+    "--junit_path",
+    default="",
+    type=str,
+    help="Where to write the junit xml file with the results.")
 
 
 def build_parser():
@@ -300,10 +300,10 @@ def build_parser():
 def main():  # pylint: disable=too-many-locals
   logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
   logging.basicConfig(
-      level=logging.INFO,
-      format=('%(levelname)s|%(asctime)s'
-              '|%(pathname)s|%(lineno)d| %(message)s'),
-      datefmt='%Y-%m-%dT%H:%M:%S',
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
   )
 
   util.maybe_activate_service_account()

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -18,7 +18,9 @@ from py import util
 from py import tf_job_client
 
 
-def wait_for_delete(client, namespace, name,
+def wait_for_delete(client,
+                    namespace,
+                    name,
                     timeout=datetime.timedelta(minutes=5),
                     polling_interval=datetime.timedelta(seconds=30),
                     status_callback=None):
@@ -55,14 +57,15 @@ def wait_for_delete(client, namespace, name,
 
     time.sleep(polling_interval.seconds)
 
+
 def get_labels(name, runtime_id, replica_type=None, replica_index=None):
   """Return labels.
   """
   labels = {
-          "kubeflow.org": "",
-                "tf_job_name": name,
-                "runtime_id": runtime_id,
-        }
+    "kubeflow.org": "",
+    "tf_job_name": name,
+    "runtime_id": runtime_id,
+  }
   if replica_type:
     labels["job_type"] = replica_type
 
@@ -70,12 +73,14 @@ def get_labels(name, runtime_id, replica_type=None, replica_index=None):
     labels["task_index"] = replica_index
   return labels
 
+
 def to_selector(labels):
   parts = []
   for k, v in labels.iteritems():
     parts.append("{0}={1}".format(k, v))
 
   return ",".join(parts)
+
 
 def list_pods(client, namespace, label_selector):
   core = k8s_client.CoreV1Api(client)
@@ -93,18 +98,17 @@ def list_pods(client, namespace, label_selector):
         # There was a problem parsing the body of the response as json.
         logging.error(
           ("Exception when calling DefaultApi->"
-             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-            e.body)
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-      ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-        message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
 
-def run_test(args): # pylint: disable=too-many-branches,too-many-statements
+
+def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
   """Run a test."""
   gcs_client = storage.Client(project=args.project)
   project = args.project
@@ -131,8 +135,9 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
     if k == "namespace":
       namespace = v
-    util.run(["ks", "param", "set", "--env=" + env, args.component, k, v],
-             cwd=args.app_dir)
+    util.run(
+      ["ks", "param", "set", "--env=" + env, args.component, k, v],
+      cwd=args.app_dir)
 
   if not name:
     raise ValueError("name must be provided as a parameter.")
@@ -156,22 +161,22 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
     for trial in range(num_trials):
       logging.info("Trial %s", trial)
-      util.run(["ks", "apply", env, "-c", args.component],
-               cwd=args.app_dir)
+      util.run(["ks", "apply", env, "-c", args.component], cwd=args.app_dir)
 
       logging.info("Created job %s in namespaces %s", name, namespace)
-      results = tf_job_client.wait_for_job(api_client, namespace, name,
-                                           status_callback=tf_job_client.log_status)
+      results = tf_job_client.wait_for_job(
+        api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       if results.get("status", {}).get("state", {}).lower() != "succeeded":
         t.failure = "Trial {0} Job {1} in namespace {2} in state {3}".format(
-          trial, name, namespace, results.get("status", {}).get("state", None))
+          trial, name, namespace,
+          results.get("status", {}).get("state", None))
         logging.error(t.failure)
         break
 
       runtime_id = results.get("spec", {}).get("RuntimeId")
-      logging.info("Trial %s Job %s in namespace %s runtime ID %s",
-                   trial, name, namespace, runtime_id)
+      logging.info("Trial %s Job %s in namespace %s runtime ID %s", trial, name,
+                   namespace, runtime_id)
 
       # TODO(jlewi): We should check that pods were created for each replica
       pod_labels = get_labels(name, runtime_id)
@@ -183,15 +188,15 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
 
       if not pods.items:
         t.failure = ("Trial {0} Job {1} in namespace {2} no pods found for "
-                     " selector {3}").format(
-                     trial, name, namespace, pod_selector)
+                     " selector {3}").format(trial, name, namespace,
+                                             pod_selector)
         logging.error(t.failure)
         break
 
       tf_job_client.delete_tf_job(api_client, namespace, name)
 
-      wait_for_delete(api_client, namespace, name,
-                      status_callback=tf_job_client.log_status)
+      wait_for_delete(
+        api_client, namespace, name, status_callback=tf_job_client.log_status)
 
       # Verify the pods have been deleted. tf_job_client uses foreground
       # deletion so there shouldn't be any resources for the job left
@@ -199,17 +204,16 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
       pods = list_pods(api_client, namespace, pod_selector)
 
       logging.info("Trial %s selector: %s matched %s pods", trial, pod_selector,
-                       len(pods.items))
+                   len(pods.items))
 
       if pods.items:
         t.failure = ("Trial {0} Job {1} in namespace {2} pods found for "
-                         " selector {3}; pods\n{4}").format(
-                           trial, name, namespace, pod_selector, pods)
+                     " selector {3}; pods\n{4}").format(trial, name, namespace,
+                                                        pod_selector, pods)
         logging.error(t.failure)
         break
 
       logging.info("Trial %s all pods deleted.", trial)
-
 
     # TODO(jlewi):
     #  Here are some validation checks to run:
@@ -222,7 +226,7 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
     t.failure = "Timeout waiting for {0} in namespace {1} to finish.".format(
       name, namespace)
     logging.error(t.failure)
-  except Exception as e: # pylint: disable-msg=broad-except
+  except Exception as e:  # pylint: disable-msg=broad-except
     # TODO(jlewi): I'm observing flakes where the exception has message "status"
     # in an effort to try to nail down this exception we print out more
     # information about the exception.
@@ -239,20 +243,15 @@ def run_test(args): # pylint: disable=too-many-branches,too-many-statements
     if args.junit_path:
       test_util.create_junit_xml_file([t], args.junit_path, gcs_client)
 
+
 def add_common_args(parser):
   """Add a set of common parser arguments."""
 
   parser.add_argument(
-    "--project",
-    default=None,
-    type=str,
-    help=("The project to use."))
+    "--project", default=None, type=str, help=("The project to use."))
 
   parser.add_argument(
-    "--cluster",
-    default=None,
-    type=str,
-    help=("The name of the cluster."))
+    "--cluster", default=None, type=str, help=("The name of the cluster."))
 
   parser.add_argument(
     "--app_dir",
@@ -284,28 +283,28 @@ def add_common_args(parser):
     type=str,
     help="Where to write the junit xml file with the results.")
 
+
 def build_parser():
   # create the top-level parser
-  parser = argparse.ArgumentParser(
-    description="Run a TFJob test.")
+  parser = argparse.ArgumentParser(description="Run a TFJob test.")
   subparsers = parser.add_subparsers()
 
-  parser_test = subparsers.add_parser(
-    "test",
-    help="Run a tfjob test.")
+  parser_test = subparsers.add_parser("test", help="Run a tfjob test.")
 
   add_common_args(parser_test)
   parser_test.set_defaults(func=run_test)
 
   return parser
 
+
 def main():  # pylint: disable=too-many-locals
-  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
-  logging.basicConfig(level=logging.INFO,
-                      format=('%(levelname)s|%(asctime)s'
-                              '|%(pathname)s|%(lineno)d| %(message)s'),
-                      datefmt='%Y-%m-%dT%H:%M:%S',
-                      )
+  logging.getLogger().setLevel(logging.INFO)  # pylint: disable=too-many-locals
+  logging.basicConfig(
+    level=logging.INFO,
+    format=('%(levelname)s|%(asctime)s'
+            '|%(pathname)s|%(lineno)d| %(message)s'),
+    datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   util.maybe_activate_service_account()
 
@@ -314,6 +313,7 @@ def main():  # pylint: disable=too-many-locals
   # parse the args and call whatever function was selected
   args = parser.parse_args()
   args.func(args)
+
 
 if __name__ == "__main__":
   main()

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -11,7 +11,9 @@ import six
 
 from py import util
 
+
 class TestCase(object):
+
   def __init__(self, class_name="", name=""):
     self.class_name = class_name
     self.name = name
@@ -19,6 +21,7 @@ class TestCase(object):
     self.time = None
     # String describing the failure.
     self.failure = None
+
 
 class TestSuite(object):
   """A suite of test cases."""
@@ -66,6 +69,7 @@ class TestSuite(object):
     """Return an iterator of TestCases."""
     return six.itervalues(self._cases)
 
+
 def wrap_test(test_func, test_case):
   """Wrap a test func.
 
@@ -83,14 +87,14 @@ def wrap_test(test_func, test_case):
   try:
     test_func()
   except subprocess.CalledProcessError as e:
-    test_case.failure = (
-       "Subprocess failed;\n{0}".format(e.output))
+    test_case.failure = ("Subprocess failed;\n{0}".format(e.output))
     raise
   except Exception as e:
     test_case.failure = "Test failed; " + e.message
     raise
   finally:
     test_case.time = time.time() - start
+
 
 def create_xml(test_cases):
   """Create an Element tree representing the test cases.
@@ -109,8 +113,11 @@ def create_xml(test_cases):
 
     if c.failure:
       failures += 1
-  attrib = {"failures": "{0}".format(failures), "tests": "{0}".format(len(test_cases)),
-            "time": "{0}".format(total_time)}
+  attrib = {
+    "failures": "{0}".format(failures),
+    "tests": "{0}".format(len(test_cases)),
+    "time": "{0}".format(total_time)
+  }
   root = ElementTree.Element("testsuite", attrib)
 
   for c in test_cases:
@@ -137,6 +144,7 @@ def create_xml(test_cases):
 
   t = ElementTree.ElementTree(root)
   return t
+
 
 def create_junit_xml_file(test_cases, output_path, gcs_client=None):
   """Create a JUnit XML file.
@@ -174,6 +182,7 @@ def create_junit_xml_file(test_cases, output_path, gcs_client=None):
         else:
           raise
     t.write(output_path)
+
 
 def get_num_failures(xml_string):
   """Return the number of failures based on the XML string."""

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -11,7 +11,9 @@ import six
 
 from py import util
 
+
 class TestCase(object):
+
   def __init__(self, class_name="", name=""):
     self.class_name = class_name
     self.name = name
@@ -19,6 +21,7 @@ class TestCase(object):
     self.time = None
     # String describing the failure.
     self.failure = None
+
 
 class TestSuite(object):
   """A suite of test cases."""
@@ -66,6 +69,7 @@ class TestSuite(object):
     """Return an iterator of TestCases."""
     return six.itervalues(self._cases)
 
+
 def wrap_test(test_func, test_case):
   """Wrap a test func.
 
@@ -83,14 +87,14 @@ def wrap_test(test_func, test_case):
   try:
     test_func()
   except subprocess.CalledProcessError as e:
-    test_case.failure = (
-       "Subprocess failed;\n{0}".format(e.output))
+    test_case.failure = ("Subprocess failed;\n{0}".format(e.output))
     raise
   except Exception as e:
     test_case.failure = "Test failed; " + e.message
     raise
   finally:
     test_case.time = time.time() - start
+
 
 def create_xml(test_cases):
   """Create an Element tree representing the test cases.
@@ -109,14 +113,17 @@ def create_xml(test_cases):
 
     if c.failure:
       failures += 1
-  attrib = {"failures": "{0}".format(failures), "tests": "{0}".format(len(test_cases)),
-            "time": "{0}".format(total_time)}
+  attrib = {
+      "failures": "{0}".format(failures),
+      "tests": "{0}".format(len(test_cases)),
+      "time": "{0}".format(total_time)
+  }
   root = ElementTree.Element("testsuite", attrib)
 
   for c in test_cases:
     attrib = {
-      "classname": c.class_name,
-      "name": c.name,
+        "classname": c.class_name,
+        "name": c.name,
     }
     if c.time:
       attrib["time"] = "{0}".format(c.time)
@@ -137,6 +144,7 @@ def create_xml(test_cases):
 
   t = ElementTree.ElementTree(root)
   return t
+
 
 def create_junit_xml_file(test_cases, output_path, gcs_client=None):
   """Create a JUnit XML file.
@@ -174,6 +182,7 @@ def create_junit_xml_file(test_cases, output_path, gcs_client=None):
         else:
           raise
     t.write(output_path)
+
 
 def get_num_failures(xml_string):
   """Return the number of failures based on the XML string."""

--- a/py/test_util.py
+++ b/py/test_util.py
@@ -114,16 +114,16 @@ def create_xml(test_cases):
     if c.failure:
       failures += 1
   attrib = {
-      "failures": "{0}".format(failures),
-      "tests": "{0}".format(len(test_cases)),
-      "time": "{0}".format(total_time)
+    "failures": "{0}".format(failures),
+    "tests": "{0}".format(len(test_cases)),
+    "time": "{0}".format(total_time)
   }
   root = ElementTree.Element("testsuite", attrib)
 
   for c in test_cases:
     attrib = {
-        "classname": c.class_name,
-        "name": c.name,
+      "classname": c.class_name,
+      "name": c.name,
     }
     if c.time:
       attrib["time"] = "{0}".format(c.time)

--- a/py/test_util_test.py
+++ b/py/test_util_test.py
@@ -105,7 +105,7 @@ class TestWrapTest(unittest.TestCase):
 
     def run():
       raise subprocess.CalledProcessError(
-          10, "some command", output="some output")
+        10, "some command", output="some output")
 
     t = test_util.TestCase()
     self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run,

--- a/py/test_util_test.py
+++ b/py/test_util_test.py
@@ -8,7 +8,9 @@ import unittest
 
 from py import test_util
 
+
 class XMLTest(unittest.TestCase):
+
   def test_write_xml(self):
     with tempfile.NamedTemporaryFile(delete=False) as hf:
       pass
@@ -61,7 +63,9 @@ class XMLTest(unittest.TestCase):
     xml_value = s.getvalue()
     self.assertEqual(0, test_util.get_num_failures(xml_value))
 
+
 class TestSuiteTest(unittest.TestCase):
+
   def testSuite(self):
     """Test TestSuite."""
     s = test_util.TestSuite("test_class")
@@ -84,8 +88,11 @@ class TestSuiteTest(unittest.TestCase):
 
     self.assertItemsEqual(["c1", "c2"], names)
 
+
 class TestWrapTest(unittest.TestCase):
+
   def testOk(self):
+
     def ok():
       time.sleep(1)
 
@@ -95,15 +102,19 @@ class TestWrapTest(unittest.TestCase):
     self.assertEqual(None, t.failure)
 
   def testSubprocessError(self):
+
     def run():
-      raise subprocess.CalledProcessError(10, "some command", output="some output")
+      raise subprocess.CalledProcessError(
+        10, "some command", output="some output")
 
     t = test_util.TestCase()
-    self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run, t)
+    self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run,
+                      t)
     self.assertGreater(t.time, 0)
     self.assertEqual("Subprocess failed;\nsome output", t.failure)
 
   def testGeneralError(self):
+
     def run():
       time.sleep(1)
       raise ValueError("some error")
@@ -112,6 +123,7 @@ class TestWrapTest(unittest.TestCase):
     self.assertRaises(ValueError, test_util.wrap_test, run, t)
     self.assertGreater(t.time, 0)
     self.assertEqual("Test failed; some error", t.failure)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/test_util_test.py
+++ b/py/test_util_test.py
@@ -8,7 +8,9 @@ import unittest
 
 from py import test_util
 
+
 class XMLTest(unittest.TestCase):
+
   def test_write_xml(self):
     with tempfile.NamedTemporaryFile(delete=False) as hf:
       pass
@@ -61,7 +63,9 @@ class XMLTest(unittest.TestCase):
     xml_value = s.getvalue()
     self.assertEquals(0, test_util.get_num_failures(xml_value))
 
+
 class TestSuiteTest(unittest.TestCase):
+
   def testSuite(self):
     """Test TestSuite."""
     s = test_util.TestSuite("test_class")
@@ -84,8 +88,11 @@ class TestSuiteTest(unittest.TestCase):
 
     self.assertItemsEqual(["c1", "c2"], names)
 
+
 class TestWrapTest(unittest.TestCase):
+
   def testOk(self):
+
     def ok():
       time.sleep(1)
 
@@ -95,15 +102,19 @@ class TestWrapTest(unittest.TestCase):
     self.assertEquals(None, t.failure)
 
   def testSubprocessError(self):
+
     def run():
-      raise subprocess.CalledProcessError(10, "some command", output="some output")
+      raise subprocess.CalledProcessError(
+          10, "some command", output="some output")
 
     t = test_util.TestCase()
-    self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run, t)
+    self.assertRaises(subprocess.CalledProcessError, test_util.wrap_test, run,
+                      t)
     self.assertGreater(t.time, 0)
     self.assertEquals("Subprocess failed;\nsome output", t.failure)
 
   def testGeneralError(self):
+
     def run():
       time.sleep(1)
       raise ValueError("some error")
@@ -112,6 +123,7 @@ class TestWrapTest(unittest.TestCase):
     self.assertRaises(ValueError, test_util.wrap_test, run, t)
     self.assertGreater(t.time, 0)
     self.assertEquals("Test failed; some error", t.failure)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -28,7 +28,7 @@ def create_tf_job(client, spec):
     # Create a Resource
     namespace = spec["metadata"].get("namespace", "default")
     api_response = crd_api.create_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, spec)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, spec)
     logging.info("Created job %s", api_response["metadata"]["name"])
     return api_response
   except ApiException as e:
@@ -41,8 +41,8 @@ def create_tf_job(client, spec):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-            ("Exception when calling DefaultApi->"
-             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
@@ -56,13 +56,13 @@ def delete_tf_job(client, namespace, name):
   crd_api = k8s_client.CustomObjectsApi(client)
   try:
     body = {
-        # Set garbage collection so that job won't be deleted until all
-        # owned references are deleted.
-        "propagationPolicy": "Foreground",
+      # Set garbage collection so that job won't be deleted until all
+      # owned references are deleted.
+      "propagationPolicy": "Foreground",
     }
     logging.info("Deleting job %s.%s", namespace, name)
     api_response = crd_api.delete_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name, body)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name, body)
     logging.info("Deleted job %s.%s", namespace, name)
     return api_response
   except ApiException as e:
@@ -75,8 +75,8 @@ def delete_tf_job(client, namespace, name):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-            ("Exception when calling DefaultApi->"
-             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
@@ -118,7 +118,7 @@ def wait_for_job(client,
   end_time = datetime.datetime.now() + timeout
   while True:
     results = crd_api.get_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name)
 
     if status_callback:
       status_callback(results)
@@ -129,8 +129,8 @@ def wait_for_job(client,
 
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.TimeoutError(
-          "Timeout waiting for job {0} in namespace {1} to finish.".format(
-              name, namespace))
+        "Timeout waiting for job {0} in namespace {1} to finish.".format(
+          name, namespace))
 
     time.sleep(polling_interval.seconds)
 

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -15,6 +15,7 @@ TF_JOB_VERSION = "v1alpha1"
 TF_JOB_PLURAL = "tfjobs"
 TF_JOB_KIND = "TFJob"
 
+
 def create_tf_job(client, spec):
   """Create a TFJob.
 
@@ -27,7 +28,7 @@ def create_tf_job(client, spec):
     # Create a Resource
     namespace = spec["metadata"].get("namespace", "default")
     api_response = crd_api.create_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, spec)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, spec)
     logging.info("Created job %s", api_response["metadata"]["name"])
     return api_response
   except ApiException as e:
@@ -40,17 +41,16 @@ def create_tf_job(client, spec):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-            ("Exception when calling DefaultApi->"
-              "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-              e.body)
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-        ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-          message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
+
 
 def delete_tf_job(client, namespace, name):
   crd_api = k8s_client.CustomObjectsApi(client)
@@ -62,8 +62,7 @@ def delete_tf_job(client, namespace, name):
     }
     logging.info("Deleting job %s.%s", namespace, name)
     api_response = crd_api.delete_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name,
-        body)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name, body)
     logging.info("Deleted job %s.%s", namespace, name)
     return api_response
   except ApiException as e:
@@ -76,28 +75,30 @@ def delete_tf_job(client, namespace, name):
       except ValueError:
         # There was a problem parsing the body of the response as json.
         logging.error(
-            ("Exception when calling DefaultApi->"
-              "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-              e.body)
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-        ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-          message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
+
 
 def log_status(tf_job):
   """A callback to use with wait_for_job."""
   logging.info("Job %s in namespace %s; uid=%s; phase=%s, state=%s,",
-           tf_job.get("metadata", {}).get("name"),
-           tf_job.get("metadata", {}).get("namespace"),
-           tf_job.get("metadata", {}).get("uid"),
-           tf_job.get("status", {}).get("phase"),
-           tf_job.get("status", {}).get("state"))
+               tf_job.get("metadata", {}).get("name"),
+               tf_job.get("metadata", {}).get("namespace"),
+               tf_job.get("metadata", {}).get("uid"),
+               tf_job.get("status", {}).get("phase"),
+               tf_job.get("status", {}).get("state"))
 
-def wait_for_job(client, namespace, name,
+
+def wait_for_job(client,
+                 namespace,
+                 name,
                  timeout=datetime.timedelta(minutes=5),
                  polling_interval=datetime.timedelta(seconds=30),
                  status_callback=None):
@@ -117,7 +118,7 @@ def wait_for_job(client, namespace, name,
   end_time = datetime.datetime.now() + timeout
   while True:
     results = crd_api.get_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name)
+      TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name)
 
     if status_callback:
       status_callback(results)

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -15,6 +15,7 @@ TF_JOB_VERSION = "v1alpha1"
 TF_JOB_PLURAL = "tfjobs"
 TF_JOB_KIND = "TFJob"
 
+
 def create_tf_job(client, spec):
   """Create a TFJob.
 
@@ -41,29 +42,27 @@ def create_tf_job(client, spec):
         # There was a problem parsing the body of the response as json.
         logging.error(
             ("Exception when calling DefaultApi->"
-              "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-              e.body)
+             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-        ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-          message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
+
 
 def delete_tf_job(client, namespace, name):
   crd_api = k8s_client.CustomObjectsApi(client)
   try:
     body = {
-      # Set garbage collection so that job won't be deleted until all
-      # owned references are deleted.
-      "propagationPolicy": "Foreground",
+        # Set garbage collection so that job won't be deleted until all
+        # owned references are deleted.
+        "propagationPolicy": "Foreground",
     }
     logging.info("Deleting job %s.%s", namespace, name)
     api_response = crd_api.delete_namespaced_custom_object(
-        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name,
-        body)
+        TF_JOB_GROUP, TF_JOB_VERSION, namespace, TF_JOB_PLURAL, name, body)
     logging.info("Deleted job %s.%s", namespace, name)
     return api_response
   except ApiException as e:
@@ -77,27 +76,29 @@ def delete_tf_job(client, namespace, name):
         # There was a problem parsing the body of the response as json.
         logging.error(
             ("Exception when calling DefaultApi->"
-              "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"),
-              e.body)
+             "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
         raise
       message = body.get("message")
 
-    logging.error(
-        ("Exception when calling DefaultApi->"
-         "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-          message)
+    logging.error(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
     raise e
+
 
 def log_status(tf_job):
   """A callback to use with wait_for_job."""
   logging.info("Job %s in namespace %s; uid=%s; phase=%s, state=%s,",
-           tf_job.get("metadata", {}).get("name"),
-           tf_job.get("metadata", {}).get("namespace"),
-           tf_job.get("metadata", {}).get("uid"),
-           tf_job.get("status", {}).get("phase"),
-           tf_job.get("status", {}).get("state"))
+               tf_job.get("metadata", {}).get("name"),
+               tf_job.get("metadata", {}).get("namespace"),
+               tf_job.get("metadata", {}).get("uid"),
+               tf_job.get("status", {}).get("phase"),
+               tf_job.get("status", {}).get("state"))
 
-def wait_for_job(client, namespace, name,
+
+def wait_for_job(client,
+                 namespace,
+                 name,
                  timeout=datetime.timedelta(minutes=5),
                  polling_interval=datetime.timedelta(seconds=30),
                  status_callback=None):
@@ -128,8 +129,8 @@ def wait_for_job(client, namespace, name,
 
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.TimeoutError(
-        "Timeout waiting for job {0} in namespace {1} to finish.".format(
-          name, namespace))
+          "Timeout waiting for job {0} in namespace {1} to finish.".format(
+              name, namespace))
 
     time.sleep(polling_interval.seconds)
 

--- a/py/util.py
+++ b/py/util.py
@@ -64,7 +64,7 @@ def run(command, cwd=None, env=None, dryrun=False):
     # subprocess output doesn't show up in Airflow. This might be because
     # we had multiple levels of processes invoking python processes.
     with tempfile.NamedTemporaryFile(
-            prefix="tmpRunLogs", delete=False, mode="w") as hf:
+        prefix="tmpRunLogs", delete=False, mode="w") as hf:
       log_file = hf.name
       subprocess.check_call(command, cwd=cwd, env=env, stdout=hf, stderr=hf)
   finally:
@@ -82,7 +82,7 @@ def run_and_output(command, cwd=None, env=None):
   # So prefer using run if we don't need to return the output.
   try:
     output = subprocess.check_output(
-        command, cwd=cwd, env=env, stderr=subprocess.STDOUT).decode("utf-8")
+      command, cwd=cwd, env=env, stderr=subprocess.STDOUT).decode("utf-8")
     logging.info("Subprocess output:\n%s", output)
   except subprocess.CalledProcessError as e:
     logging.info("Subprocess output:\n%s", e.output)
@@ -121,21 +121,21 @@ def clone_repo(dest,
   if branches:
     for b in branches:
       run(
-          [
-              "git",
-              "fetch",
-              "origin",
-              b,
-          ], cwd=dest)
+        [
+          "git",
+          "fetch",
+          "origin",
+          b,
+        ], cwd=dest)
 
     if not sha:
       b = branches[-1].split(":", 1)[-1]
       run(
-          [
-              "git",
-              "checkout",
-              b,
-          ], cwd=dest)
+        [
+          "git",
+          "checkout",
+          b,
+        ], cwd=dest)
 
   if sha:
     run(["git", "checkout", sha], cwd=dest)
@@ -169,7 +169,7 @@ def create_cluster(gke, project, zone, cluster_request):
     cluster_rquest: The request for the cluster.
   """
   request = gke.projects().zones().clusters().create(
-      body=cluster_request, projectId=project, zone=zone)
+    body=cluster_request, projectId=project, zone=zone)
 
   try:
     logging.info("Creating cluster; project=%s, zone=%s, name=%s", project,
@@ -200,7 +200,7 @@ def delete_cluster(gke, name, project, zone):
   """
 
   request = gke.projects().zones().clusters().delete(
-      clusterId=name, projectId=project, zone=zone)
+    clusterId=name, projectId=project, zone=zone)
 
   try:
     response = request.execute()
@@ -241,10 +241,10 @@ def wait_for_operation(client,
   while True:
     if zone:
       op = client.projects().zones().operations().get(
-          projectId=project, zone=zone, operationId=op_id).execute()
+        projectId=project, zone=zone, operationId=op_id).execute()
     else:
       op = client.globalOperations().get(
-          project=project, operation=op_id).execute()
+        project=project, operation=op_id).execute()
 
     status = op.get("status", "")
     # Need to handle other status's
@@ -252,7 +252,7 @@ def wait_for_operation(client,
       return op
     if datetime.datetime.now() > endtime:
       raise TimeoutError(
-          "Timed out waiting for op: {0} to complete.".format(op_id))
+        "Timed out waiting for op: {0} to complete.".format(op_id))
     time.sleep(polling_interval.total_seconds())
 
   # Linter complains if we don't have a return here even though its unreachable.
@@ -262,8 +262,8 @@ def wait_for_operation(client,
 def configure_kubectl(project, zone, cluster_name):
   logging.info("Configuring kubectl")
   run([
-      "gcloud", "--project=" + project, "container", "clusters", "--zone=" + zone,
-      "get-credentials", cluster_name
+    "gcloud", "--project=" + project, "container", "clusters", "--zone=" + zone,
+    "get-credentials", cluster_name
   ])
 
 
@@ -297,8 +297,8 @@ def wait_for_deployment(api_client, namespace, name):
   logging.error("Timeout waiting for deployment %s in namespace %s to be "
                 "ready", name, namespace)
   raise TimeoutError(
-      "Timeout waiting for deployment {0} in namespace {1}".format(
-          name, namespace))
+    "Timeout waiting for deployment {0} in namespace {1}".format(
+      name, namespace))
 
 
 def wait_for_statefulset(api_client, namespace, name):
@@ -331,8 +331,8 @@ def wait_for_statefulset(api_client, namespace, name):
   logging.error("Timeout waiting for statefulset %s in namespace %s to be "
                 "ready", name, namespace)
   raise TimeoutError(
-      "Timeout waiting for statefulset {0} in namespace {1}".format(
-          name, namespace))
+    "Timeout waiting for statefulset {0} in namespace {1}".format(
+      name, namespace))
 
 
 def install_gpu_drivers(api_client):
@@ -472,7 +472,7 @@ def split_gcs_uri(gcs_uri):
 def _refresh_credentials():
   # userinfo.email scope was insufficient for authorizing requests to K8s.
   credentials, _ = google.auth.default(
-      scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    scopes=["https://www.googleapis.com/auth/cloud-platform"])
   request = google.auth.transport.requests.Request()
   credentials.refresh(request)
   return credentials
@@ -516,11 +516,11 @@ def load_kube_config(config_file=None,
     config_persister = _save_kube_config
 
   loader = kube_config._get_kube_config_loader_for_yaml_file(  # pylint: disable=protected-access
-      config_file,
-      active_context=context,
-      config_persister=config_persister,
-      get_google_credentials=get_google_credentials,
-      **kwargs)
+    config_file,
+    active_context=context,
+    config_persister=config_persister,
+    get_google_credentials=get_google_credentials,
+    **kwargs)
 
   if client_configuration is None:
     config = type.__call__(kubernetes_configuration.Configuration)
@@ -535,6 +535,6 @@ def maybe_activate_service_account():
     logging.info("GOOGLE_APPLICATION_CREDENTIALS is set; configuring gcloud "
                  "to use service account.")
     run([
-        "gcloud", "auth", "activate-service-account",
-        "--key-file=" + os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+      "gcloud", "auth", "activate-service-account",
+      "--key-file=" + os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
     ])

--- a/py/util.py
+++ b/py/util.py
@@ -28,6 +28,7 @@ from kubernetes.client import rest
 MASTER_REPO_OWNER = os.getenv("REPO_OWNER", "kubeflow")
 MASTER_REPO_NAME = os.getenv("REPO_NAME", "tf-operator")
 
+
 # TODO(jlewi): Should we stream the output by polling the subprocess?
 # look at run_and_stream in build_and_push.
 #
@@ -62,16 +63,15 @@ def run(command, cwd=None, env=None, dryrun=False):
     # We do this because if just inherit the handles from the parent the
     # subprocess output doesn't show up in Airflow. This might be because
     # we had multiple levels of processes invoking python processes.
-    with tempfile.NamedTemporaryFile(prefix="tmpRunLogs", delete=False,
-                                     mode="w") as hf:
+    with tempfile.NamedTemporaryFile(
+            prefix="tmpRunLogs", delete=False, mode="w") as hf:
       log_file = hf.name
-      subprocess.check_call(command, cwd=cwd, env=env,
-                            stdout=hf,
-                            stderr=hf)
+      subprocess.check_call(command, cwd=cwd, env=env, stdout=hf, stderr=hf)
   finally:
     with open(log_file, "r") as hf:
       output = hf.read()
     logging.info("Subprocess output:\n%s", output)
+
 
 def run_and_output(command, cwd=None, env=None):
   logging.info("Running: %s \ncwd=%s", " ".join(command), cwd)
@@ -81,8 +81,8 @@ def run_and_output(command, cwd=None, env=None):
   # The output won't be available until the command completes.
   # So prefer using run if we don't need to return the output.
   try:
-    output = subprocess.check_output(command, cwd=cwd, env=env,
-                                     stderr=subprocess.STDOUT).decode("utf-8")
+    output = subprocess.check_output(
+        command, cwd=cwd, env=env, stderr=subprocess.STDOUT).decode("utf-8")
     logging.info("Subprocess output:\n%s", output)
   except subprocess.CalledProcessError as e:
     logging.info("Subprocess output:\n%s", e.output)
@@ -90,8 +90,11 @@ def run_and_output(command, cwd=None, env=None):
   return output
 
 
-def clone_repo(dest, repo_owner=MASTER_REPO_OWNER, repo_name=MASTER_REPO_NAME,
-               sha=None, branches=None):
+def clone_repo(dest,
+               repo_owner=MASTER_REPO_OWNER,
+               repo_name=MASTER_REPO_NAME,
+               sha=None,
+               branches=None):
   """Clone the repo,
 
   Args:
@@ -117,11 +120,22 @@ def clone_repo(dest, repo_owner=MASTER_REPO_OWNER, repo_name=MASTER_REPO_NAME,
 
   if branches:
     for b in branches:
-      run(["git", "fetch", "origin", b,], cwd=dest)
+      run(
+          [
+              "git",
+              "fetch",
+              "origin",
+              b,
+          ], cwd=dest)
 
     if not sha:
       b = branches[-1].split(":", 1)[-1]
-      run(["git", "checkout", b,], cwd=dest)
+      run(
+          [
+              "git",
+              "checkout",
+              b,
+          ], cwd=dest)
 
   if sha:
     run(["git", "checkout", sha], cwd=dest)
@@ -133,10 +147,12 @@ def clone_repo(dest, repo_owner=MASTER_REPO_OWNER, repo_name=MASTER_REPO_NAME,
 
   return dest, sha
 
+
 def install_go_deps(src_dir):
   """Run glide to install dependencies."""
   # Install dependencies
   run(["glide", "install", "--strip-vendor"], cwd=src_dir)
+
 
 def to_gcs_uri(bucket, path):
   """Convert bucket and path to a GCS URI."""
@@ -152,9 +168,8 @@ def create_cluster(gke, project, zone, cluster_request):
     zone: The zone to create the cluster in.
     cluster_rquest: The request for the cluster.
   """
-  request = gke.projects().zones().clusters().create(body=cluster_request,
-                                                     projectId=project,
-                                                     zone=zone)
+  request = gke.projects().zones().clusters().create(
+      body=cluster_request, projectId=project, zone=zone)
 
   try:
     logging.info("Creating cluster; project=%s, zone=%s, name=%s", project,
@@ -165,13 +180,14 @@ def create_cluster(gke, project, zone, cluster_request):
     logging.info("Cluster creation done.\n %s", create_op)
 
   except errors.HttpError as e:
-    logging.error("Exception occured creating cluster: %s, status: %s",
-                  e, e.resp["status"])
+    logging.error("Exception occured creating cluster: %s, status: %s", e,
+                  e.resp["status"])
     # Status appears to be a string.
     if e.resp["status"] == '409':
       pass
     else:
       raise
+
 
 def delete_cluster(gke, name, project, zone):
   """Delete the cluster.
@@ -183,9 +199,8 @@ def delete_cluster(gke, name, project, zone):
     zone: Zone where the cluster is running.
   """
 
-  request = gke.projects().zones().clusters().delete(clusterId=name,
-                                                     projectId=project,
-                                                     zone=zone)
+  request = gke.projects().zones().clusters().delete(
+      clusterId=name, projectId=project, zone=zone)
 
   try:
     response = request.execute()
@@ -194,8 +209,9 @@ def delete_cluster(gke, name, project, zone):
     logging.info("Cluster deletion done.\n %s", delete_op)
 
   except errors.HttpError as e:
-    logging.error("Exception occured deleting cluster: %s, status: %s",
-                  e, e.resp["status"])
+    logging.error("Exception occured deleting cluster: %s, status: %s", e,
+                  e.resp["status"])
+
 
 def wait_for_operation(client,
                        project,
@@ -225,28 +241,31 @@ def wait_for_operation(client,
   while True:
     if zone:
       op = client.projects().zones().operations().get(
-        projectId=project, zone=zone,
-          operationId=op_id).execute()
+          projectId=project, zone=zone, operationId=op_id).execute()
     else:
-      op = client.globalOperations().get(project=project,
-                                         operation=op_id).execute()
+      op = client.globalOperations().get(
+          project=project, operation=op_id).execute()
 
     status = op.get("status", "")
     # Need to handle other status's
     if status == "DONE":
       return op
     if datetime.datetime.now() > endtime:
-      raise TimeoutError("Timed out waiting for op: {0} to complete.".format(
-        op_id))
+      raise TimeoutError(
+          "Timed out waiting for op: {0} to complete.".format(op_id))
     time.sleep(polling_interval.total_seconds())
 
   # Linter complains if we don't have a return here even though its unreachable.
   return None
 
+
 def configure_kubectl(project, zone, cluster_name):
   logging.info("Configuring kubectl")
-  run(["gcloud", "--project=" + project, "container",
-       "clusters", "--zone=" + zone, "get-credentials", cluster_name])
+  run([
+      "gcloud", "--project=" + project, "container", "clusters", "--zone=" + zone,
+      "get-credentials", cluster_name
+  ])
+
 
 def wait_for_deployment(api_client, namespace, name):
   """Wait for deployment to be ready.
@@ -279,7 +298,8 @@ def wait_for_deployment(api_client, namespace, name):
                 "ready", name, namespace)
   raise TimeoutError(
       "Timeout waiting for deployment {0} in namespace {1}".format(
-      name, namespace))
+          name, namespace))
+
 
 def wait_for_statefulset(api_client, namespace, name):
   """Wait for deployment to be ready.
@@ -312,7 +332,8 @@ def wait_for_statefulset(api_client, namespace, name):
                 "ready", name, namespace)
   raise TimeoutError(
       "Timeout waiting for statefulset {0} in namespace {1}".format(
-      name, namespace))
+          name, namespace))
+
 
 def install_gpu_drivers(api_client):
   """Install GPU drivers on the cluster.
@@ -339,6 +360,7 @@ def install_gpu_drivers(api_client):
     else:
       raise
 
+
 def wait_for_gpu_driver_install(api_client,
                                 timeout=datetime.timedelta(minutes=10)):
   """Wait until some nodes are available with GPUs."""
@@ -356,6 +378,7 @@ def wait_for_gpu_driver_install(api_client,
   logging.error("Timeout waiting for GPU nodes to be ready.")
   raise TimeoutError("Timeout waiting for GPU nodes to be ready.")
 
+
 def cluster_has_gpu_nodes(api_client):
   """Return true if the cluster has nodes with GPUs."""
   api = k8s_client.CoreV1Api(api_client)
@@ -365,6 +388,7 @@ def cluster_has_gpu_nodes(api_client):
     if "cloud.google.com/gke-accelerator" in n.metadata.labels:
       return True
   return False
+
 
 def create_tiller_service_accounts(api_client):
   logging.info("Creating service account for tiller.")
@@ -403,6 +427,7 @@ subjects:
     else:
       raise
 
+
 def setup_cluster(api_client):
   """Setup a cluster.
 
@@ -426,10 +451,13 @@ def setup_cluster(api_client):
   if use_gpus:
     wait_for_gpu_driver_install(api_client)
 
+
 class TimeoutError(Exception):
   """An error indicating an operation timed out."""
 
+
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
+
 
 def split_gcs_uri(gcs_uri):
   """Split a GCS URI into bucket and path."""
@@ -440,13 +468,15 @@ def split_gcs_uri(gcs_uri):
     path = m.group(2).lstrip("/")
   return bucket, path
 
+
 def _refresh_credentials():
   # userinfo.email scope was insufficient for authorizing requests to K8s.
   credentials, _ = google.auth.default(
-    scopes=["https://www.googleapis.com/auth/cloud-platform"])
+      scopes=["https://www.googleapis.com/auth/cloud-platform"])
   request = google.auth.transport.requests.Request()
   credentials.refresh(request)
   return credentials
+
 
 # TODO(jlewi): This is a work around for
 # https://github.com/kubernetes-incubator/client-python/issues/339.
@@ -455,7 +485,8 @@ def _refresh_credentials():
 # This function is based on
 # https://github.com/kubernetes-client/python-base/blob/master/config/kube_config.py#L331
 # we modify it though so that we can pass through the function to get credentials.
-def load_kube_config(config_file=None, context=None,
+def load_kube_config(config_file=None,
+                     context=None,
                      client_configuration=None,
                      persist_config=True,
                      get_google_credentials=_refresh_credentials,
@@ -477,16 +508,19 @@ def load_kube_config(config_file=None, context=None,
 
   config_persister = None
   if persist_config:
+
     def _save_kube_config(config_map):
       with open(config_file, 'w') as f:
         yaml.safe_dump(config_map, f, default_flow_style=False)
+
     config_persister = _save_kube_config
 
   loader = kube_config._get_kube_config_loader_for_yaml_file(  # pylint: disable=protected-access
-    config_file, active_context=context,
-    config_persister=config_persister,
-    get_google_credentials=get_google_credentials,
-    **kwargs)
+      config_file,
+      active_context=context,
+      config_persister=config_persister,
+      get_google_credentials=get_google_credentials,
+      **kwargs)
 
   if client_configuration is None:
     config = type.__call__(kubernetes_configuration.Configuration)
@@ -495,9 +529,12 @@ def load_kube_config(config_file=None, context=None,
   else:
     loader.load_and_set(client_configuration)
 
+
 def maybe_activate_service_account():
   if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
     logging.info("GOOGLE_APPLICATION_CREDENTIALS is set; configuring gcloud "
-                     "to use service account.")
-    run(["gcloud", "auth", "activate-service-account",
-         "--key-file=" + os.getenv("GOOGLE_APPLICATION_CREDENTIALS")])
+                 "to use service account.")
+    run([
+        "gcloud", "auth", "activate-service-account",
+        "--key-file=" + os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    ])

--- a/py/util_test.py
+++ b/py/util_test.py
@@ -7,7 +7,9 @@ import mock
 
 from py import util
 
+
 class UtilTest(unittest.TestCase):
+
   def test_wait_for_deployment(self):
     api_client = mock.MagicMock(spec=k8s_client.ApiClient)
 
@@ -15,16 +17,19 @@ class UtilTest(unittest.TestCase):
     response.status = k8s_client.ExtensionsV1beta1DeploymentStatus()
     response.status.ready_replicas = 1
     api_client.call_api.return_value = response
-    result = util.wait_for_deployment(api_client, "some-namespace", "some-deployment")
+    result = util.wait_for_deployment(api_client, "some-namespace",
+                                      "some-deployment")
     self.assertIsNotNone(result)
 
   def test_wait_for_statefulset(self):
     api_client = mock.MagicMock(spec=k8s_client.ApiClient)
 
     response = k8s_client.V1beta1StatefulSet()
-    response.status = k8s_client.V1beta1StatefulSetStatus(ready_replicas=1, replicas=1)
+    response.status = k8s_client.V1beta1StatefulSetStatus(
+        ready_replicas=1, replicas=1)
     api_client.call_api.return_value = response
-    result = util.wait_for_statefulset(api_client, "some-namespace", "some-set")
+    result = util.wait_for_statefulset(
+        api_client, "some-namespace", "some-set")
     self.assertIsNotNone(result)
 
   def testSplitGcsUri(self):
@@ -35,6 +40,7 @@ class UtilTest(unittest.TestCase):
     bucket, path = util.split_gcs_uri("gs://some-bucket")
     self.assertEquals("some-bucket", bucket)
     self.assertEquals("", path)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/util_test.py
+++ b/py/util_test.py
@@ -7,7 +7,9 @@ import mock
 
 from py import util
 
+
 class UtilTest(unittest.TestCase):
+
   def test_wait_for_deployment(self):
     api_client = mock.MagicMock(spec=k8s_client.ApiClient)
 
@@ -15,14 +17,16 @@ class UtilTest(unittest.TestCase):
     response.status = k8s_client.ExtensionsV1beta1DeploymentStatus()
     response.status.ready_replicas = 1
     api_client.call_api.return_value = response
-    result = util.wait_for_deployment(api_client, "some-namespace", "some-deployment")
+    result = util.wait_for_deployment(api_client, "some-namespace",
+                                      "some-deployment")
     self.assertIsNotNone(result)
 
   def test_wait_for_statefulset(self):
     api_client = mock.MagicMock(spec=k8s_client.ApiClient)
 
     response = k8s_client.V1beta1StatefulSet()
-    response.status = k8s_client.V1beta1StatefulSetStatus(ready_replicas=1, replicas=1)
+    response.status = k8s_client.V1beta1StatefulSetStatus(
+      ready_replicas=1, replicas=1)
     api_client.call_api.return_value = response
     result = util.wait_for_statefulset(api_client, "some-namespace", "some-set")
     self.assertIsNotNone(result)
@@ -35,6 +39,7 @@ class UtilTest(unittest.TestCase):
     bucket, path = util.split_gcs_uri("gs://some-bucket")
     self.assertEqual("some-bucket", bucket)
     self.assertEqual("", path)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/util_test.py
+++ b/py/util_test.py
@@ -26,10 +26,9 @@ class UtilTest(unittest.TestCase):
 
     response = k8s_client.V1beta1StatefulSet()
     response.status = k8s_client.V1beta1StatefulSetStatus(
-        ready_replicas=1, replicas=1)
+      ready_replicas=1, replicas=1)
     api_client.call_api.return_value = response
-    result = util.wait_for_statefulset(
-        api_client, "some-namespace", "some-set")
+    result = util.wait_for_statefulset(api_client, "some-namespace", "some-set")
     self.assertIsNotNone(result)
 
   def testSplitGcsUri(self):


### PR DESCRIPTION
to enforce more consistent code style.

python code changes are all automated by the tool.

I think yapf is better because it is more aggressive with a reasonable default. Ideally I've imagined something opinionated such as https://prettier.io/, and having such a tool means that the code format can only be in one shape. YMMV.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/401)
<!-- Reviewable:end -->
