### PR TITLE
Fix setup_cluster.

### DIFF
--- a/py/deploy.py
+++ b/py/deploy.py
@@ -57,13 +57,13 @@ def ks_deploy(app_dir, component, params, env=None, account=None):
     env: (Optional) The environment to use, if none is specified a new one
       is created.
     account: (Optional) The account to use.
-    
+
   Raises:
     ValueError: If input arguments aren't valid.
   """
   if not component:
     raise ValueError("component can't be None.")
-    
+
   # TODO(jlewi): It might be better if the test creates the app and uses
   # the latest stable release of the ksonnet configs. That however will cause
   # problems when we make changes to the TFJob operator that require changes
@@ -112,8 +112,6 @@ def setup(args):
           "https://www.googleapis.com/auth/cloud-platform",
         ],
       },
-      # TODO(jlewi): Stop pinning GKE version once 1.8 becomes the default.
-      "initialClusterVersion": "1.8.5-gke.0",
     }
   }
 

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -14,10 +14,10 @@ class ReleaseTest(unittest.TestCase):
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_postsubmit(
+  def test_build_postsubmit(  # pylint: disable=no-self-use
       self,
       mock_build_and_push,
-      mock_clone,  # pylint: disable=no-self-use
+      mock_clone,
       _mock_install,
       _mock_os,
       _mock_makedirs):
@@ -40,8 +40,8 @@ class ReleaseTest(unittest.TestCase):
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install,
-                    _mock_os, _mock_makedirs):  # pylint: disable=no-self-use
+  def test_build_pr(self, mock_build_and_push, mock_clone, _mock_install,  # pylint: disable=no-self-use
+                    _mock_os, _mock_makedirs):
     parser = release.build_parser()
     args = parser.parse_args(
       ["pr", "--pr=10", "--commit=22", "--src_dir=/top/src_dir"])


### PR DESCRIPTION
* We need to stop pinning GKE version to 1.8.5 because that is no longer
  a valid version.

* We should no longer need to pin because 1.8 is now the default.

* Fix some lint issues that seem to have crept in.

Fix #240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/421)
<!-- Reviewable:end -->
