### PR TITLE
controller_service: Headless service

### DIFF
--- a/pkg/controller.v2/controller_helper.go
+++ b/pkg/controller.v2/controller_helper.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +54,10 @@ func genLabels(tfjobKey string) map[string]string {
 func genGeneralName(tfjobKey, rtype, index string) string {
 	n := tfjobKey + "-" + rtype + "-" + index
 	return strings.Replace(n, "/", "-", -1)
+}
+
+func genDNSRecord(tfjobKey, rtype, index, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc.cluster.local", genGeneralName(tfjobKey, rtype, index), namespace)
 }
 
 // convertTFJobToUnstructured uses JSON to convert TFJob to Unstructured.

--- a/pkg/controller.v2/controller_service.go
+++ b/pkg/controller.v2/controller_service.go
@@ -115,7 +115,8 @@ func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rt, index s
 
 	service := &v1.Service{
 		Spec: v1.ServiceSpec{
-			Selector: labels,
+			ClusterIP: "None",
+			Selector:  labels,
 			Ports: []v1.ServicePort{
 				{
 					Name: genGeneralName(tfjobKey, rt, index),

--- a/pkg/controller.v2/controller_tensorflow.go
+++ b/pkg/controller.v2/controller_tensorflow.go
@@ -97,7 +97,7 @@ func genClusterSpec(tfjob *tfv1alpha2.TFJob) ClusterSpec {
 		replicaNames := make([]string, 0, *spec.Replicas)
 
 		for i := int32(0); i < *spec.Replicas; i++ {
-			host := genGeneralName(tfjobKey, rt, fmt.Sprintf("%d", i)) + ":" + defaultPortStr
+			host := genDNSRecord(tfjobKey, rt, fmt.Sprintf("%d", i), tfjob.ObjectMeta.Namespace) + ":" + defaultPortStr
 			replicaNames = append(replicaNames, host)
 		}
 


### PR DESCRIPTION
Close #574 

We use the DNS record instead of service name to do service discovery, and use headless to lower the overhead.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/576)
<!-- Reviewable:end -->
