### PR TITLE
travis: Ignore generated code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,6 @@ script:
   # directory.
   # With go 1.9 vendor will be automatically excluded.
   # For now though we just run all tests in pkg.
-  - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*,pkg/apis/tensorflow/*/zz_generated.*.go"
+  # And we can not use ** because goveralls uses filepath.Match
+  # to match ignore files and it does not support it.
+  - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*.go,pkg/client/*/*/*.go,pkg/client/*/*/*/*.go,pkg/client/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*/*.go,pkg/apis/tensorflow/*/zz_generated.*.go"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
   # directory.
   # With go 1.9 vendor will be automatically excluded.
   # For now though we just run all tests in pkg.
-  - $GOPATH/bin/goveralls -service=travis-ci -v -package ./pkg/...
+  - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*,pkg/apis/tensorflow/*/zz_generated.*.go"


### PR DESCRIPTION
Now our coverage test includes generated code and this PR is to remove them from the list of coveralls.

Coverage increased (+16.3%) to 44.86% when pulling e97e51a on gaocegege:test-ignore into 423b0d0 on kubeflow:master.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/453)
<!-- Reviewable:end -->
