### PR TITLE
define cleanup policy

### DIFF
--- a/examples/tf_job_clean_policy.yaml
+++ b/examples/tf_job_clean_policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: "kubeflow.org/v1alpha1"
+kind: "TFJob"
+metadata:
+  name: "example-job"
+spec:
+  # The default behavior is CleanAll, which is the same as current behavior, but the user can set CleanRunning for reserving
+  # succeed/failed pod for checking logs, and non-running pod will not consume any GPU/CPU/Memory resource.
+  # And for further investigation, the user can set CleanNone for keeping all the components.
+  cleanPodPolicy: CleanRunning
+  replicaSpecs:
+    - replicas: 1
+      tfReplicaType: MASTER
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow
+          restartPolicy: OnFailure
+    - replicas: 1
+      tfReplicaType: WORKER
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow
+          restartPolicy: OnFailure
+    - replicas: 2
+      tfReplicaType: PS
+      template:
+        spec:
+          containers:
+            - image: gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff
+              name: tensorflow
+          restartPolicy: OnFailure

--- a/examples/tf_job_clean_policy.yaml
+++ b/examples/tf_job_clean_policy.yaml
@@ -3,10 +3,10 @@ kind: "TFJob"
 metadata:
   name: "example-job"
 spec:
-  # The default behavior is CleanAll, which is the same as current behavior, but the user can set CleanRunning for reserving
+  # The default behavior is `All`, which is the same as current behavior, but the user can set `Running` for reserving
   # succeed/failed pod for checking logs, and non-running pod will not consume any GPU/CPU/Memory resource.
-  # And for further investigation, the user can set CleanNone for keeping all the components.
-  cleanPodPolicy: CleanRunning
+  # And for further investigation, the user can set `None` for keeping all the components.
+  cleanupPodPolicy: Running
   replicaSpecs:
     - replicas: 1
       tfReplicaType: MASTER

--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -58,9 +58,22 @@ type TFJobSpec struct {
 	// TerminationPolicy specifies the condition that the tfjob should be considered finished.
 	TerminationPolicy *TerminationPolicySpec `json:"terminationPolicy,omitempty"`
 
+	// CleanPodPolicy specifies the operation when tfjob is finished or failed.
+	CleanPodPolicy CleanPodPolicyType `json:"cleanPodPolicy,omitempty"`
+
 	// SchedulerName specifies the name of scheduler which should handle the TFJob
 	SchedulerName string `json:"schedulerName,omitempty"`
 }
