### PR TITLE
Create PDB of TFReplicaSet for gang scheduling by kube-arbitrator

### DIFF
--- a/cmd/tf-operator/app/options/options.go
+++ b/cmd/tf-operator/app/options/options.go
@@ -26,6 +26,7 @@ type ServerOption struct {
 	PrintVersion         bool
 	GCInterval           time.Duration
 	JsonLogFormat        bool
+	EnableGangScheduling bool
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -42,4 +43,5 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&s.GCInterval, "gc-interval", 10*time.Minute, "GC interval")
 	fs.StringVar(&s.ControllerConfigFile, "controller-config-file", "", "Path to file containing the controller config.")
 	fs.BoolVar(&s.JsonLogFormat, "json-log-format", true, "Set true to use json style log format. Set false to use plaintext style log format")
+	fs.BoolVar(&s.EnableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling by kube-arbitrator.")
 }

--- a/cmd/tf-operator/app/server.go
+++ b/cmd/tf-operator/app/server.go
@@ -79,7 +79,7 @@ func Run(opt *options.ServerOption) error {
 	defer close(neverStop)
 
 	tfJobInformerFactory := informers.NewSharedInformerFactory(tfJobClient, time.Second*30)
-	controller, err := controller.New(kubeClient, tfJobClient, *controllerConfig, tfJobInformerFactory)
+	controller, err := controller.New(kubeClient, tfJobClient, *controllerConfig, tfJobInformerFactory, opt.EnableGangScheduling)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
kube-arbitrator (technically its component kube-batchd) requires PDB
for its gang scheduling feature. The feature is useful for creating
every pod of TFJob at the same time. This commit lets tf-operator
create the PDB for the purpose.

The change isn't tested yet for now (I will be able to test it with a working k8s cluster probably next week...). I'm glad if I can have feedback about the design, especially the usage of kube-arbitrator.

/cc @jlewi @gaocegege @ScorpioCPH @k82cn @jinzhejz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/452)
<!-- Reviewable:end -->
