### PR TITLE
Support custom labels for each replica

### DIFF
--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -31,8 +31,6 @@ const (
 	Replicas = 1
 )
 
-type KubernetesLabels map[string]string
-
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -104,7 +102,7 @@ type TFReplicaSpec struct {
 	// TFPort is the port to use for TF services.
 	TFPort        *int32 `json:"tfPort,omitempty" protobuf:"varint,1,opt,name=tfPort"`
 	TFReplicaType `json:"tfReplicaType"`
-	TFExtraLabels []*KubernetesLabels `json:"tfExtraLabels,omitempty" protobuf:"varint,4,opt,name=tfExtraLabels"`
+	TFExtraLabels []*map[string]string `json:"tfExtraLabels,omitempty" protobuf:"varint,4,opt,name=tfExtraLabels"`
 }
 
 type TensorBoardSpec struct {

--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -31,6 +31,8 @@ const (
 	Replicas = 1
 )
 
+type KubernetesLabels map[string]string
+
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -102,6 +104,7 @@ type TFReplicaSpec struct {
 	// TFPort is the port to use for TF services.
 	TFPort        *int32 `json:"tfPort,omitempty" protobuf:"varint,1,opt,name=tfPort"`
 	TFReplicaType `json:"tfReplicaType"`
+	TFExtraLabels []*KubernetesLabels `json:"tfExtraLabels,omitempty" protobuf:"varint,4,opt,name=tfExtraLabels"`
 }
 
 type TensorBoardSpec struct {

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -69,6 +69,11 @@ func ValidateTFJobSpec(c *tfv1.TFJobSpec) error {
 		if !found {
 			return fmt.Errorf("Replica type %v is missing a container named %v", r.TFReplicaType, tfv1.TENSORFLOW)
 		}
+
+		extraLabelSize := len(r.TFExtraLabels)
+		if extraLabelSize != 0 && int32(extraLabelSize) != *r.Replicas {
+			return fmt.Errorf("Expect tfReplicaSpec.tfExtraLabels size is 0 or equal to tfReplicaSpec.replicas but tfReplicaSpec.tfExtraLabels is %v", extraLabelSize)
+		}
 	}
 
 	if !chiefExists {

--- a/pkg/apis/tensorflow/validation/validation_test.go
+++ b/pkg/apis/tensorflow/validation/validation_test.go
@@ -99,6 +99,63 @@ func TestValidate(t *testing.T) {
 			},
 			expectingError: false,
 		},
+		{
+			in: &tfv1.TFJobSpec{
+				ReplicaSpecs: []*tfv1.TFReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TFReplicaType: tfv1.WORKER,
+						Replicas:      proto.Int32(2),
+						TFExtraLabels: []*map[string]string{0: {"label1": "value1"}},
+					},
+				},
+				TFImage: "tensorflow/tensorflow:1.3.0",
+				TerminationPolicy: &tfv1.TerminationPolicySpec{
+					Chief: &tfv1.ChiefSpec{
+						ReplicaName:  "WORKER",
+						ReplicaIndex: 0,
+					},
+				},
+			},
+			// Expect ReplicaSpecs.TFExtraLabels equal to 0 or ReplicaSpecs.Replicas
+			expectingError: true,
+		},
+		{
+			in: &tfv1.TFJobSpec{
+				ReplicaSpecs: []*tfv1.TFReplicaSpec{
+					{
+						Template: &v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "tensorflow",
+									},
+								},
+							},
+						},
+						TFReplicaType: tfv1.WORKER,
+						Replicas:      proto.Int32(2),
+						TFExtraLabels: []*map[string]string{0: {"label1": "value1"}, 1: {"label2": "value2"}},
+					},
+				},
+				TFImage: "tensorflow/tensorflow:1.3.0",
+				TerminationPolicy: &tfv1.TerminationPolicySpec{
+					Chief: &tfv1.ChiefSpec{
+						ReplicaName:  "WORKER",
+						ReplicaIndex: 0,
+					},
+				},
+			},
+			expectingError: false,
+		},
 	}
 
 	for _, c := range testCases {

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -122,6 +122,12 @@ func (s *TFReplicaSet) Create(config *tfv1alpha1.ControllerConfig) error {
 		taskLabels := s.Labels()
 		taskLabels["task_index"] = fmt.Sprintf("%v", index)
 
+		if len(s.Spec.TFExtraLabels) > 0 {
+			for key, value := range *s.Spec.TFExtraLabels[index] {
+				taskLabels[key] = value
+			}
+		}
+
 		// Create the service.
 		service := &v1.Service{
 			ObjectMeta: meta_v1.ObjectMeta{


### PR DESCRIPTION
User can specify labels to each replica by set replicaSpec[i].tfExtraLabels.
Labels size must equal to replica size, or failed at validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/413)
<!-- Reviewable:end -->
