### PR TITLE
Set JSONLogFormat to false by default

### DIFF
--- a/cmd/tf-operator/app/options/options.go
+++ b/cmd/tf-operator/app/options/options.go
@@ -47,6 +47,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 
-	fs.BoolVar(&s.JSONLogFormat, "json-log-format", true,
+	fs.BoolVar(&s.JSONLogFormat, "json-log-format", false,
 		"Set true to use json style log format. Set false to use plaintext style log format")
 }


### PR DESCRIPTION
This PR set JSONLogFormat to false by default for debug.

@gaocegege PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/495)
<!-- Reviewable:end -->
