### PR TITLE
Add sleep and random exit image for e2e test

### DIFF
--- a/test/e2e/sleep-and-random-exit/Dockerfile
+++ b/test/e2e/sleep-and-random-exit/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+
+COPY ./sleep_and_random_exit.sh ~/
+
+ENTRYPOINT ["~/sleep_and_random_exit.sh"]

--- a/test/e2e/sleep-and-random-exit/sleep-and-random-exit.sh
+++ b/test/e2e/sleep-and-random-exit/sleep-and-random-exit.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# This script will sleep a random seconds,
+# Then exit a random code
+
+random_sleep=`shuf -i 10-30 -n 1`
+echo "sleep $random_sleep"
+sleep $random_sleep
+
+random_exit=`shuf -i 0-3 -n 1`
+echo "exit $random_exit"
+exit $random_exit


### PR DESCRIPTION
Hi, this PR add an image for e2e test:

- Run a script that sleep a random seconds.
- Then exit a random code:
  - Exit 0 means this pod is `succeeded`.
  - Exit nonzero means this pod is `failed`.

We can use this image to count active/failed/succeeded pods.

@jlewi @gaocegege PTAL, thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/487)
<!-- Reviewable:end -->
