### PR TITLE
Create resources (Services/Jobs) only once

### DIFF
--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -115,17 +115,6 @@ func (s *TFReplicaSet) Labels() KubernetesLabels {
 		"tf_job_name": s.Job.job.ObjectMeta.Name})
 }
 
-func (s *TFReplicaSet) Create(config *tfv1alpha1.ControllerConfig) error {
-	// Create services
-	err := s.SyncServices()
-	if err != nil {
-		return err
-	}
-
-	// Create pods
-	return s.SyncPods()
-}
-
 // CreateServiceWithIndex will create a new service with specify index
 func (s *TFReplicaSet) CreateServiceWithIndex(index int32) (*v1.Service, error) {
 	taskLabels := s.Labels()

--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -87,8 +87,12 @@ func TestTFReplicaSet(t *testing.T) {
 		t.Fatalf("NewTFReplicaSet failed: %v", err)
 	}
 
-	if err := replica.Create(&tfv1alpha1.ControllerConfig{}); err != nil {
-		t.Fatalf("replica.Create() error; %v", err)
+	if err := replica.SyncPods(); err != nil {
+		t.Fatalf("replica.SyncPods() error; %v", err)
+	}
+
+	if err := replica.SyncServices(); err != nil {
+		t.Fatalf("replica.SyncServices() error; %v", err)
 	}
 
 	trueVal := true

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -107,17 +107,6 @@ func (j *TrainingJob) ClusterSpec() ClusterSpec {
 	return clusterSpec
 }
 
-// createResources creates all the replicas if requested
-func (j *TrainingJob) createResources(config *tfv1alpha1.ControllerConfig) error {
-	for _, r := range j.Replicas {
-		if err := r.Create(config); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // deleteResources deletes the replicas it it was created
 func (j *TrainingJob) deleteResources() error {
 	for _, r := range j.Replicas {
@@ -248,7 +237,6 @@ func (j *TrainingJob) setup(config *tfv1alpha1.ControllerConfig) {
 
 // setup Replicas. This creates in memory data structures corresponding to the replicas.
 func (j *TrainingJob) setupReplicas() error {
-
 	if len(j.Replicas) != len(j.job.Spec.ReplicaSpecs) {
 		j.Replicas = make([]*TFReplicaSet, 0, len(j.job.Spec.ReplicaSpecs))
 		for _, t := range j.job.Spec.ReplicaSpecs {
@@ -325,43 +313,6 @@ func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig) error {
 		return err
 	}
 
-	// TODO(jlewi): Can we determine from the CRD status whether we should
-	// Create the resources or not? We need to ensure the resources exist so for
-	// now we always call Create.
-	if j.job.Status.Phase == tfv1alpha1.TFJobPhaseCreating || j.job.Status.Phase == tfv1alpha1.TFJobPhaseRunning {
-		// We call Create to make sure all the resources exist and are running.
-		if cErr := j.createResources(config); cErr != nil {
-			// TODO(jlewi): Should we eventually give up and mark the job as failed if we can't create the resources?
-			j.status.Reason = fmt.Sprintf("Could not create job resources; %v", cErr)
-			if err := j.updateCRDStatus(); err != nil {
-				log.Warningf("Job %v; failed to update status error: %v", j.job.ObjectMeta.Name, err)
-				return err
-			}
-			log.Errorf("trainingJobCreateReplicas() error; %v", cErr)
-			return cErr
-		}
-
-		state, replicaStatuses, err := j.GetStatus()
-
-		j.status.ReplicaStatuses = replicaStatuses
-		if err != nil {
-			log.Errorf("GetStatus() for job %v returned error: %v", j.job.ObjectMeta.Name, err)
-			return err
-		}
-		// TODO(jlewi): We should update the Phase if we detect the job is done.
-		if state == tfv1alpha1.StateFailed {
-			log.Errorf("Master failed Job: %v.", j.job.ObjectMeta.Name)
-			j.status.Phase = tfv1alpha1.TFJobPhaseDone
-			j.status.State = tfv1alpha1.StateFailed
-		} else if state == tfv1alpha1.StateSucceeded {
-			log.Infof("Master succeeded Job: %v.", j.job.ObjectMeta.Name)
-			j.status.Phase = tfv1alpha1.TFJobPhaseDone
-			j.status.State = tfv1alpha1.StateSucceeded
-		} else {
-			log.Infof("Job %v status=%v", j.job.ObjectMeta.Name, util.Pformat(j.status))
-		}
-	}
-
 	// sync pods
 	for _, rc := range j.Replicas {
 		err := rc.SyncPods()
@@ -376,6 +327,37 @@ func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig) error {
 		if err != nil {
 			log.Errorf("SyncServices error: %v", err)
 		}
+	}
+
+	if err := j.updateCRDStatus(); err != nil {
+		log.Warningf("Job %v; failed to update status error: %v", j.job.ObjectMeta.Name, err)
+		return err
+	}
+
+	// Call GetStatus in each reconcile loop
+	state, replicaStatuses, err := j.GetStatus()
+
+	j.status.ReplicaStatuses = replicaStatuses
+	if err != nil {
+		log.Errorf("GetStatus() for job %v returned error: %v", j.job.ObjectMeta.Name, err)
+		return err
+	}
+
+	// TODO(jlewi): We should update the Phase if we detect the job is done.
+	if state == tfv1alpha1.StateFailed {
+		log.Errorf("Master failed Job: %v.", j.job.ObjectMeta.Name)
+		j.status.Phase = tfv1alpha1.TFJobPhaseDone
+		j.status.State = tfv1alpha1.StateFailed
+	} else if state == tfv1alpha1.StateSucceeded {
+		log.Infof("Master succeeded Job: %v.", j.job.ObjectMeta.Name)
+		j.status.Phase = tfv1alpha1.TFJobPhaseDone
+		j.status.State = tfv1alpha1.StateSucceeded
+	} else if state == tfv1alpha1.StateRunning {
+		log.Infof("Master running Job: %v.", j.job.ObjectMeta.Name)
+		j.status.Phase = tfv1alpha1.TFJobPhaseRunning
+		j.status.State = tfv1alpha1.StateRunning
+	} else {
+		log.Infof("Job %v status=%v", j.job.ObjectMeta.Name, util.Pformat(j.status))
 	}
 
 	// If the phase changed we should update the CRD.


### PR DESCRIPTION
Hi, this PR update a little in `Reconcile()` loop:
  - Move the `GetStatus()` logic out of `Creation` block.
    - Call `GetStatus()` in each reconcile loop to make it more robust.
  - set `TFJob.Status.Phase` to `TFJobPhaseRunning` to keep creating resources (services/jobs) only once.

@jlewi @gaocegege @wackxu PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/418)
<!-- Reviewable:end -->
