### PR TITLE
Adds gcloudignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,7 @@
+# This file specifies files that are not uploaded to GCP
+# Uses same syntax as gitignore
+
+.git
+.gitignore
+#!include:.gitignore
+vendor


### PR DESCRIPTION
Motivation for this is to not upload the entire vendor directory (or other potentially unecessary files) when building a container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/510)
<!-- Reviewable:end -->
