### PR TITLE
Remove unreachable code

### DIFF
--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -211,12 +211,6 @@ func (j *TrainingJob) masterName() string {
 
 // setup the training job.
 func (j *TrainingJob) setup(config *tfv1alpha1.ControllerConfig) {
-	if j.job == nil {
-		j.status.Reason = "Internal error; setup failed; job is missing spec."
-		j.status.Phase = tfv1alpha1.TFJobPhaseFailed
-		j.status.State = tfv1alpha1.StateFailed
-	}
-
 	err := func() error {
 		// If the job has already started we shouldn't set it up again.
 		if j.status.Phase != tfv1alpha1.TFJobPhaseNone {


### PR DESCRIPTION
As we have checked `j.job.Status.Phase` [here](https://github.com/kubeflow/tf-operator/blob/master/pkg/trainer/training.go#L312) before calling setup(), these codes can never be reached.

@gaocegege @jlewi PTAL, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/434)
<!-- Reviewable:end -->
