### PR TITLE
return err if the spec area is nil after unmashal for tfjob v1alpha2

### DIFF
--- a/pkg/controller.v2/informer.go
+++ b/pkg/controller.v2/informer.go
@@ -89,7 +89,7 @@ func tfJobFromUnstructured(obj interface{}) (*tfv1alpha2.TFJob, error) {
 	}
 	var tfjob tfv1alpha2.TFJob
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, &tfjob)
-	if err != nil {
+	if err != nil || tfjob.Spec.TFReplicaSpecs == nil {
 		return &tfjob, errFailedMarshal
 	}
 	return &tfjob, nil


### PR DESCRIPTION
this is to fix: #641
func `tfJobFromUnstructured` may not recognize the spec area, `tfjob.Spec.TFReplicaSpecs` will be nil then, this logic should be considered to be err and stop sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/678)
<!-- Reviewable:end -->
