### PR TITLE
fix not proper log message

### DIFF
--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -311,13 +311,19 @@ func (tc *TFJobController) processNextWorkItem() bool {
 
 	tfJob, err := tc.getTFJobFromKey(key.(string))
 	if err != nil {
-		log.Errorf("Failed to get TFJob from key %s: %v", key, err)
+		if err == errNotExists {
+			log.Infof("TFJob has been deleted: %v", key)
+			return true
+		}
+
 		// Log the failure to conditions.
+		log.Errorf("Failed to get TFJob from key %s: %v", key, err)
 		if err == errFailedMarshal {
 			errMsg := fmt.Sprintf("Failed to unmarshal the object to TFJob object: %v", err)
 			loggerForTFJob(tfJob).Warn(errMsg)
 			tc.recorder.Event(tfJob, v1.EventTypeWarning, failedMarshalTFJobReason, errMsg)
 		}
+
 		return true
 	}
 


### PR DESCRIPTION
this fix the issue in #727 
If the err is errNotExists, then we can simply print the information and return directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/734)
<!-- Reviewable:end -->
