### PR TITLE
replace glide with dep in the developer guide

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -13,12 +13,12 @@ ln -sf ${GIT_TRAINING} ${GOPATH}/src/github.com/kubeflow/tf-operator
 
 * GIT_TRAINING should be the location where you checked out https://github.com/kubeflow/tf-operator
 
-Resolve dependencies (if you don't have glide install, check how to do it [here](https://github.com/Masterminds/glide/blob/master/README.md#install))
+Resolve dependencies (if you don't have dep install, check how to do it [here](https://github.com/golang/dep))
 
-Install dependencies, `-v` will ignore subpackage vendor
+Install dependencies
 
 ```sh
-glide install -v
+dep ensure
 ```
 
 Build it


### PR DESCRIPTION
Since we have changed from glide to dep, we should update the developer guide.
Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/572)
<!-- Reviewable:end -->
