### PR TITLE
Fix missing string for logging placeholder

### DIFF
--- a/py/release.py
+++ b/py/release.py
@@ -377,7 +377,7 @@ def build_local(args):
   go_src_dir = os.path.join(go_dir, "src", "github.com", REPO_ORG, REPO_NAME)
 
   if not os.path.exists(go_src_dir):
-    logging.info("Directory %s  doesn't exist.")
+    logging.info("Directory %s  doesn't exist.", go_src_dir)
     logging.info("Creating symbolic link %s pointing to %s", go_src_dir,
                  src_dir)
     os.symlink(src_dir, go_src_dir)


### PR DESCRIPTION
In `py/release.py`, an info logging uses a placeholder, but no string matches that.

This PR completes that missing string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/570)
<!-- Reviewable:end -->
