### PR TITLE
add OwnerReferences to pdb

### DIFF
--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -503,7 +503,7 @@ func (j *TrainingJob) syncPdb() error {
 			return err
 		}
 
-		j.recorder.Eventf(j.job, v1.EventTypeNormal, SuccessfulCreateReason, "Created PDB: %v", createdPdb.Name)
+		j.recorder.Eventf(j.job, v1.EventTypeNormal, SuccessfulCreateReason, "Created PDB: %v", createdPdb.ObjectMeta.Name)
 	}
 
 	j.pdb = createdPdb

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -503,7 +503,7 @@ func (j *TrainingJob) syncPdb() error {
 			return err
 		}
 
-		j.recorder.Eventf(j.job, v1.EventTypeNormal, SuccessfulCreateReason, "Created PDB: %v", createdPdb.ObjectMeta.Name)
+		j.recorder.Eventf(j.job, v1.EventTypeNormal, SuccessfulCreateReason, "Created PDB: %v", createdPdb.Name)
 	}
 
 	j.pdb = createdPdb

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -458,6 +458,9 @@ func (j *TrainingJob) syncPdb() error {
 	pdb := &v1beta1.PodDisruptionBudget{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: "tf-job-pdb-" + j.job.ObjectMeta.Name,
+			OwnerReferences: []meta_v1.OwnerReference{
+				helper.AsOwner(j.job),
+			},
 		},
 		Spec: v1beta1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -388,6 +388,7 @@ func TestPDBForGangScheduling(t *testing.T) {
 			jobSpec: &tfv1alpha1.TFJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "some-meta-name",
+					UID:  "some-meta-uid",
 				},
 				Spec: tfv1alpha1.TFJobSpec{
 					RuntimeId: "some-runtime-id",

--- a/pkg/trainer/training_test.go
+++ b/pkg/trainer/training_test.go
@@ -388,7 +388,6 @@ func TestPDBForGangScheduling(t *testing.T) {
 			jobSpec: &tfv1alpha1.TFJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "some-meta-name",
-					UID:  "some-meta-uid",
 				},
 				Spec: tfv1alpha1.TFJobSpec{
 					RuntimeId: "some-runtime-id",


### PR DESCRIPTION
Hi, after fixing the name of ObjectMeta of PDB.
I think we could add the OwnerReferences to PDB too.
This enable the Kubernetes GC to automatically delete the PDB  when users delete the tfjob manually.
Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/565)
<!-- Reviewable:end -->
