### PR TITLE
*: Remove APIExtension clientset

### DIFF
--- a/cmd/tf-operator/main.go
+++ b/cmd/tf-operator/main.go
@@ -17,10 +17,11 @@ package main
 import (
 	"flag"
 
-	"github.com/kubeflow/tf-operator/cmd/tf-operator/app"
-	"github.com/kubeflow/tf-operator/cmd/tf-operator/app/options"
 	"github.com/onrik/logrus/filename"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/kubeflow/tf-operator/cmd/tf-operator/app"
+	"github.com/kubeflow/tf-operator/cmd/tf-operator/app/options"
 )
 
 func init() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,7 +22,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -61,9 +60,8 @@ var (
 )
 
 type Controller struct {
-	KubeClient   kubernetes.Interface
-	APIExtclient apiextensionsclient.Interface
-	TFJobClient  tfjobclient.Interface
+	KubeClient  kubernetes.Interface
+	TFJobClient tfjobclient.Interface
 
 	config tfv1alpha1.ControllerConfig
 	jobs   map[string]*trainer.TrainingJob
@@ -85,7 +83,7 @@ type Controller struct {
 	syncHandler func(jobKey string) (bool, error)
 }
 
-func New(kubeClient kubernetes.Interface, APIExtclient apiextensionsclient.Interface, tfJobClient tfjobclient.Interface,
+func New(kubeClient kubernetes.Interface, tfJobClient tfjobclient.Interface,
 	config tfv1alpha1.ControllerConfig, tfJobInformerFactory informers.SharedInformerFactory) (*Controller, error) {
 	tfJobInformer := tfJobInformerFactory.Kubeflow().V1alpha1().TFJobs()
 
@@ -97,11 +95,10 @@ func New(kubeClient kubernetes.Interface, APIExtclient apiextensionsclient.Inter
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
 
 	controller := &Controller{
-		KubeClient:   kubeClient,
-		APIExtclient: APIExtclient,
-		TFJobClient:  tfJobClient,
-		WorkQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "TFjobs"),
-		recorder:     recorder,
+		KubeClient:  kubeClient,
+		TFJobClient: tfJobClient,
+		WorkQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "TFjobs"),
+		recorder:    recorder,
 		// TODO(jlewi)): What to do about cluster.Cluster?
 		jobs:   make(map[string]*trainer.TrainingJob),
 		config: config,

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	log "github.com/sirupsen/logrus"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -45,14 +44,6 @@ func MustNewKubeClient() kubernetes.Interface {
 		log.Fatal(err)
 	}
 	return kubernetes.NewForConfigOrDie(cfg)
-}
-
-func MustNewApiExtensionsClient() apiextensionsclient.Interface {
-	cfg, err := GetClusterConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return apiextensionsclient.NewForConfigOrDie(cfg)
 }
 
 // Obtain the config from the Kube configuration used by kubeconfig, or from k8s cluster.


### PR DESCRIPTION
It seems that the APIExtension client is not used in our code, then we could remove it.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/454)
<!-- Reviewable:end -->
