### PR TITLE
fix the bug of keeping creating new pdb

### DIFF
--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -478,7 +478,7 @@ func (j *TrainingJob) syncPdb() error {
 	minAvailable := intstr.FromInt(int(nrReplicas))
 	pdb := &v1beta1.PodDisruptionBudget{
 		ObjectMeta: meta_v1.ObjectMeta{
-			GenerateName: "tf-job-pdb-",
+			Name: "tf-job-pdb-" + j.job.ObjectMeta.Name,
 		},
 		Spec: v1beta1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
@@ -494,7 +494,7 @@ func (j *TrainingJob) syncPdb() error {
 	createdPdb, err := j.KubeCli.PolicyV1beta1().PodDisruptionBudgets(j.job.ObjectMeta.Namespace).Create(pdb)
 	if err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
-			j.contextLogger.Infof("PDB: %v already exists.", j.job.ObjectMeta.Name)
+			j.contextLogger.Infof("PDB: %v already exists.", "tf-job-pdb-" + j.job.ObjectMeta.Name)
 			return nil
 		}
 

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -494,7 +494,7 @@ func (j *TrainingJob) syncPdb() error {
 	createdPdb, err := j.KubeCli.PolicyV1beta1().PodDisruptionBudgets(j.job.ObjectMeta.Namespace).Create(pdb)
 	if err != nil {
 		if k8s_errors.IsAlreadyExists(err) {
-			j.contextLogger.Infof("PDB: %v already exists.", "tf-job-pdb-" + j.job.ObjectMeta.Name)
+			j.contextLogger.Infof("PDB: %v already exists.", "tf-job-pdb-"+j.job.ObjectMeta.Name)
 			return nil
 		}
 


### PR DESCRIPTION
The original code will let the controller keep creating new pdb for the job since the names are not the same. 
They only have the same prefix which is GenerateName: "tf-job-pdb-".

I try to fix it by assigning the name, "tf-job-pdb-" + j.job.ObjectMeta.Name, to the pdb in order to make controller only create pdb once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/539)
<!-- Reviewable:end -->
