### PR TITLE
Revert "cleanup jobs after finished (#725)"

### DIFF
--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,10 +48,6 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
-	// CleanPodDelay defines the delay of executing CleanPodPolicy.
-	// Default to 0.
-	CleanPodDelay *CleanPodDelay `json:"cleanPodDelay,omitempty"`
-
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.
 	// For example,
@@ -88,13 +84,6 @@ const (
 	CleanPodPolicyRunning   CleanPodPolicy = "Running"
 	CleanPodPolicyNone      CleanPodPolicy = "None"
 )
-
-// CleanPodDelay defines the delay of executing CleanPodPolicy using duration string.
-// A duration string is a possibly signed sequence of
-// decimal numbers, each with optional fraction and a unit suffix,
-// such as "300ms", "-1.5h" or "2h45m".
-// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-type CleanPodDelay string
 
 // RestartPolicy describes how the TFReplicas should be restarted.
 // Only one of the following restart policies may be specified.

--- a/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
@@ -109,11 +109,6 @@ func (in *TFJobSpec) DeepCopyInto(out *TFJobSpec) {
 		*out = new(CleanPodPolicy)
 		**out = **in
 	}
-	if in.CleanPodDelay != nil {
-		in, out := &in.CleanPodDelay, &out.CleanPodDelay
-		*out = new(CleanPodDelay)
-		**out = **in
-	}
 	if in.TFReplicaSpecs != nil {
 		in, out := &in.TFReplicaSpecs, &out.TFReplicaSpecs
 		*out = make(map[TFReplicaType]*TFReplicaSpec, len(*in))

--- a/pkg/controller.v2/controller_status.go
+++ b/pkg/controller.v2/controller_status.go
@@ -17,9 +17,7 @@ package controller
 
 import (
 	"fmt"
-	"time"
 
-	log "github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -240,23 +238,4 @@ func filterOutCondition(conditions []tfv1alpha2.TFJobCondition, condType tfv1alp
 		newConditions = append(newConditions, c)
 	}
 	return newConditions
-}
-
-func isAfterCleanDelay(tfJob *tfv1alpha2.TFJob) bool {
-	if tfJob.Spec.CleanPodDelay == nil { // default to 0 (no delay)
-		return true
-	}
-	currentTime := time.Now()
-	durationStr := string(*tfJob.Spec.CleanPodDelay)
-	duration, err := time.ParseDuration(durationStr)
-	if err != nil {
-		log.Warnf("Parse CleanPodDelay duration error: %v, use 0 as default.", err)
-		return true
-	}
-	if tfJob.Status.CompletionTime != nil {
-		if currentTime.After(tfJob.Status.CompletionTime.Add(duration)) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
This reverts commit 0b9d4227f4ed5f77c9eba3d2317892376fe22e67.

Discussion for why we are reverting in #718 [see comment](https://github.com/kubeflow/tf-operator/issues/718#issuecomment-406500117)

To summarize

  1. Adding CleanPodDelay doesn't really solve the problem of garbage collecting old jobs
  1. CleanPodDelay isn't really a great solution for preserving logs from pods; a better solution is cluster logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/746)
<!-- Reviewable:end -->
