### PR TITLE
Fix output on test failure

### DIFF
--- a/pkg/trainer/replicas_test.go
+++ b/pkg/trainer/replicas_test.go
@@ -157,7 +157,7 @@ func TestTFReplicaSet(t *testing.T) {
 		p := l.Items[index]
 
 		if !reflect.DeepEqual(expectedLabels, p.ObjectMeta.Labels) {
-			t.Fatalf("Pod Labels; Got %v Want: %v", expectedLabels, p.ObjectMeta.Labels)
+			t.Fatalf("Pod Labels; Got %v Want: %v", p.ObjectMeta.Labels, expectedLabels)
 		}
 
 		if len(p.Spec.Containers) != 1 {


### PR DESCRIPTION
Just had some minor confusion with this and wanted to prevent for others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/511)
<!-- Reviewable:end -->
