### PR TITLE
Use tf_job_name not tf_job_key as the label name.

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	LabelGroupName = "group_name"
-	labelTFJobKey  = "tf_job_key"
+	labelTFJobName  = "tf_job_name"
 )
 
 var (
@@ -48,10 +48,10 @@ func GenOwnerReference(tfjob *tfv1alpha2.TFJob) *metav1.OwnerReference {
 	return controllerRef
 }
 
-func GenLabels(tfjobKey string) map[string]string {
+func GenLabels(tfJobName string) map[string]string {
 	return map[string]string{
 		LabelGroupName: tfv1alpha2.GroupName,
-		labelTFJobKey:  strings.Replace(tfjobKey, "/", "-", -1),
+		labelTFJobName:  strings.Replace(tfJobName, "/", "-", -1),
 	}
 }
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	LabelGroupName = "group_name"
-	labelTFJobName  = "tf_job_name"
+	labelTFJobName = "tf_job_name"
 )
 
 var (
@@ -51,7 +51,7 @@ func GenOwnerReference(tfjob *tfv1alpha2.TFJob) *metav1.OwnerReference {
 func GenLabels(tfJobName string) map[string]string {
 	return map[string]string{
 		LabelGroupName: tfv1alpha2.GroupName,
-		labelTFJobName:  strings.Replace(tfJobName, "/", "-", -1),
+		labelTFJobName: strings.Replace(tfJobName, "/", "-", -1),
 	}
 }
 

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -52,8 +52,8 @@ func TestGenLabels(t *testing.T) {
 
 	labels := GenLabels(testKey)
 
-	if labels[labelTFJobKey] != expctedKey {
-		t.Errorf("Expected %s %s, got %s", labelTFJobKey, expctedKey, labels[labelTFJobKey])
+	if labels[labelTFJobName] != expctedKey {
+		t.Errorf("Expected %s %s, got %s", labelTFJobName, expctedKey, labels[labelTFJobName])
 	}
 	if labels[LabelGroupName] != tfv1alpha2.GroupName {
 		t.Errorf("Expected %s %s, got %s", LabelGroupName, tfv1alpha2.GroupName, labels[LabelGroupName])

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -458,7 +458,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
                                       pod_selector,
                                       ["Running"],
                                       timeout=datetime.timedelta(
-                                        minutes=2))
+                                        minutes=4))
         logging.info("Pods are ready")
         logging.info("Issuing the terminate request")
         terminateReplica(masterHost, namespace, target)

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -171,7 +171,7 @@ def get_labels_v1alpha2(name, replica_type=None,
   """
   labels = {
     "group_name": "kubeflow.org",
-    "tf_job_key": name,
+    "tf_job_name": name,
   }
   if replica_type:
     labels["tf-replica-type"] = replica_type


### PR DESCRIPTION
* tf_job_name is consistent with v1alpha1; this desirable from a compatibility
  perspective.

* tf_job_key isn't quite right because the job key includes namespace
  but we are no longer using the namespace in the value

Related to #672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/689)
<!-- Reviewable:end -->
