### PR TITLE
Cleanup tf-job after a configured TTL

### DIFF
--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -50,6 +50,8 @@ type TFJobSpec struct {
 
 	// TTLSecondsAfterFinishing is the TTL to clean up tf-jobs (temporary
 	// before kubernetes adds the cleanup controller).
+	// It may take extra ReconcilePeriod seconds for the cleanup, since
+	// reconcile gets called periodically.
 	// Default to infinite.
 	TTLSecondsAfterFinishing *int32 `json:"ttlSecondsAfterFinishing,omitempty"`
 

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,6 +48,11 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
+	// TTL to clean up tf-jobs (temporary before kubernetes adds the
+	// cleanup controller).
+	// Default to infinite.
+	TTLAfterFinished *TFJobTTLAfterFinished `json:"ttlAfterFinished,omitempty"`
+
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.
 	// For example,
@@ -77,6 +82,13 @@ type TFReplicaSpec struct {
 
 // CleanPodPolicy describes how to deal with pods when the TFJob is finished.
 type CleanPodPolicy string
+
+// TFJobTTLAfterFinished uses a duration string to describe the timeout of
+// cleanup tf-jobs.  A duration string is a possibly signed sequence of
+// decimal numbers, each with optional fraction and a unit suffix,
+// such as "300ms", "-1.5h" or "2h45m".
+// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+type TFJobTTLAfterFinished string
 
 const (
 	CleanPodPolicyUndefined CleanPodPolicy = ""

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -51,7 +51,7 @@ type TFJobSpec struct {
 	// TTL to clean up tf-jobs (temporary before kubernetes adds the
 	// cleanup controller).
 	// Default to infinite.
-	TTLAfterFinished *TFJobTTLAfterFinished `json:"ttlAfterFinished,omitempty"`
+	TTLAfterFinished *TTLAfterFinished `json:"ttlAfterFinished,omitempty"`
 
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.
@@ -83,12 +83,12 @@ type TFReplicaSpec struct {
 // CleanPodPolicy describes how to deal with pods when the TFJob is finished.
 type CleanPodPolicy string
 
-// TFJobTTLAfterFinished uses a duration string to describe the timeout of
+// TTLAfterFinished uses a duration string to describe the timeout of
 // cleanup tf-jobs.  A duration string is a possibly signed sequence of
 // decimal numbers, each with optional fraction and a unit suffix,
 // such as "300ms", "-1.5h" or "2h45m".
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-type TFJobTTLAfterFinished string
+type TTLAfterFinished string
 
 const (
 	CleanPodPolicyUndefined CleanPodPolicy = ""

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,12 +48,12 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
-	// TTLSecondsAfterFinishing is the TTL to clean up tf-jobs (temporary
+	// TTLSecondsAfterFinished is the TTL to clean up tf-jobs (temporary
 	// before kubernetes adds the cleanup controller).
 	// It may take extra ReconcilePeriod seconds for the cleanup, since
 	// reconcile gets called periodically.
 	// Default to infinite.
-	TTLSecondsAfterFinishing *int32 `json:"ttlSecondsAfterFinishing,omitempty"`
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinishing,omitempty"`
 
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,10 +48,10 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
-	// TTL to clean up tf-jobs (temporary before kubernetes adds the
-	// cleanup controller).
+	// TTLSecondsAfterFinishing is the TTL to clean up tf-jobs (temporary
+	// before kubernetes adds the cleanup controller).
 	// Default to infinite.
-	TTLAfterFinished *TTLAfterFinished `json:"ttlAfterFinished,omitempty"`
+	TTLSecondsAfterFinishing *int32 `json:"ttlSecondsAfterFinishing,omitempty"`
 
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.
@@ -82,13 +82,6 @@ type TFReplicaSpec struct {
 
 // CleanPodPolicy describes how to deal with pods when the TFJob is finished.
 type CleanPodPolicy string
-
-// TTLAfterFinished uses a duration string to describe the timeout of
-// cleanup tf-jobs.  A duration string is a possibly signed sequence of
-// decimal numbers, each with optional fraction and a unit suffix,
-// such as "300ms", "-1.5h" or "2h45m".
-// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-type TTLAfterFinished string
 
 const (
 	CleanPodPolicyUndefined CleanPodPolicy = ""

--- a/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
@@ -109,9 +109,9 @@ func (in *TFJobSpec) DeepCopyInto(out *TFJobSpec) {
 		*out = new(CleanPodPolicy)
 		**out = **in
 	}
-	if in.TTLAfterFinished != nil {
-		in, out := &in.TTLAfterFinished, &out.TTLAfterFinished
-		*out = new(TTLAfterFinished)
+	if in.TTLSecondsAfterFinishing != nil {
+		in, out := &in.TTLSecondsAfterFinishing, &out.TTLSecondsAfterFinishing
+		*out = new(int32)
 		**out = **in
 	}
 	if in.TFReplicaSpecs != nil {

--- a/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
@@ -111,7 +111,7 @@ func (in *TFJobSpec) DeepCopyInto(out *TFJobSpec) {
 	}
 	if in.TTLAfterFinished != nil {
 		in, out := &in.TTLAfterFinished, &out.TTLAfterFinished
-		*out = new(TFJobTTLAfterFinished)
+		*out = new(TTLAfterFinished)
 		**out = **in
 	}
 	if in.TFReplicaSpecs != nil {

--- a/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
@@ -109,8 +109,8 @@ func (in *TFJobSpec) DeepCopyInto(out *TFJobSpec) {
 		*out = new(CleanPodPolicy)
 		**out = **in
 	}
-	if in.TTLSecondsAfterFinishing != nil {
-		in, out := &in.TTLSecondsAfterFinishing, &out.TTLSecondsAfterFinishing
+	if in.TTLSecondsAfterFinished != nil {
+		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/tensorflow/v1alpha2/zz_generated.deepcopy.go
@@ -109,6 +109,11 @@ func (in *TFJobSpec) DeepCopyInto(out *TFJobSpec) {
 		*out = new(CleanPodPolicy)
 		**out = **in
 	}
+	if in.TTLAfterFinished != nil {
+		in, out := &in.TTLAfterFinished, &out.TTLAfterFinished
+		*out = new(TFJobTTLAfterFinished)
+		**out = **in
+	}
 	if in.TFReplicaSpecs != nil {
 		in, out := &in.TFReplicaSpecs, &out.TFReplicaSpecs
 		*out = make(map[TFReplicaType]*TFReplicaSpec, len(*in))

--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -473,6 +473,10 @@ func (tc *TFJobController) reconcileTFJobs(tfjob *tfv1alpha2.TFJob) error {
 			return err
 		}
 
+		if err := tc.cleanupTFJob(tfjob); err != nil {
+			return err
+		}
+
 		if tc.config.enableGangScheduling {
 			if err := tc.deletePdb(tfjob); err != nil {
 				return err

--- a/pkg/controller.v2/controller.go
+++ b/pkg/controller.v2/controller.go
@@ -111,6 +111,9 @@ type TFJobController struct {
 	// To allow injection of updateStatus for testing.
 	updateStatusHandler func(tfjob *tfv1alpha2.TFJob) error
 
+	// To allow injection of deleteTFJob for testing.
+	deleteTFJobHandler func(tfjob *tfv1alpha2.TFJob) error
+
 	// tfJobInformer is a temporary field for unstructured informer support.
 	tfJobInformer cache.SharedIndexInformer
 
@@ -211,6 +214,8 @@ func NewTFJobController(
 	// Set sync handler.
 	tc.syncHandler = tc.syncTFJob
 	tc.updateStatusHandler = tc.updateTFJobStatus
+	// set delete handler.
+	tc.deleteTFJobHandler = tc.deleteTFJob
 
 	// Set up an event handler for when tfjob resources change.
 	tfJobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controller.v2/controller_tfjob.go
+++ b/pkg/controller.v2/controller_tfjob.go
@@ -129,7 +129,7 @@ func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 		return nil
 	}
 	if currentTime.After(tfJob.Status.CompletionTime.Add(duration)) {
-		err := tc.tfJobClientSet.KubeflowV1alpha2().TFJobs(tfJob.Namespace).Delete(tfJob.Name, &metav1.DeleteOptions{})
+		err := tc.deleteTFJobHandler(tfJob)
 		if err != nil {
 			log.Warnf("Cleanup TFJob error: %v.", err)
 			return err
@@ -138,11 +138,15 @@ func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 	}
 	go func() {
 		time.Sleep(duration)
-		err := tc.tfJobClientSet.KubeflowV1alpha2().TFJobs(tfJob.Namespace).Delete(tfJob.Name, &metav1.DeleteOptions{})
+		err := tc.deleteTFJobHandler(tfJob)
 		if err != nil {
 			log.Warnf("Cleanup TFJob error: %v.", err)
 		}
-
 	}()
 	return nil
+}
+
+// deleteTFJob delets the given TFJob.
+func (tc *TFJobController) deleteTFJob(tfJob *tfv1alpha2.TFJob) error {
+	return tc.tfJobClientSet.KubeflowV1alpha2().TFJobs(tfJob.Namespace).Delete(tfJob.Name, &metav1.DeleteOptions{})
 }

--- a/pkg/controller.v2/controller_tfjob.go
+++ b/pkg/controller.v2/controller_tfjob.go
@@ -118,7 +118,7 @@ func (tc *TFJobController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods [
 
 func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 	currentTime := time.Now()
-	ttl := tfJob.Spec.TTLSecondsAfterFinishing
+	ttl := tfJob.Spec.TTLSecondsAfterFinished
 	if ttl == nil {
 		// do nothing if the cleanup delay is not set
 		return nil
@@ -127,14 +127,14 @@ func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 	if currentTime.After(tfJob.Status.CompletionTime.Add(duration)) {
 		err := tc.deleteTFJobHandler(tfJob)
 		if err != nil {
-			log.Warnf("Cleanup TFJob error: %v.", err)
+			loggerForTFJob(tfJob).Warnf("Cleanup TFJob error: %v.", err)
 			return err
 		}
 		return nil
 	}
 	key, err := KeyFunc(tfJob)
 	if err != nil {
-		log.Warnf("Couldn't get key for tfjob object %#v: %v", tfJob, err)
+		loggerForTFJob(tfJob).Warnf("Couldn't get key for tfjob object: %v", err)
 		return err
 	}
 	tc.workQueue.AddRateLimited(key)

--- a/pkg/controller.v2/controller_tfjob_test.go
+++ b/pkg/controller.v2/controller_tfjob_test.go
@@ -367,7 +367,7 @@ func TestCleanupTFJob(t *testing.T) {
 	ttl2s := &ttlaf2s
 	testCases := []testCase{
 		testCase{
-			description: "4 workers and 2 ps is running, TTLSecondsAfterFinishing unset",
+			description: "4 workers and 2 ps is running, TTLSecondsAfterFinished unset",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, nil),
 
 			pendingWorkerPods:   0,
@@ -386,7 +386,7 @@ func TestCleanupTFJob(t *testing.T) {
 			expectedDeleteFinished: false,
 		},
 		testCase{
-			description: "4 workers and 2 ps is running, TTLSecondsAfterFinishing is 0",
+			description: "4 workers and 2 ps is running, TTLSecondsAfterFinished is 0",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl0),
 
 			pendingWorkerPods:   0,
@@ -405,7 +405,7 @@ func TestCleanupTFJob(t *testing.T) {
 			expectedDeleteFinished: true,
 		},
 		testCase{
-			description: "4 workers and 2 ps is succeeded, TTLSecondsAfterFinishing is 2",
+			description: "4 workers and 2 ps is succeeded, TTLSecondsAfterFinished is 2",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl2s),
 
 			pendingWorkerPods:   0,
@@ -484,7 +484,7 @@ func TestCleanupTFJob(t *testing.T) {
 		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelWorker, tc.activeWorkerServices, t)
 		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelPS, tc.activePSServices, t)
 
-		ttl := tc.tfJob.Spec.TTLSecondsAfterFinishing
+		ttl := tc.tfJob.Spec.TTLSecondsAfterFinished
 		if ttl != nil {
 			dur := time.Second * time.Duration(*ttl)
 			time.Sleep(dur)

--- a/pkg/controller.v2/controller_tfjob_test.go
+++ b/pkg/controller.v2/controller_tfjob_test.go
@@ -361,13 +361,13 @@ func TestCleanupTFJob(t *testing.T) {
 		expectedDeleteFinished bool
 	}
 
-	ttlaf0 := tfv1alpha2.TTLAfterFinished("0")
+	ttlaf0 := int32(0)
 	ttl0 := &ttlaf0
-	ttlaf2s := tfv1alpha2.TTLAfterFinished("2s")
+	ttlaf2s := int32(2)
 	ttl2s := &ttlaf2s
 	testCases := []testCase{
 		testCase{
-			description: "4 workers and 2 ps is running, TTLAfterFinished unset",
+			description: "4 workers and 2 ps is running, TTLSecondsAfterFinishing unset",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, nil),
 
 			pendingWorkerPods:   0,
@@ -386,7 +386,7 @@ func TestCleanupTFJob(t *testing.T) {
 			expectedDeleteFinished: false,
 		},
 		testCase{
-			description: "4 workers and 2 ps is running, TTLAfterFinished is 0",
+			description: "4 workers and 2 ps is running, TTLSecondsAfterFinishing is 0",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl0),
 
 			pendingWorkerPods:   0,
@@ -405,7 +405,7 @@ func TestCleanupTFJob(t *testing.T) {
 			expectedDeleteFinished: true,
 		},
 		testCase{
-			description: "4 workers and 2 ps is succeeded, TTLAfterFinished is 2 second",
+			description: "4 workers and 2 ps is succeeded, TTLSecondsAfterFinishing is 2",
 			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl2s),
 
 			pendingWorkerPods:   0,
@@ -484,9 +484,9 @@ func TestCleanupTFJob(t *testing.T) {
 		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelWorker, tc.activeWorkerServices, t)
 		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelPS, tc.activePSServices, t)
 
-		ttl := tc.tfJob.Spec.TTLAfterFinished
+		ttl := tc.tfJob.Spec.TTLSecondsAfterFinishing
 		if ttl != nil {
-			dur, _ := time.ParseDuration(string(*ttl))
+			dur := time.Second * time.Duration(*ttl)
 			time.Sleep(dur)
 		}
 

--- a/pkg/controller.v2/controller_tfjob_test.go
+++ b/pkg/controller.v2/controller_tfjob_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
@@ -67,6 +68,9 @@ func TestAddTFJob(t *testing.T) {
 		return true, nil
 	}
 	ctr.updateStatusHandler = func(tfjob *tfv1alpha2.TFJob) error {
+		return nil
+	}
+	ctr.deleteTFJobHandler = func(tfjob *tfv1alpha2.TFJob) error {
 		return nil
 	}
 
@@ -332,6 +336,170 @@ func TestDeletePodsAndServices(t *testing.T) {
 		}
 		if len(fakeServiceControl.DeleteServiceName) != tc.expectedPodDeletions {
 			t.Errorf("%s: unexpected number of service deletes.  Expected %d, saw %d\n", tc.description, tc.expectedPodDeletions, len(fakeServiceControl.DeleteServiceName))
+		}
+	}
+}
+
+func TestCleanupTFJob(t *testing.T) {
+	type testCase struct {
+		description string
+		tfJob       *tfv1alpha2.TFJob
+
+		pendingWorkerPods   int32
+		activeWorkerPods    int32
+		succeededWorkerPods int32
+		failedWorkerPods    int32
+
+		pendingPSPods   int32
+		activePSPods    int32
+		succeededPSPods int32
+		failedPSPods    int32
+
+		activeWorkerServices int32
+		activePSServices     int32
+
+		expectedDeleteFinished bool
+	}
+
+	ttlaf0 := tfv1alpha2.TTLAfterFinished("0")
+	ttl0 := &ttlaf0
+	ttlaf2s := tfv1alpha2.TTLAfterFinished("2s")
+	ttl2s := &ttlaf2s
+	testCases := []testCase{
+		testCase{
+			description: "4 workers and 2 ps is running, TTLAfterFinished unset",
+			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, nil),
+
+			pendingWorkerPods:   0,
+			activeWorkerPods:    4,
+			succeededWorkerPods: 0,
+			failedWorkerPods:    0,
+
+			pendingPSPods:   0,
+			activePSPods:    2,
+			succeededPSPods: 0,
+			failedPSPods:    0,
+
+			activeWorkerServices: 4,
+			activePSServices:     2,
+
+			expectedDeleteFinished: false,
+		},
+		testCase{
+			description: "4 workers and 2 ps is running, TTLAfterFinished is 0",
+			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl0),
+
+			pendingWorkerPods:   0,
+			activeWorkerPods:    4,
+			succeededWorkerPods: 0,
+			failedWorkerPods:    0,
+
+			pendingPSPods:   0,
+			activePSPods:    2,
+			succeededPSPods: 0,
+			failedPSPods:    0,
+
+			activeWorkerServices: 4,
+			activePSServices:     2,
+
+			expectedDeleteFinished: true,
+		},
+		testCase{
+			description: "4 workers and 2 ps is succeeded, TTLAfterFinished is 2 second",
+			tfJob:       testutil.NewTFJobWithCleanupJobDelay(0, 4, 2, ttl2s),
+
+			pendingWorkerPods:   0,
+			activeWorkerPods:    0,
+			succeededWorkerPods: 4,
+			failedWorkerPods:    0,
+
+			pendingPSPods:   0,
+			activePSPods:    0,
+			succeededPSPods: 2,
+			failedPSPods:    0,
+
+			activeWorkerServices: 4,
+			activePSServices:     2,
+
+			expectedDeleteFinished: true,
+		},
+	}
+	for _, tc := range testCases {
+		// Prepare the clientset and controller for the test.
+		kubeClientSet := kubeclientset.NewForConfigOrDie(&rest.Config{
+			Host: "",
+			ContentConfig: rest.ContentConfig{
+				GroupVersion: &v1.SchemeGroupVersion,
+			},
+		},
+		)
+		config := &rest.Config{
+			Host: "",
+			ContentConfig: rest.ContentConfig{
+				GroupVersion: &tfv1alpha2.SchemeGroupVersion,
+			},
+		}
+		tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
+		ctr, kubeInformerFactory, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+		fakePodControl := &controller.FakePodControl{}
+		ctr.podControl = fakePodControl
+		fakeServiceControl := &control.FakeServiceControl{}
+		ctr.serviceControl = fakeServiceControl
+		ctr.recorder = &record.FakeRecorder{}
+		ctr.tfJobInformerSynced = testutil.AlwaysReady
+		ctr.podInformerSynced = testutil.AlwaysReady
+		ctr.serviceInformerSynced = testutil.AlwaysReady
+		tfJobIndexer := ctr.tfJobInformer.GetIndexer()
+		ctr.updateStatusHandler = func(tfJob *tfv1alpha2.TFJob) error {
+			return nil
+		}
+		deleteFinished := false
+		ctr.deleteTFJobHandler = func(tfJob *tfv1alpha2.TFJob) error {
+			deleteFinished = true
+			return nil
+		}
+
+		// Set succeeded to run the logic about deleting.
+		testutil.SetTFJobCompletionTime(tc.tfJob)
+
+		err := updateTFJobConditions(tc.tfJob, tfv1alpha2.TFJobSucceeded, tfJobSucceededReason, "")
+		if err != nil {
+			t.Errorf("Append tfjob condition error: %v", err)
+		}
+
+		unstructured, err := generator.ConvertTFJobToUnstructured(tc.tfJob)
+		if err != nil {
+			t.Errorf("Failed to convert the TFJob to Unstructured: %v", err)
+		}
+
+		if err := tfJobIndexer.Add(unstructured); err != nil {
+			t.Errorf("Failed to add tfjob to tfJobIndexer: %v", err)
+		}
+
+		podIndexer := kubeInformerFactory.Core().V1().Pods().Informer().GetIndexer()
+		testutil.SetPodsStatuses(podIndexer, tc.tfJob, testutil.LabelWorker, tc.pendingWorkerPods, tc.activeWorkerPods, tc.succeededWorkerPods, tc.failedWorkerPods, t)
+		testutil.SetPodsStatuses(podIndexer, tc.tfJob, testutil.LabelPS, tc.pendingPSPods, tc.activePSPods, tc.succeededPSPods, tc.failedPSPods, t)
+
+		serviceIndexer := kubeInformerFactory.Core().V1().Services().Informer().GetIndexer()
+		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelWorker, tc.activeWorkerServices, t)
+		testutil.SetServices(serviceIndexer, tc.tfJob, testutil.LabelPS, tc.activePSServices, t)
+
+		ttl := tc.tfJob.Spec.TTLAfterFinished
+		if ttl != nil {
+			dur, _ := time.ParseDuration(string(*ttl))
+			time.Sleep(dur)
+		}
+
+		forget, err := ctr.syncTFJob(testutil.GetKey(tc.tfJob, t))
+		if err != nil {
+			t.Errorf("%s: unexpected error when syncing jobs %v", tc.description, err)
+		}
+		if !forget {
+			t.Errorf("%s: unexpected forget value. Expected true, saw %v\n", tc.description, forget)
+		}
+
+		if deleteFinished != tc.expectedDeleteFinished {
+			t.Errorf("%s: unexpected status. Expected %v, saw %v", tc.description, tc.expectedDeleteFinished, deleteFinished)
 		}
 	}
 }

--- a/pkg/util/testutil/tfjob.go
+++ b/pkg/util/testutil/tfjob.go
@@ -37,13 +37,13 @@ func NewTFJobWithCleanPolicy(chief, worker, ps int, policy tfv1alpha2.CleanPodPo
 func NewTFJobWithCleanupJobDelay(chief, worker, ps int, ttl *int32) *tfv1alpha2.TFJob {
 	if chief == 1 {
 		tfJob := NewTFJobWithChief(worker, ps)
-		tfJob.Spec.TTLSecondsAfterFinishing = ttl
+		tfJob.Spec.TTLSecondsAfterFinished = ttl
 		policy := tfv1alpha2.CleanPodPolicyNone
 		tfJob.Spec.CleanPodPolicy = &policy
 		return tfJob
 	}
 	tfJob := NewTFJob(worker, ps)
-	tfJob.Spec.TTLSecondsAfterFinishing = ttl
+	tfJob.Spec.TTLSecondsAfterFinished = ttl
 	policy := tfv1alpha2.CleanPodPolicyNone
 	tfJob.Spec.CleanPodPolicy = &policy
 	return tfJob

--- a/pkg/util/testutil/tfjob.go
+++ b/pkg/util/testutil/tfjob.go
@@ -15,6 +15,8 @@
 package testutil
 
 import (
+	"time"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,6 +30,21 @@ func NewTFJobWithCleanPolicy(chief, worker, ps int, policy tfv1alpha2.CleanPodPo
 		return tfJob
 	}
 	tfJob := NewTFJob(worker, ps)
+	tfJob.Spec.CleanPodPolicy = &policy
+	return tfJob
+}
+
+func NewTFJobWithCleanupJobDelay(chief, worker, ps int, ttl *tfv1alpha2.TTLAfterFinished) *tfv1alpha2.TFJob {
+	if chief == 1 {
+		tfJob := NewTFJobWithChief(worker, ps)
+		tfJob.Spec.TTLAfterFinished = ttl
+		policy := tfv1alpha2.CleanPodPolicyNone
+		tfJob.Spec.CleanPodPolicy = &policy
+		return tfJob
+	}
+	tfJob := NewTFJob(worker, ps)
+	tfJob.Spec.TTLAfterFinished = ttl
+	policy := tfv1alpha2.CleanPodPolicyNone
 	tfJob.Spec.CleanPodPolicy = &policy
 	return tfJob
 }
@@ -104,4 +121,9 @@ func NewTFReplicaSpecTemplate() v1.PodTemplateSpec {
 			},
 		},
 	}
+}
+
+func SetTFJobCompletionTime(tfJob *tfv1alpha2.TFJob) {
+	now := metav1.Time{Time: time.Now()}
+	tfJob.Status.CompletionTime = &now
 }

--- a/pkg/util/testutil/tfjob.go
+++ b/pkg/util/testutil/tfjob.go
@@ -34,16 +34,16 @@ func NewTFJobWithCleanPolicy(chief, worker, ps int, policy tfv1alpha2.CleanPodPo
 	return tfJob
 }
 
-func NewTFJobWithCleanupJobDelay(chief, worker, ps int, ttl *tfv1alpha2.TTLAfterFinished) *tfv1alpha2.TFJob {
+func NewTFJobWithCleanupJobDelay(chief, worker, ps int, ttl *int32) *tfv1alpha2.TFJob {
 	if chief == 1 {
 		tfJob := NewTFJobWithChief(worker, ps)
-		tfJob.Spec.TTLAfterFinished = ttl
+		tfJob.Spec.TTLSecondsAfterFinishing = ttl
 		policy := tfv1alpha2.CleanPodPolicyNone
 		tfJob.Spec.CleanPodPolicy = &policy
 		return tfJob
 	}
 	tfJob := NewTFJob(worker, ps)
-	tfJob.Spec.TTLAfterFinished = ttl
+	tfJob.Spec.TTLSecondsAfterFinishing = ttl
 	policy := tfv1alpha2.CleanPodPolicyNone
 	tfJob.Spec.CleanPodPolicy = &policy
 	return tfJob


### PR DESCRIPTION
If the ttl is not set, the tf-job will not be cleaned up

This is a temporary solution before the ``cleanup controller'' is implemented
in kubernetes.

#718

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/753)
<!-- Reviewable:end -->
