### PR TITLE
Updates to enable e2e test for v1alpha2

### DIFF
--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -308,7 +308,9 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
       else:
         for replicakey in results.get("spec", {}).get("tfReplicaSpecs", {}):
           logging.info("replicakey: %s", results.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {}))
-          num_expected += results.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {}).get("replicas", 0)
+          replica_spec = results.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {})
+          if replica_spec:
+            num_expected += replica_spec.get("replicas", 1)
 
       creation_failures = []
       if len(created_pods) != num_expected:

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -263,7 +263,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
 
   start = time.time()
 
-  try:
+  try: # pylint: disable=too-many-nested-blocks
     # We repeat the test multiple times.
     # This ensures that if we delete the job we can create a new job with the
     # same name.
@@ -287,7 +287,8 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
           break
       else:
         # For v1alpha2 check for non-empty completionTime
-        if results.get("status", {}).get("conditions", [])[-1].get("type", "").lower() != "succeeded":
+        last_condition = results.get("status", {}).get("conditions", [])[-1]
+        if last_condition.get("type", "").lower() != "succeeded":
           t.failure = "Trial {0} Job {1} in namespace {2} in status {3}".format(
             trial, name, namespace, results.get("status", {}))
           logging.error(t.failure)
@@ -307,7 +308,6 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
           num_expected += replica.get("replicas", 0)
       else:
         for replicakey in results.get("spec", {}).get("tfReplicaSpecs", {}):
-          logging.info("replicakey: %s", results.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {}))
           replica_spec = results.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {})
           if replica_spec:
             num_expected += replica_spec.get("replicas", 1)

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -140,8 +140,14 @@ def wait_for_job(client,
         status_callback(results)
 
       # If we poll the CRD quick enough status won't have been set yet.
-      if results.get("status", {}).get("phase", {}) == "Done":
-        return results
+      if version == "v1alpha1":
+        if results.get("status", {}).get("phase", {}) == "Done":
+          return results
+      else:
+        # For v1alpha2 check for non-empty completionTime
+        if results.get("status", {}).get("completionTime", ""):
+          return results
+
 
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.TimeoutError(


### PR DESCRIPTION
* Update test_runner.py to track new fields in version v1alpha2 for TFJob
* Update simple_tfjob.jsonnet with new TFJob spec for v1alpha2

/assign @gaocegege 

Related https://github.com/kubeflow/kubeflow/issues/852

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/629)
<!-- Reviewable:end -->
