### PR TITLE
crd: Add validation using OpenAPI 3.0

### DIFF
--- a/examples/crd/crd-v1alpha2.yaml
+++ b/examples/crd/crd-v1alpha2.yaml
@@ -9,3 +9,26 @@ spec:
     kind: TFJob
     singular: tfjob
     plural: tfjobs
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            tfReplicaSpecs:
+              properties:
+                Worker:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                PS:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                Chief:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 1

--- a/examples/crd/crd-v1alpha2.yaml
+++ b/examples/crd/crd-v1alpha2.yaml
@@ -16,6 +16,8 @@ spec:
           properties:
             tfReplicaSpecs:
               properties:
+                # The validation works when the configuration contains
+                # `Worker`, `PS` or `Chief`. Otherise it will not be validated.
                 Worker:
                   properties:
                     replicas:


### PR DESCRIPTION
/assign @jlewi @ScorpioCPH 

The feature is restricted and I only add validation for replicas. This avoids the crash problem when replicas < 0.

related to: kubeflow/tf-operator#437

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/605)
<!-- Reviewable:end -->