+
+// CleanPodPolicyType defines all kinds of types of cleanPodPolicy.
+type CleanPodPolicyType string
+
+const (
+	CleanUndefined CleanPodPolicyType = ""
+	CleanAll       CleanPodPolicyType = "CleanAll"
+	CleanRunning   CleanPodPolicyType = "CleanRunning"
+	CleanNone      CleanPodPolicyType = "CleanNone"
+)
 
 // TerminationPolicySpec structure for storing specifications for process termination
 type TerminationPolicySpec struct {

--- a/pkg/apis/tensorflow/v1alpha1/types.go
+++ b/pkg/apis/tensorflow/v1alpha1/types.go
@@ -58,21 +58,21 @@ type TFJobSpec struct {
 	// TerminationPolicy specifies the condition that the tfjob should be considered finished.
 	TerminationPolicy *TerminationPolicySpec `json:"terminationPolicy,omitempty"`
 
-	// CleanPodPolicy specifies the operation when tfjob is finished or failed.
-	CleanPodPolicy CleanPodPolicyType `json:"cleanPodPolicy,omitempty"`
+	// CleanupPodPolicy specifies the operation when tfjob is finished or failed.
+	CleanupPodPolicy CleanupPodPolicy `json:"cleanupPodPolicy,omitempty"`
 
 	// SchedulerName specifies the name of scheduler which should handle the TFJob
 	SchedulerName string `json:"schedulerName,omitempty"`
 }
 
-// CleanPodPolicyType defines all kinds of types of cleanPodPolicy.
-type CleanPodPolicyType string
+// CleanupPodPolicy defines all kinds of types of cleanPodPolicy.
+type CleanupPodPolicy string
 
 const (
-	CleanUndefined CleanPodPolicyType = ""
-	CleanAll       CleanPodPolicyType = "CleanAll"
-	CleanRunning   CleanPodPolicyType = "CleanRunning"
-	CleanNone      CleanPodPolicyType = "CleanNone"
+	CleanupPodUndefined CleanupPodPolicy = ""
+	CleanupPodAll       CleanupPodPolicy = "All"
+	CleanupPodRunning   CleanupPodPolicy = "Running"
+	CleanupPodNone      CleanupPodPolicy = "None"
 )
 
 // TerminationPolicySpec structure for storing specifications for process termination

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -239,21 +239,21 @@ func (s *TFReplicaSet) CreatePodWithIndex(index int32) (*v1.Pod, error) {
 	return s.ClientSet.CoreV1().Pods(s.Job.job.ObjectMeta.Namespace).Create(pod)
 }
 
-// Delete the replicas by clean policy when the tfjob is complete or failed: CleanAll, CleanNone, CleanRunning, the default is CleanAll
-func (s *TFReplicaSet) DeleteResourcesByCleanPolicy(cleanPolicy tfv1alpha1.CleanPodPolicyType) (err error) {
-	log.Infof("DeleteResourcesByCleanPolicy for %s with CleanPodPolicyType %v", s.Job.job.ObjectMeta.Name, cleanPolicy)
-	switch cleanPolicy {
-	case tfv1alpha1.CleanUndefined, tfv1alpha1.CleanAll:
+// Delete the replicas by cleanup pod policy when the tfjob is complete or failed: CleanupPodAll, CleanupPodNone, CleanupPodRunning, the default is CleanupPodAll
+func (s *TFReplicaSet) DeleteResourcesByCleanPolicy(cleanupPodPolicy tfv1alpha1.CleanupPodPolicy) (err error) {
+	log.Infof("DeleteResourcesByCleanPolicy for %s with CleanupPodPolicy %v", s.Job.job.ObjectMeta.Name, cleanupPodPolicy)
+	switch cleanupPodPolicy {
+	case tfv1alpha1.CleanupPodUndefined, tfv1alpha1.CleanupPodAll:
 		s.contextLogger.Infof("Apply Clean All Policy for %s", s.Job.job.ObjectMeta.Name)
 		err = s.Delete()
-	case tfv1alpha1.CleanNone:
+	case tfv1alpha1.CleanupPodNone:
 		s.contextLogger.Infof("Apply Clean None Policy for %s", s.Job.job.ObjectMeta.Name)
-	case tfv1alpha1.CleanRunning:
+	case tfv1alpha1.CleanupPodRunning:
 		s.contextLogger.Infof("Apply Clean Running Pod Policy for %s", s.Job.job.ObjectMeta.Name)
 		err = s.DeleteRunningPods()
 	default:
-		s.contextLogger.Errorf("Unknown cleanPolicy %v", cleanPolicy)
-		err = fmt.Errorf("Unknown cleanPolicy %v", cleanPolicy)
+		s.contextLogger.Errorf("Unknown cleanupPodPolicy %v", cleanupPodPolicy)
+		err = fmt.Errorf("Unknown cleanupPodPolicy %v", cleanupPodPolicy)
 	}
 
 	return err

--- a/pkg/trainer/replicas.go
+++ b/pkg/trainer/replicas.go
@@ -240,24 +240,23 @@ func (s *TFReplicaSet) CreatePodWithIndex(index int32) (*v1.Pod, error) {
 }
 
 // Delete the replicas by clean policy when the tfjob is complete or failed: CleanAll, CleanNone, CleanRunning, the default is CleanAll
-func (s *TFReplicaSet) DeleteResourcesByCleanPolicy(cleanPolicy tfv1alpha1.CleanPodPolicyType) error {
+func (s *TFReplicaSet) DeleteResourcesByCleanPolicy(cleanPolicy tfv1alpha1.CleanPodPolicyType) (err error) {
 	log.Infof("DeleteResourcesByCleanPolicy for %s with CleanPodPolicyType %v", s.Job.job.ObjectMeta.Name, cleanPolicy)
 	switch cleanPolicy {
 	case tfv1alpha1.CleanUndefined, tfv1alpha1.CleanAll:
 		s.contextLogger.Infof("Apply Clean All Policy for %s", s.Job.job.ObjectMeta.Name)
-		return s.Delete()
+		err = s.Delete()
 	case tfv1alpha1.CleanNone:
 		s.contextLogger.Infof("Apply Clean None Policy for %s", s.Job.job.ObjectMeta.Name)
-		return nil
 	case tfv1alpha1.CleanRunning:
 		s.contextLogger.Infof("Apply Clean Running Pod Policy for %s", s.Job.job.ObjectMeta.Name)
-		return s.DeleteRunningPods()
+		err = s.DeleteRunningPods()
 	default:
 		s.contextLogger.Errorf("Unknown cleanPolicy %v", cleanPolicy)
-		return fmt.Errorf("Unknown cleanPolicy %v", cleanPolicy)
+		err = fmt.Errorf("Unknown cleanPolicy %v", cleanPolicy)
 	}
 
-	return nil
+	return err
 }
 
 // Deletes the running pods

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -139,12 +139,12 @@ func (j *TrainingJob) ClusterSpec() ClusterSpec {
 	return clusterSpec
 }
 
-// cleanResourcesByCleanPolicy deletes the replicas by following the policy CleanAll, CleanNone, CleanRunning, the default is CleanAll
+// cleanResourcesByCleanPolicy deletes the replicas by following the policy CleanupAll, CleanupNone, CleanupRunning, the default is CleanupAll
 func (j *TrainingJob) deleteResourcesByCleanPolicy() error {
 	log.Infof("deleteResourcesByCleanPolicy for %s, %v", j.job.ObjectMeta.Name, j.Replicas)
 	for _, r := range j.Replicas {
 		log.Infof("deleteResourcesByCleanPolicy for %s, %v", j.job.ObjectMeta.Name, r)
-		if err := r.DeleteResourcesByCleanPolicy(j.job.Spec.CleanPodPolicy); err != nil {
+		if err := r.DeleteResourcesByCleanPolicy(j.job.Spec.CleanupPodPolicy); err != nil {
 			return err
 		}
 	}

--- a/pkg/trainer/training.go
+++ b/pkg/trainer/training.go
@@ -154,6 +154,7 @@ func (j *TrainingJob) deleteResourcesByCleanPolicy() error {
 
 // deleteResources deletes the replicas it it was created
 func (j *TrainingJob) deleteResources() error {
+	log.Infof("deleteResources()")
 	for _, r := range j.Replicas {
 		if err := r.Delete(); err != nil {
 			return err
@@ -399,11 +400,11 @@ func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig, enableGangS
 		// TODO(jlewi): We should update the Phase if we detect the job is done.
 		if state == tfv1alpha1.StateFailed {
 			j.contextLogger.Errorf("Master failed Job: %v.", j.job.ObjectMeta.Name)
-			j.status.Phase = tfv1alpha1.TFJobPhaseDone
+			j.status.Phase = tfv1alpha1.TFJobPhaseCleanUp
 			j.status.State = tfv1alpha1.StateFailed
 		} else if state == tfv1alpha1.StateSucceeded {
 			j.contextLogger.Infof("Master succeeded Job: %v.", j.job.ObjectMeta.Name)
-			j.status.Phase = tfv1alpha1.TFJobPhaseDone
+			j.status.Phase = tfv1alpha1.TFJobPhaseCleanUp
 			j.status.State = tfv1alpha1.StateSucceeded
 		} else if state == tfv1alpha1.StateRunning {
 			j.contextLogger.Infof("Master running Job: %v.", j.job.ObjectMeta.Name)
@@ -421,23 +422,14 @@ func (j *TrainingJob) Reconcile(config *tfv1alpha1.ControllerConfig, enableGangS
 	}
 
 	// When the job is done or failed, we need to determine if we need clean up the resource
-	if j.job.Status.Phase == tfv1alpha1.TFJobPhaseDone {
+	if j.job.Status.Phase == tfv1alpha1.TFJobPhaseCleanUp {
 		j.contextLogger.Infof("Handle clean up policy when the tfjob %s is done.", j.job.ObjectMeta.Name)
 		if cErr := j.deleteResourcesByCleanPolicy(); cErr != nil {
-			j.contextLogger.Errorf("Job %v trainingJob.deleteResourcesByCleanPolicy() error; %v", j.job.ObjectMeta.Name, cErr)
-			return cErr
-		}
-		return nil
-	}
-
-	if j.job.Status.Phase == tfv1alpha1.TFJobPhaseCleanUp {
-		if cErr := j.deleteResources(); cErr != nil {
 			j.contextLogger.Errorf("Job %v trainingJob.Delete() error; %v", j.job.ObjectMeta.Name, cErr)
 			// Return an error so that we stay in phase cleanup and retry.
-			// return cErr
+			return cErr
 		}
-		// j.status.Phase = tfv1alpha1.TFJobPhaseDone
-		return nil
+		j.status.Phase = tfv1alpha1.TFJobPhaseDone
 	}
 
 	// updateCRDStatus will update the status of the CRD with c.Status if c.Status


### PR DESCRIPTION
- Add cleanupPodPolicy when the v1alpha1 TFJob is succeed or failed
- The cleanupPodPolicy contains:
    - All: the default behavior which is the same with the current behavior. it will  delete all the resources related to the TFJob object
    - Running: delete running pods and reserve succeed/failed pod for checking logs. Since non-running pod will not consume any GPU/CPU/Memory resource, while the important info always keeps in the log of succeed/failed pod 
     - None: keep all the resources for further investigation


The motivation of doing this is it's we'd like to provide flexibility to the end user to handle the resources when TFJob is done. 


Signed-off-by: cheyang <cheyang@163.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/685)
<!-- Reviewable:end -->
