### PR TITLE
pkg: Support customized port

### DIFF
--- a/pkg/apis/tensorflow/v1alpha2/constants.go
+++ b/pkg/apis/tensorflow/v1alpha2/constants.go
@@ -18,6 +18,11 @@ const (
 	// EnvKubeflowNamespace is ENV for kubeflow namespace specified by user.
 	EnvKubeflowNamespace = "KUBEFLOW_NAMESPACE"
 
-	defaultPortName = "tfjob-port"
-	defaultPort     = 2222
+	// DefaultPortName is name of the port used to communicate between PS and
+	// workers.
+	DefaultPortName = "tfjob-port"
+	// DefaultContainerName is the name of the TFJob container.
+	DefaultContainerName = "tensorflow"
+	// DefaultPort is default value of the port.
+	DefaultPort = 2222
 )

--- a/pkg/apis/tensorflow/v1alpha2/defaults.go
+++ b/pkg/apis/tensorflow/v1alpha2/defaults.go
@@ -29,14 +29,28 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
+// setDefaultPort sets the default ports for tensorflow container.
 func setDefaultPort(spec *v1.PodSpec) {
-	for i := range spec.Containers {
-		if len(spec.Containers[i].Ports) == 0 {
-			spec.Containers[i].Ports = append(spec.Containers[i].Ports, v1.ContainerPort{
-				Name:          defaultPortName,
-				ContainerPort: defaultPort,
-			})
+	index := 0
+	for i, container := range spec.Containers {
+		if container.Name == DefaultContainerName {
+			index = i
+			break
 		}
+	}
+
+	hasTFJobPort := false
+	for _, port := range spec.Containers[index].Ports {
+		if port.Name == DefaultPortName {
+			hasTFJobPort = true
+			break
+		}
+	}
+	if !hasTFJobPort {
+		spec.Containers[index].Ports = append(spec.Containers[index].Ports, v1.ContainerPort{
+			Name:          DefaultPortName,
+			ContainerPort: DefaultPort,
+		})
 	}
 }
 

--- a/pkg/apis/tensorflow/v1alpha2/defaults_test.go
+++ b/pkg/apis/tensorflow/v1alpha2/defaults_test.go
@@ -38,11 +38,12 @@ func expectedTFJob() *TFJob {
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								v1.Container{
+									Name:  DefaultContainerName,
 									Image: testImage,
 									Ports: []v1.ContainerPort{
 										v1.ContainerPort{
-											Name:          defaultPortName,
-											ContainerPort: defaultPort,
+											Name:          DefaultPortName,
+											ContainerPort: DefaultPort,
 										},
 									},
 								},
@@ -70,11 +71,12 @@ func TestSetDefaultTFJob(t *testing.T) {
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										v1.Container{
+											Name:  DefaultContainerName,
 											Image: testImage,
 											Ports: []v1.ContainerPort{
 												v1.ContainerPort{
-													Name:          defaultPortName,
-													ContainerPort: defaultPort,
+													Name:          DefaultPortName,
+													ContainerPort: DefaultPort,
 												},
 											},
 										},
@@ -98,6 +100,7 @@ func TestSetDefaultTFJob(t *testing.T) {
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
 										v1.Container{
+											Name:  DefaultContainerName,
 											Image: testImage,
 										},
 									},

--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -48,8 +48,6 @@ const (
 	// labels for pods and servers.
 	tfReplicaTypeLabel  = "tf-replica-type"
 	tfReplicaIndexLabel = "tf-replica-index"
-
-	defaultPortStr = "2222"
 )
 
 var (

--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -359,6 +359,9 @@ func (tc *TFJobController) syncTFJob(key string) (bool, error) {
 	tfjob := sharedTFJob.DeepCopy()
 	tfjobNeedsSync := tc.satisfiedExpectations(tfjob)
 
+	// Set default for the new tfjob.
+	scheme.Scheme.Default(tfjob)
+
 	var reconcileTFJobsErr error
 	if tfjobNeedsSync && tfjob.DeletionTimestamp == nil {
 		reconcileTFJobsErr = tc.reconcileTFJobs(tfjob)

--- a/pkg/controller.v2/controller_pod.go
+++ b/pkg/controller.v2/controller_pod.go
@@ -32,6 +32,10 @@ import (
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
 )
 
+const (
+	tfConfig = "TF_CONFIG"
+)
+
 // reconcilePods checks and updates pods for each given TFReplicaSpec.
 // It will requeue the tfjob in case of an error while creating/deleting pods.
 func (tc *TFJobController) reconcilePods(
@@ -137,7 +141,7 @@ func (tc *TFJobController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index strin
 			podTemplate.Spec.Containers[i].Env = make([]v1.EnvVar, 0)
 		}
 		podTemplate.Spec.Containers[i].Env = append(podTemplate.Spec.Containers[i].Env, v1.EnvVar{
-			Name:  "TF_CONFIG",
+			Name:  tfConfig,
 			Value: tfConfigStr,
 		})
 	}

--- a/pkg/controller.v2/controller_pod.go
+++ b/pkg/controller.v2/controller_pod.go
@@ -123,7 +123,10 @@ func (tc *TFJobController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index strin
 	}
 
 	// Generate TF_CONFIG JSON string.
-	tfConfigStr := genTFConfigJSONStr(tfjob, rt, index)
+	tfConfigStr, err := genTFConfigJSONStr(tfjob, rt, index)
+	if err != nil {
+		return err
+	}
 
 	if tfConfigStr == "" {
 		return nil

--- a/pkg/controller.v2/controller_service.go
+++ b/pkg/controller.v2/controller_service.go
@@ -57,7 +57,7 @@ func (tc *TFJobController) reconcileServices(
 			// TODO(gaocegege): Kill some services.
 		} else if len(serviceSlice) == 0 {
 			loggerForReplica(tfjob, rt).Infof("need to create new service: %s-%d", rt, index)
-			err := tc.createNewService(tfjob, rt, strconv.Itoa(index), spec)
+			err := tc.createNewService(tfjob, rtype, strconv.Itoa(index), spec)
 			if err != nil {
 				return err
 			}
@@ -92,13 +92,15 @@ func getServiceSlices(services []*v1.Service, replicas int, logger *log.Entry) [
 }
 
 // createNewService creates a new service for the given index and type.
-func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rt, index string, spec *tfv1alpha2.TFReplicaSpec) error {
+func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType, index string, spec *tfv1alpha2.TFReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return err
 	}
 
+	// Convert TFReplicaType to lower string.
+	rt := strings.ToLower(string(rtype))
 	expectationServicesKey := genExpectationServicesKey(tfjobKey, rt)
 	err = tc.expectations.ExpectCreations(expectationServicesKey, 1)
 	if err != nil {
@@ -113,6 +115,11 @@ func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rt, index s
 	labels[tfReplicaTypeLabel] = rt
 	labels[tfReplicaIndexLabel] = index
 
+	port, err := getPortFromTFJob(tfjob, rtype)
+	if err != nil {
+		return err
+	}
+
 	service := &v1.Service{
 		Spec: v1.ServiceSpec{
 			ClusterIP: "None",
@@ -120,7 +127,7 @@ func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rt, index s
 			Ports: []v1.ServicePort{
 				{
 					Name: genGeneralName(tfjobKey, rt, index),
-					Port: defaultServicePort,
+					Port: port,
 				},
 			},
 		},

--- a/pkg/controller.v2/controller_service.go
+++ b/pkg/controller.v2/controller_service.go
@@ -30,10 +30,6 @@ import (
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
 )
 
-const (
-	defaultServicePort = 2222
-)
-
 // reconcileServices checks and updates services for each given TFReplicaSpec.
 // It will requeue the tfjob in case of an error while creating/deleting services.
 func (tc *TFJobController) reconcileServices(

--- a/pkg/controller.v2/controller_tensorflow.go
+++ b/pkg/controller.v2/controller_tensorflow.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
@@ -61,12 +60,17 @@ type TaskSpec struct {
 //         },
 //     }
 // }
-func genTFConfigJSONStr(tfjob *tfv1alpha2.TFJob, rtype, index string) string {
+func genTFConfigJSONStr(tfjob *tfv1alpha2.TFJob, rtype, index string) (string, error) {
 	// Configure the TFCONFIG environment variable.
 	i, _ := strconv.ParseInt(index, 0, 32)
 
+	cluster, err := genClusterSpec(tfjob)
+	if err != nil {
+		return "", err
+	}
+
 	tfConfig := TFConfig{
-		Cluster: genClusterSpec(tfjob),
+		Cluster: cluster,
 		Task: TaskSpec{
 			Type:  rtype,
 			Index: int(i),
@@ -75,19 +79,18 @@ func genTFConfigJSONStr(tfjob *tfv1alpha2.TFJob, rtype, index string) string {
 
 	tfConfigJSONStr, err := json.Marshal(tfConfig)
 	if err != nil {
-		log.Errorf("TFJob: %v serializing tfConfig return error: %v", tfjob.Name, err)
-		return ""
+		return "", err
 	}
 
-	return string(tfConfigJSONStr)
+	return string(tfConfigJSONStr), nil
 }
 
 // genClusterSpec will generate ClusterSpec.
-func genClusterSpec(tfjob *tfv1alpha2.TFJob) ClusterSpec {
+func genClusterSpec(tfjob *tfv1alpha2.TFJob) (ClusterSpec, error) {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
-		return nil
+		return nil, err
 	}
 
 	clusterSpec := make(ClusterSpec)
@@ -96,13 +99,17 @@ func genClusterSpec(tfjob *tfv1alpha2.TFJob) ClusterSpec {
 		rt := strings.ToLower(string(rtype))
 		replicaNames := make([]string, 0, *spec.Replicas)
 
+		port, err := getPortFromTFJob(tfjob, rtype)
+		if err != nil {
+			return nil, err
+		}
 		for i := int32(0); i < *spec.Replicas; i++ {
-			host := genDNSRecord(tfjobKey, rt, fmt.Sprintf("%d", i), tfjob.ObjectMeta.Namespace) + ":" + defaultPortStr
+			host := genDNSRecord(tfjobKey, rt, fmt.Sprintf("%d", i), tfjob.ObjectMeta.Namespace) + ":" + port
 			replicaNames = append(replicaNames, host)
 		}
 
 		clusterSpec[rt] = replicaNames
 	}
 
-	return clusterSpec
+	return clusterSpec, nil
 }

--- a/pkg/controller.v2/controller_tensorflow.go
+++ b/pkg/controller.v2/controller_tensorflow.go
@@ -104,7 +104,7 @@ func genClusterSpec(tfjob *tfv1alpha2.TFJob) (ClusterSpec, error) {
 			return nil, err
 		}
 		for i := int32(0); i < *spec.Replicas; i++ {
-			host := genDNSRecord(tfjobKey, rt, fmt.Sprintf("%d", i), tfjob.ObjectMeta.Namespace) + ":" + port
+			host := fmt.Sprintf("%s:%d", genDNSRecord(tfjobKey, rt, fmt.Sprintf("%d", i), tfjob.ObjectMeta.Namespace), port)
 			replicaNames = append(replicaNames, host)
 		}
 

--- a/pkg/controller.v2/controller_tfjob_test.go
+++ b/pkg/controller.v2/controller_tfjob_test.go
@@ -140,6 +140,7 @@ func newTFReplicaSpecTemplate() v1.PodTemplateSpec {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				v1.Container{
+					Name:  tfv1alpha2.DefaultContainerName,
 					Image: testImageName,
 					Args:  []string{"Fake", "Fake"},
 				},

--- a/test/e2e/dist-mnist/tj_job_mnist.yaml
+++ b/test/e2e/dist-mnist/tj_job_mnist.yaml
@@ -10,7 +10,7 @@ spec:
       template:
         spec:
           containers:
-            - name: dist-mnist-ps
+            - name: tensorflow
               image: kubeflow/tf-dist-mnist-test:1.0
     Worker:
       replicas: 4
@@ -18,6 +18,6 @@ spec:
       template:
         spec:
           containers:
-            - name: dist-mnist-worker
+            - name: tensorflow
               image: kubeflow/tf-dist-mnist-test:1.0
               args: ["train_steps", "50000"]


### PR DESCRIPTION


This PR is to close #532 

We have two hard coded name: tensorflow for container and tfjob-port for port name

We will set the default value for the port if we do not get it from the spec.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/621)
<!-- Reviewable:end -->
