### PR TITLE
Reenable cluster teardown.

### DIFF
--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -218,11 +218,10 @@
             {
               name: "exit-handler",
               steps: [
-                // DO NOT SUBMIT comment out to facilitate debugging.
-                //[{
-                //  name: "teardown-cluster",
-                //  template: "teardown-cluster",
-                //}],
+                [{
+                  name: "teardown-cluster",
+                  template: "teardown-cluster",
+                }],
                 [{
                   name: "copy-artifacts",
                   template: "copy-artifacts",


### PR DESCRIPTION
The code to disable the onExit handler should not have been committed

Fix #560

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/520)
<!-- Reviewable:end -->
