### PR TITLE
[v1alpha2] Estimator support -  Do not include `evaluator` in cluster spec

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -96,8 +96,8 @@ kubectl create -f ./examples/crd/crd.yml
 Or
 
 ```bash
-# If you are using v1alpha1
-kubectl create -f ./examples/crd/crd-v1alpha2.yml
+# If you are using v1alpha2
+kubectl create -f ./examples/crd/crd-v1alpha2.yaml
 ```
 
 ### Run Operator

--- a/examples/crd/crd-v1alpha2.yaml
+++ b/examples/crd/crd-v1alpha2.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   group: kubeflow.org
   version: v1alpha2
+  scope: Namespaced
   names:
     kind: TFJob
     singular: tfjob

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -108,7 +108,7 @@ const (
 	TFReplicaTypeChief TFReplicaType = "Chief"
 
 	// TFReplicaTypeEval is the type for evaluation replica in TensorFlow.
-	TFReplicaTypeEval TFReplicaType = "Eval"
+	TFReplicaTypeEval TFReplicaType = "Evaluator"
 )
 
 // TFJobStatus represents the current observed state of the TFJob.

--- a/pkg/controller.v2/controller_tensorflow.go
+++ b/pkg/controller.v2/controller_tensorflow.go
@@ -96,6 +96,11 @@ func genClusterSpec(tfjob *tfv1alpha2.TFJob) (ClusterSpec, error) {
 	clusterSpec := make(ClusterSpec)
 
 	for rtype, spec := range tfjob.Spec.TFReplicaSpecs {
+		if rtype == tfv1alpha2.TFReplicaTypeEval {
+			// https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig
+			// evaluator is not part of training cluster
+			continue
+		}
 		rt := strings.ToLower(string(rtype))
 		replicaNames := make([]string, 0, *spec.Replicas)
 


### PR DESCRIPTION
When using `Estimator` and `tf.estimator.train_and_evaluate` for distributed task,
the `evaluator` should not be included in the cluster spec.

> Example of evaluator node (evaluator is not part of training cluster):
>
> ``` python
>   cluster = {'chief': ['host0:2222'],
>              'ps': ['host1:2222', 'host2:2222'],
>              'worker': ['host3:2222', 'host4:2222', 'host5:2222']}
>   os.environ['TF_CONFIG'] = json.dumps(
>       {'cluster': cluster,
>        'task': {'type': 'evaluator', 'index': 0}})
>   config = RunConfig()
>   assert config.master == ''
>   assert config.evaluator_master == ''
>   assert config.task_id == 0
>   assert config.num_ps_replicas == 0
>   assert config.num_worker_replicas == 0
>   assert config.cluster_spec == {}
>   assert config.task_type == 'evaluator'
>   assert not config.is_chief
> ```

Refs:
https://www.tensorflow.org/api_docs/python/tf/estimator/RunConfig
https://www.tensorflow.org/api_docs/python/tf/estimator/train_and_evaluate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/650)
<!-- Reviewable:end -->
