### PR TITLE
.travis.yml: Add failure notification in GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ script:
   - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*.go,pkg/client/*/*/*.go,pkg/client/*/*/*/*.go,pkg/client/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*/*.go,pkg/apis/tensorflow/*/zz_generated.*.go"
 
 notifications:
-    webhooks: https://www.travisbuddy.com/
-    on_success: never
+  webhooks: https://www.travisbuddy.com/
+  on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ script:
   # And we can not use ** because goveralls uses filepath.Match
   # to match ignore files and it does not support it.
   - goveralls -service=travis-ci -v -package ./pkg/... -ignore "pkg/client/*/*.go,pkg/client/*/*/*.go,pkg/client/*/*/*/*.go,pkg/client/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*.go,pkg/client/*/*/*/*/*/*/*.go,pkg/apis/tensorflow/*/zz_generated.*.go"
+
+notifications:
+    webhooks: https://www.travisbuddy.com/
+    on_success: never


### PR DESCRIPTION
> TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contributors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed. 

It will help us to know the failures of Travis builds in GitHub notification page.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/579)
<!-- Reviewable:end -->
