### PR TITLE
controller: Separate ps and worker pods

### DIFF
--- a/pkg/controller/controller_pod.go
+++ b/pkg/controller/controller_pod.go
@@ -46,17 +46,18 @@ func (tc *TFJobController) reconcilePods(
 
 	// Convert TFReplicaType to lower string.
 	rt := strings.ToLower(string(rtype))
-
-	// Get active pods for this TFReplicaType.
-	activePods := filterActivePodsForTFReplicaType(pods, rt)
-
+	// Get all pods for the type rt.
+	pods = filterPodsForTFReplicaType(pods, rt)
+	activePods := FilterActivePods(pods)
 	succeeded, failed := getPodStatus(pods)
 
-	diff := len(activePods) - int(*(spec.Replicas))
+	// Expect to have `replicas - succeeded` pods alive.
+	expected := *spec.Replicas - succeeded
+	diff := len(activePods) - int(expected)
 
 	if diff < 0 {
 		// Need to create new pods.
-		diffIndexes := getDiffPodIndexes(activePods, *spec.Replicas)
+		diffIndexes := getDiffPodIndexes(activePods, expected)
 		if diff+len(diffIndexes) != 0 {
 			// This should never happened.
 			return fmt.Errorf("pods diff(%d) is not equal to length(%d) of diffIndexes", diff, len(diffIndexes))
@@ -135,7 +136,7 @@ func (tc *TFJobController) reconcilePods(
 	}
 
 	// Update the active status since we have created -diff pods during the loop.
-	tfjob.Status.TFReplicaStatuses[rtype].Active = int32(len(activePods) - diff)
+	tfjob.Status.TFReplicaStatuses[rtype].Active = int32(expected)
 	tfjob.Status.TFReplicaStatuses[rtype].Succeeded = succeeded
 	tfjob.Status.TFReplicaStatuses[rtype].Failed = failed
 
@@ -214,11 +215,8 @@ func (tc *TFJobController) getPodsForTFJob(tfjob *tfv1alpha2.TFJob) ([]*v1.Pod, 
 	return cm.ClaimPods(pods)
 }
 
-// filterActivePodsForTFReplicaType returns pods that have not terminated,
-// and belong to a TFReplicaType.
-func filterActivePodsForTFReplicaType(pods []*v1.Pod, tfReplicaType string) []*v1.Pod {
-	activePods := FilterActivePods(pods)
-
+// filterPodsForTFReplicaType returns pods belong to a TFReplicaType.
+func filterPodsForTFReplicaType(pods []*v1.Pod, tfReplicaType string) []*v1.Pod {
 	var result []*v1.Pod
 
 	tfReplicaSelector := &metav1.LabelSelector{
@@ -227,7 +225,7 @@ func filterActivePodsForTFReplicaType(pods []*v1.Pod, tfReplicaType string) []*v
 
 	tfReplicaSelector.MatchLabels[tfReplicaTypeLabel] = tfReplicaType
 
-	for _, pod := range activePods {
+	for _, pod := range pods {
 		selector, _ := metav1.LabelSelectorAsSelector(tfReplicaSelector)
 		if !selector.Matches(labels.Set(pod.Labels)) {
 			continue

--- a/pkg/controller/controller_pod.go
+++ b/pkg/controller/controller_pod.go
@@ -136,7 +136,7 @@ func (tc *TFJobController) reconcilePods(
 	}
 
 	// Update the active status since we have created -diff pods during the loop.
-	tfjob.Status.TFReplicaStatuses[rtype].Active = int32(expected)
+	tfjob.Status.TFReplicaStatuses[rtype].Active = expected
 	tfjob.Status.TFReplicaStatuses[rtype].Succeeded = succeeded
 	tfjob.Status.TFReplicaStatuses[rtype].Failed = failed
 

--- a/pkg/controller/controller_service.go
+++ b/pkg/controller/controller_service.go
@@ -107,7 +107,7 @@ func (tc *TFJobController) reconcileServices(
 			}
 		}
 	} else if diff > 0 {
-		// TODO(CPH): Need to delete pods.
+		// TODO(CPH): Need to delete service.
 		log.Infof("need to delete service but it is not implemented yet")
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
@@ -303,7 +302,6 @@ func TestNormalPath(t *testing.T) {
 		podIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
 		setPodsStatuses(podIndexer, tfJob, labelWorker, tc.pendingWorkerPods, tc.activeWorkerPods, tc.succeededWorkerPods, tc.failedWorkerPods, t)
 		setPodsStatuses(podIndexer, tfJob, labelPS, tc.pendingPSPods, tc.activePSPods, tc.succeededPSPods, tc.failedPSPods, t)
-		log.Info(podIndexer.List())
 
 		forget, err := controller.syncTFJob(getKey(tfJob, t))
 		// We need requeue syncJob task if podController error

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -167,8 +167,8 @@ func TestNormalPath(t *testing.T) {
 		ps     int
 
 		// pod setup
-		podControllerError error
-		jobKeyForget       bool
+		ControllerError error
+		jobKeyForget    bool
 
 		pendingWorkerPods   int32
 		activeWorkerPods    int32
@@ -305,7 +305,7 @@ func TestNormalPath(t *testing.T) {
 
 		forget, err := controller.syncTFJob(getKey(tfJob, t))
 		// We need requeue syncJob task if podController error
-		if tc.podControllerError != nil {
+		if tc.ControllerError != nil {
 			if err == nil {
 				t.Errorf("%s: Syncing jobs would return error when podController exception", name)
 			}


### PR DESCRIPTION
/assign @ScorpioCPH 

We do not separate the pods of PS and workers in the controller, then it has bugs when the replicas are succeeded.

If the PR LGTM, I will file another PR for service.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/481)
<!-- Reviewable:end -->
