### PR TITLE
Improve meta information in log messages to make it easier to debug jobs

### DIFF
--- a/cmd/tf-operator.v2/app/options/options.go
+++ b/cmd/tf-operator.v2/app/options/options.go
@@ -45,7 +45,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 
-	fs.BoolVar(&s.JSONLogFormat, "json-log-format", false,
+	fs.BoolVar(&s.JSONLogFormat, "json-log-format", true,
 		"Set true to use json style log format. Set false to use plaintext style log format")
 	fs.BoolVar(&s.EnableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling by kube-arbitrator.")
 }

--- a/pkg/controller.v2/controller_logger.go
+++ b/pkg/controller.v2/controller_logger.go
@@ -17,11 +17,12 @@ package controller
 import (
 	log "github.com/sirupsen/logrus"
 
+	"strings"
+
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"strings"
 )
 
 func loggerForReplica(tfjob *tfv1alpha2.TFJob, rtype string) *log.Entry {
@@ -67,7 +68,7 @@ func loggerForKey(key string) *log.Entry {
 	})
 }
 
-func loggerForUnstructured(obj *metav1unstructured.Unstructured) *log.Entry{
+func loggerForUnstructured(obj *metav1unstructured.Unstructured) *log.Entry {
 	job := ""
 	if obj.GetKind() == tfv1alpha2.Kind {
 		job = obj.GetNamespace() + "." + obj.GetName()

--- a/pkg/controller.v2/controller_tfjob.go
+++ b/pkg/controller.v2/controller_tfjob.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	tfv1alpha2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha2"
@@ -22,11 +23,16 @@ func (tc *TFJobController) addTFJob(obj interface{}) {
 	// Convert from unstructured object.
 	tfJob, err := tfJobFromUnstructured(obj)
 	if err != nil {
-		log.Errorf("Failed to convert the TFJob: %v", err)
+		un, ok := obj.(*metav1unstructured.Unstructured)
+		logger := &log.Entry{}
+		if ok {
+			logger = loggerForUnstructured(un)
+		}
+		logger.Errorf("Failed to convert the TFJob: %v", err)
 		// Log the failure to conditions.
 		if err == errFailedMarshal {
 			errMsg := fmt.Sprintf("Failed to unmarshal the object to TFJob object: %v", err)
-			log.Warn(errMsg)
+			logger.Warn(errMsg)
 			tc.recorder.Event(tfJob, v1.EventTypeWarning, failedMarshalTFJobReason, errMsg)
 		}
 		return
@@ -36,19 +42,20 @@ func (tc *TFJobController) addTFJob(obj interface{}) {
 	scheme.Scheme.Default(tfJob)
 
 	msg := fmt.Sprintf("TFJob %s is created.", tfJob.Name)
-	log.Info(msg)
+	logger := loggerForTFJob(tfJob)
+	logger.Info(msg)
 
 	// Add a created condition.
 	err = updateTFJobConditions(tfJob, tfv1alpha2.TFJobCreated, tfJobCreatedReason, msg)
 	if err != nil {
-		log.Infof("Append tfJob condition error: %v", err)
+		logger.Errorf("Append tfJob condition error: %v", err)
 		return
 	}
 
 	// Convert from tfjob object
 	err = unstructuredFromTFJob(obj, tfJob)
 	if err != nil {
-		log.Error("Failed to convert the obj: %v", err)
+		logger.Error("Failed to convert the obj: %v", err)
 		return
 	}
 	tc.enqueueTFJob(obj)


### PR DESCRIPTION
* Use <namespace>.<name> as opposed to <namespace>/<name>; the former
  is more consistent with K8s style.

* Add functions for constructing loggers for the pod and unstructured meta
  information. This will allow us to appropriately tag a number of log
  messages with meta information.

* Update a bunch of log messages which weren't logging info with
  appropriate meta information.

* Make json log formatting the default; this was the case for v1.
  json logging should be the default because otherwise we lose the meta
  information in the logs. With json logs its always possible to filter/reformat
  the log entries if you don't care about the metainformation.

Related to:
  #24 Use logrus
  #635

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/765)
<!-- Reviewable:end -->
