### PR TITLE
Add tf-operator.v2 to release.py so that we build a Docker image containing the v1alph2 controller

### DIFF
--- a/build/images/tf_operator/Dockerfile
+++ b/build/images/tf_operator/Dockerfile
@@ -13,9 +13,12 @@ RUN mkdir -p /opt/kubeflow/samples
 COPY tf_smoke.py /opt/kubeflow/samples/
 RUN chmod a+x /opt/kubeflow/samples/*
 COPY tf-operator /opt/mlkube
+COPY tf-operator.v2 /opt/kubeflow
 COPY e2e /opt/mlkube/test
 COPY backend /opt/tensorflow_k8s/dashboard/
 COPY build /opt/tensorflow_k8s/dashboard/frontend/build
+
+RUN chmod a+x /opt/kubeflow/tf-operator.v2
 RUN chmod a+x /opt/mlkube/tf-operator
 RUN chmod a+x /opt/mlkube/test/e2e
 RUN chmod a+x /opt/tensorflow_k8s/dashboard/backend

--- a/py/release.py
+++ b/py/release.py
@@ -147,11 +147,13 @@ def build_operator_image(root_dir,
 
   targets = [
     "github.com/kubeflow/tf-operator/cmd/tf-operator",
+    "github.com/kubeflow/tf-operator/cmd/tf-operator.v2",
     "github.com/kubeflow/tf-operator/test/e2e",
     "github.com/kubeflow/tf-operator/dashboard/backend",
   ]
   for t in targets:
-    if t == "github.com/kubeflow/tf-operator/cmd/tf-operator":
+    if t in ["github.com/kubeflow/tf-operator/cmd/tf-operator",
+             "github.com/kubeflow/tf-operator/cmd/tf-operator.v2"]:
       util.run([
         "go", "install", "-ldflags",
         "-X github.com/kubeflow/tf-operator/version.GitSHA={}".format(commit), t
@@ -176,6 +178,7 @@ def build_operator_image(root_dir,
     "build/images/tf_operator/Dockerfile",
     "examples/tf_sample/tf_sample/tf_smoke.py",
     os.path.join(go_path, bin_path, "tf-operator"),
+    os.path.join(go_path, bin_path, "tf-operator.v2"),
     os.path.join(go_path, bin_path, "e2e"),
     os.path.join(go_path, bin_path, "backend"), "dashboard/frontend/build"
   ]


### PR DESCRIPTION
* We need to add the tf-operator.v2 to release.py so that we can start building Docker images containing the new controller.

Fix #600

/assign @ScorpioCPH 
/assign @gaocegege

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/601)
<!-- Reviewable:end -->
