### PR TITLE
Fix a test flake caused by conditions being None

### DIFF
--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -217,6 +217,8 @@ def wait_for_condition(client,
 
       # If we poll the CRD quick enough status won't have been set yet.
       conditions = results.get("status", {}).get("conditions", [])
+      # Conditions might have a value of None in status.
+      conditions = conditions or []
       for c in conditions:
         if c.get("type", "") in expected_condition:
           return results


### PR DESCRIPTION
* We observed conditions have a value of None in status. So explicitly
  guard against that.

Fix #744 

/assign @richardsliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/745)
<!-- Reviewable:end -->
