### PR TITLE
controller: Move control interface to control package

### DIFF
--- a/pkg/control/pod_control.go
+++ b/pkg/control/pod_control.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Most code here is copied from Kubernetes, while we change the
 // logic about name generation to generate name with type and index.
 
-package controller
+package control
 
 import (
 	"fmt"

--- a/pkg/control/pod_control_test.go
+++ b/pkg/control/pod_control_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package control
 
 import (
 	"encoding/json"

--- a/pkg/control/service_control.go
+++ b/pkg/control/service_control.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package control
 
 import (
 	"fmt"

--- a/pkg/control/service_control_test.go
+++ b/pkg/control/service_control_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package control
 
 import (
 	"encoding/json"

--- a/pkg/control/service_ref_manager.go
+++ b/pkg/control/service_ref_manager.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package control
 
 import (
 	"fmt"
@@ -157,21 +157,4 @@ func (m *ServiceControllerRefManager) ReleaseService(service *v1.Service) error 
 		}
 	}
 	return err
-}
-
-// RecheckDeletionTimestamp returns a CanAdopt() function to recheck deletion.
-//
-// The CanAdopt() function calls getObject() to fetch the latest value,
-// and denies adoption attempts if that object has a non-nil DeletionTimestamp.
-func RecheckDeletionTimestamp(getObject func() (metav1.Object, error)) func() error {
-	return func() error {
-		obj, err := getObject()
-		if err != nil {
-			return fmt.Errorf("can't recheck DeletionTimestamp: %v", err)
-		}
-		if obj.GetDeletionTimestamp() != nil {
-			return fmt.Errorf("%v/%v has just been deleted at %v", obj.GetNamespace(), obj.GetName(), obj.GetDeletionTimestamp())
-		}
-		return nil
-	}
 }

--- a/pkg/control/service_ref_manager_test.go
+++ b/pkg/control/service_ref_manager_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controller
+package control
 
 import (
 	"reflect"
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
 	"github.com/kubeflow/tf-operator/pkg/generator"
 	"github.com/kubeflow/tf-operator/pkg/util/testutil"
 )
@@ -54,7 +55,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					tfJob,
 					tfJobLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testutil.NewBaseService("service1", tfJob, t), testService},
 				claimed:  []*v1.Service{testutil.NewBaseService("service1", tfJob, t)},
@@ -80,7 +81,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					controller,
 					controllerLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testService1, testService2},
 				claimed:  nil,
@@ -104,7 +105,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					controller,
 					controllerLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testutil.NewBaseService("service1", controller, t), testService2},
 				claimed:  []*v1.Service{testutil.NewBaseService("service1", controller, t)},
@@ -126,7 +127,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					controller,
 					controllerLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testutil.NewBaseService("service1", controller, t), testutil.NewBaseService("service2", controller2, t)},
 				claimed:  []*v1.Service{testutil.NewBaseService("service1", controller, t)},
@@ -148,7 +149,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					controller,
 					controllerLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testutil.NewBaseService("service1", controller, t), testService2},
 				claimed:  []*v1.Service{testutil.NewBaseService("service1", controller, t)},
@@ -175,7 +176,7 @@ func TestClaimServices(t *testing.T) {
 				manager: NewServiceControllerRefManager(&FakeServiceControl{},
 					controller,
 					controllerLabelSelector,
-					controllerKind,
+					tfv1alpha2.SchemeGroupVersionKind,
 					func() error { return nil }),
 				services: []*v1.Service{testService1, testService2},
 				claimed:  []*v1.Service{testService1},

--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -40,6 +40,7 @@ import (
 	tfjobinformers "github.com/kubeflow/tf-operator/pkg/client/informers/externalversions"
 	tfjobinformersv1alpha2 "github.com/kubeflow/tf-operator/pkg/client/informers/externalversions/kubeflow/v1alpha2"
 	tfjoblisters "github.com/kubeflow/tf-operator/pkg/client/listers/kubeflow/v1alpha2"
+	"github.com/kubeflow/tf-operator/pkg/control"
 )
 
 const (
@@ -86,7 +87,7 @@ type TFJobController struct {
 	podControl controller.PodControlInterface
 
 	// serviceControl is used to add or delete services.
-	serviceControl ServiceControlInterface
+	serviceControl control.ServiceControlInterface
 
 	// kubeClientSet is a standard kubernetes clientset.
 	kubeClientSet kubeclientset.Interface
@@ -171,12 +172,12 @@ func NewTFJobController(
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClientSet.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
 
-	realPodControl := RealPodControl{
+	realPodControl := control.RealPodControl{
 		KubeClient: kubeClientSet,
 		Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName}),
 	}
 
-	realServiceControl := RealServiceControl{
+	realServiceControl := control.RealServiceControl{
 		KubeClient: kubeClientSet,
 		Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName}),
 	}

--- a/pkg/controller.v2/controller_service.go
+++ b/pkg/controller.v2/controller_service.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
+	"github.com/kubeflow/tf-operator/pkg/control"
 	"github.com/kubeflow/tf-operator/pkg/generator"
 )
 
@@ -186,7 +187,7 @@ func (tc *TFJobController) getServicesForTFJob(tfjob *tfv1alpha2.TFJob) ([]*v1.S
 		}
 		return fresh, nil
 	})
-	cm := NewServiceControllerRefManager(tc.serviceControl, tfjob, selector, controllerKind, canAdoptFunc)
+	cm := control.NewServiceControllerRefManager(tc.serviceControl, tfjob, selector, controllerKind, canAdoptFunc)
 	return cm.ClaimServices(services)
 }
 

--- a/pkg/controller.v2/controller_test.go
+++ b/pkg/controller.v2/controller_test.go
@@ -28,6 +28,7 @@ import (
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
 	tfjobclientset "github.com/kubeflow/tf-operator/pkg/client/clientset/versioned"
 	tfjobinformers "github.com/kubeflow/tf-operator/pkg/client/informers/externalversions"
+	"github.com/kubeflow/tf-operator/pkg/control"
 	"github.com/kubeflow/tf-operator/pkg/generator"
 	"github.com/kubeflow/tf-operator/pkg/util/testutil"
 )
@@ -53,7 +54,7 @@ func newTFJobController(
 
 	ctr := NewTFJobController(tfJobInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory)
 	ctr.podControl = &controller.FakePodControl{}
-	ctr.serviceControl = &FakeServiceControl{}
+	ctr.serviceControl = &control.FakeServiceControl{}
 	return ctr, kubeInformerFactory, tfJobInformerFactory
 }
 
@@ -260,7 +261,7 @@ func TestNormalPath(t *testing.T) {
 		}
 
 		fakePodControl := ctr.podControl.(*controller.FakePodControl)
-		fakeServiceControl := ctr.serviceControl.(*FakeServiceControl)
+		fakeServiceControl := ctr.serviceControl.(*control.FakeServiceControl)
 		if int32(len(fakePodControl.Templates)) != tc.expectedPodCreations {
 			t.Errorf("%s: unexpected number of pod creates.  Expected %d, saw %d\n", name, tc.expectedPodCreations, len(fakePodControl.Templates))
 		}


### PR DESCRIPTION
Close #665 

Move the PodControl and ServiceControl out of controller package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/670)
<!-- Reviewable:end -->
