### PR TITLE
WaitForJob should use conditions for v1alpha2.

### DIFF
--- a/py/util.py
+++ b/py/util.py
@@ -426,6 +426,15 @@ def setup_cluster(api_client):
 class TimeoutError(Exception):  # pylint: disable=redefined-builtin
   """An error indicating an operation timed out."""
 
+class JobTimeError(TimeoutError):
+  """An error indicating the job timed out.
+
+  The job spec/status can be found in .job.
+  """
+
+  def __init__(self, message, job):
+    super(JobTimeError, self).__init__(message)
+    self.job = job
 
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
 


### PR DESCRIPTION
* Now that #673 is fixed wait_for_job for v1alpha2 should for condition Succeeded or failed.

* If there is a timeout waiting for the job to finish include the job spec
  in the exception so we can print it out to see what the final status is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/771)
<!-- Reviewable:end -->
