### PR TITLE
Add a new command-line argument for release.py

### DIFF
--- a/py/release.py
+++ b/py/release.py
@@ -124,12 +124,16 @@ def build_operator_image(root_dir,
                          registry,
                          project=None,
                          should_push=True,
+                         push_with_docker=False,
                          version_tag=None):
   """Build the main docker image for the TFJob CRD.
   Args:
     root_dir: Root directory of the repository.
     registry: The registry to use.
     project: If set it will be built using GCB.
+    should_push: Should push the image to the registry, Defaule is True.
+    push_with_docker: Using docker to push image to the registry instead 
+      of using gcloud, Default is False.
     version_tag: Optional tag for the version. If not specified derive
       the tag from the git hash.
   Returns:
@@ -217,11 +221,19 @@ def build_operator_image(root_dir,
     util.run(["docker", "tag", image, latest_image])
 
     if should_push:
-      util.run(["gcloud", "docker", "--", "push", image])
-      logging.info("Pushed image: %s", image)
+      if push_with_docker:
+        util.run(["docker", "push", image])
+        logging.info("Pushed image: %s", image)
 
-      util.run(["gcloud", "docker", "--", "push", latest_image])
-      logging.info("Pushed image: %s", latest_image)
+        util.run(["docker", "push", image])
+        logging.info("Pushed image: %s", image)
+      
+      else:
+        util.run(["gcloud", "docker", "--", "push", image])
+        logging.info("Pushed image: %s", image)
+
+        util.run(["gcloud", "docker", "--", "push", latest_image])
+        logging.info("Pushed image: %s", latest_image)
 
   output = {
     "image": image,
@@ -234,6 +246,7 @@ def build_and_push_artifacts(go_dir,
                              src_dir,
                              registry,
                              gcb_project=None,
+                             push_with_docker=False,
                              build_info_path=None,
                              version_tag=None):
   """Build and push the artifacts.
@@ -244,6 +257,8 @@ def build_and_push_artifacts(go_dir,
     registry: Docker registry to use.
     gcb_project: The project to use with GCB to build docker images.
       If set to none uses docker to build.
+    push_with_docker: (Optional): Using docker to push image to replace
+      gcloud.
     build_info_path: (Optional): GCS location to write YAML file containing
       information about the build.
     version_tag: (Optional): The tag to use for the image.
@@ -258,7 +273,8 @@ def build_and_push_artifacts(go_dir,
     os.makedirs(bin_dir)
 
   build_info = build_operator_image(
-    src_dir, registry, project=gcb_project, version_tag=version_tag)
+    src_dir, registry, project=gcb_project,
+    push_with_docker=push_with_docker, version_tag=version_tag)
 
   # Always write to the bin dir.
   paths = [os.path.join(bin_dir, "build_info.yaml")]
@@ -362,6 +378,7 @@ def build_and_push(go_dir, src_dir, args):
     src_dir,
     registry=args.registry,
     gcb_project=args.project,
+    push_with_docker=args.push_with_docker,
     build_info_path=args.build_info_path,
     version_tag=args.version_tag)
 
@@ -516,6 +533,11 @@ def add_common_args(parser):
     help="Don't do a dry run.")
   parser.set_defaults(dryrun=False)
 
+  parser.add_argument(
+    "--push_with_docker",
+    action="store_true",
+    help="Using docker to push image."
+  )
 
 def build_parser():
   # create the top-level parser

--- a/py/release.py
+++ b/py/release.py
@@ -132,7 +132,7 @@ def build_operator_image(root_dir,
     registry: The registry to use.
     project: If set it will be built using GCB.
     should_push: Should push the image to the registry, Defaule is True.
-    push_with_docker: Using docker to push image to the registry instead 
+    push_with_docker: Using docker to push image to the registry instead
       of using gcloud, Default is False.
     version_tag: Optional tag for the version. If not specified derive
       the tag from the git hash.
@@ -221,25 +221,29 @@ def build_operator_image(root_dir,
     util.run(["docker", "tag", image, latest_image])
 
     if should_push:
-      if push_with_docker:
-        util.run(["docker", "push", image])
-        logging.info("Pushed image: %s", image)
-
-        util.run(["docker", "push", image])
-        logging.info("Pushed image: %s", image)
-      
-      else:
-        util.run(["gcloud", "docker", "--", "push", image])
-        logging.info("Pushed image: %s", image)
-
-        util.run(["gcloud", "docker", "--", "push", latest_image])
-        logging.info("Pushed image: %s", latest_image)
+      _push_image(image, latest_image, push_with_docker)
 
   output = {
     "image": image,
     "commit": commit,
   }
   return output
+
+
+def _push_image(image, latest_image, push_with_docker):
+  if push_with_docker:
+    util.run(["docker", "push", image])
+    logging.info("Pushed image: %s", image)
+
+    util.run(["docker", "push", image])
+    logging.info("Pushed image: %s", image)
+
+  else:
+    util.run(["gcloud", "docker", "--", "push", image])
+    logging.info("Pushed image: %s", image)
+
+    util.run(["gcloud", "docker", "--", "push", latest_image])
+    logging.info("Pushed image: %s", latest_image)
 
 
 def build_and_push_artifacts(go_dir,
@@ -273,8 +277,11 @@ def build_and_push_artifacts(go_dir,
     os.makedirs(bin_dir)
 
   build_info = build_operator_image(
-    src_dir, registry, project=gcb_project,
-    push_with_docker=push_with_docker, version_tag=version_tag)
+    src_dir,
+    registry,
+    project=gcb_project,
+    push_with_docker=push_with_docker,
+    version_tag=version_tag)
 
   # Always write to the bin dir.
   paths = [os.path.join(bin_dir, "build_info.yaml")]
@@ -536,8 +543,8 @@ def add_common_args(parser):
   parser.add_argument(
     "--push_with_docker",
     action="store_true",
-    help="Using docker to push image."
-  )
+    help="Using docker to push image.")
+
 
 def build_parser():
   # create the top-level parser


### PR DESCRIPTION
By default, the release function will use gcloud to push the image. But the user not using gcloud command-tool cannot push the image to the registry. I think it's better to add an optional argument to allow user pushing the image with docker.
Add --push_with_docker argument for release.py. When using --push_with_docker, the release will use docker to push the image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/595)
<!-- Reviewable:end -->
