### PR TITLE
TFCONFIG needs to set environment:cloud to support older versions.

### DIFF
--- a/pkg/controller.v2/controller_pod_test.go
+++ b/pkg/controller.v2/controller_pod_test.go
@@ -98,7 +98,7 @@ func TestClusterSpec(t *testing.T) {
 			rt:    "worker",
 			index: "0",
 			expectedClusterSpec: `{"cluster":{"worker":["` + testutil.TestTFJobName +
-				`-worker-0:2222"]},"task":{"type":"worker","index":0}}`,
+				`-worker-0:2222"]},"task":{"type":"worker","index":0},"environment":"cloud"}`,
 		},
 		tc{
 			tfJob: testutil.NewTFJob(1, 1),
@@ -106,7 +106,7 @@ func TestClusterSpec(t *testing.T) {
 			index: "0",
 			expectedClusterSpec: `{"cluster":{"ps":["` + testutil.TestTFJobName +
 				`-ps-0:2222"],"worker":["` + testutil.TestTFJobName +
-				`-worker-0:2222"]},"task":{"type":"worker","index":0}}`,
+				`-worker-0:2222"]},"task":{"type":"worker","index":0},"environment":"cloud"}`,
 		},
 		tc{
 			tfJob: testutil.NewTFJobWithEvaluator(1, 1, 1),
@@ -114,7 +114,7 @@ func TestClusterSpec(t *testing.T) {
 			index: "0",
 			expectedClusterSpec: `{"cluster":{"ps":["` + testutil.TestTFJobName +
 				`-ps-0:2222"],"worker":["` + testutil.TestTFJobName +
-				`-worker-0:2222"]},"task":{"type":"worker","index":0}}`,
+				`-worker-0:2222"]},"task":{"type":"worker","index":0},"environment":"cloud"}`,
 		},
 	}
 	for _, c := range testCase {

--- a/pkg/controller.v2/controller_tensorflow.go
+++ b/pkg/controller.v2/controller_tensorflow.go
@@ -35,6 +35,9 @@ type TFConfig struct {
 	// See: https://www.tensorflow.org/api_docs/python/tf/train/ClusterSpec
 	Cluster ClusterSpec `json:"cluster"`
 	Task    TaskSpec    `json:"task"`
+	// Environment is used by tensorflow.contrib.learn.python.learn in versions <= 1.3
+	// TODO(jlewi): I don't think it is used in versions TF >- 1.4. So we can eventually get rid of it.
+	Environment string `json:"environment"`
 }
 
 // ClusterSpec represents a cluster TensorFlow specification.
@@ -78,6 +81,10 @@ func genTFConfigJSONStr(tfjob *tfv1alpha2.TFJob, rtype, index string) (string, e
 			Type:  rtype,
 			Index: int(i),
 		},
+		// We need to set environment to cloud  otherwise it will default to local which isn't what we want.
+		// Environment is used by tensorflow.contrib.learn.python.learn in versions <= 1.3
+		// TODO(jlewi): I don't think it is used in versions TF >- 1.4. So we can eventually get rid of it.
+		Environment: "cloud",
 	}
 
 	tfConfigJSONStr, err := json.Marshal(tfConfig)


### PR DESCRIPTION
* Older versions of TF (something like TF <=1.6) depend on the field
  environment in the TF_CONFIG to determine whether job is running distributed
  or not. We need to set it to environment: cloud so that it TF.estimator API
  will work correctly.

* Later versions of TF; e.g. TF 1.8 don't use the environment field. So
  the existence of the environment field should be a null op.

Related to: #761