### PR TITLE
Renaming TFJobController to TFController

### DIFF
--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -98,7 +98,7 @@ func Run(opt *options.ServerOption) error {
 	unstructuredInformer := controller.NewUnstructuredTFJobInformer(kcfg)
 
 	// Create tf controller.
-	tc := controller.NewTFJobController(unstructuredInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, *opt)
+	tc := controller.NewTFController(unstructuredInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, *opt)
 
 	// Start informer goroutines.
 	go kubeInformerFactory.Start(stopCh)

--- a/pkg/controller.v2/tfcontroller/informer.go
+++ b/pkg/controller.v2/tfcontroller/informer.go
@@ -55,16 +55,16 @@ func NewUnstructuredTFJobInformer(restConfig *restclientset.Config) tfjobinforme
 }
 
 // NewTFJobInformer returns TFJobInformer from the given factory.
-func (tc *TFJobController) NewTFJobInformer(tfJobInformerFactory tfjobinformers.SharedInformerFactory) tfjobinformersv1alpha2.TFJobInformer {
+func (tc *TFController) NewTFJobInformer(tfJobInformerFactory tfjobinformers.SharedInformerFactory) tfjobinformersv1alpha2.TFJobInformer {
 	return tfJobInformerFactory.Kubeflow().V1alpha2().TFJobs()
 }
 
-func (tc *TFJobController) getTFJobFromName(namespace, name string) (*tfv1alpha2.TFJob, error) {
+func (tc *TFController) getTFJobFromName(namespace, name string) (*tfv1alpha2.TFJob, error) {
 	key := fmt.Sprintf("%s/%s", namespace, name)
 	return tc.getTFJobFromKey(key)
 }
 
-func (tc *TFJobController) getTFJobFromKey(key string) (*tfv1alpha2.TFJob, error) {
+func (tc *TFController) getTFJobFromKey(key string) (*tfv1alpha2.TFJob, error) {
 	// Check if the key exists.
 	obj, exists, err := tc.tfJobInformer.GetIndexer().GetByKey(key)
 	logger := tflogger.LoggerForKey(key)

--- a/pkg/controller.v2/tfcontroller/pod.go
+++ b/pkg/controller.v2/tfcontroller/pod.go
@@ -44,7 +44,7 @@ const (
 
 // reconcilePods checks and updates pods for each given TFReplicaSpec.
 // It will requeue the tfjob in case of an error while creating/deleting pods.
-func (tc *TFJobController) reconcilePods(
+func (tc *TFController) reconcilePods(
 	tfjob *tfv1alpha2.TFJob,
 	pods []*v1.Pod,
 	rtype tfv1alpha2.TFReplicaType,
@@ -125,7 +125,7 @@ func getPodSlices(pods []*v1.Pod, replicas int, logger *log.Entry) [][]*v1.Pod {
 }
 
 // createNewPod creates a new pod for the given index and type.
-func (tc *TFJobController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, spec *tfv1alpha2.TFReplicaSpec) error {
+func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, spec *tfv1alpha2.TFReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))

--- a/pkg/controller.v2/tfcontroller/pod_test.go
+++ b/pkg/controller.v2/tfcontroller/pod_test.go
@@ -45,7 +45,7 @@ func TestAddPod(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	ctr.tfJobInformerSynced = testutil.AlwaysReady
 	ctr.PodInformerSynced = testutil.AlwaysReady
 	ctr.ServiceInformerSynced = testutil.AlwaysReady
@@ -202,7 +202,7 @@ func TestExitCode(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, kubeInformerFactory, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, kubeInformerFactory, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	fakePodControl := &controller.FakePodControl{}
 	ctr.PodControl = fakePodControl
 	ctr.tfJobInformerSynced = testutil.AlwaysReady

--- a/pkg/controller.v2/tfcontroller/service.go
+++ b/pkg/controller.v2/tfcontroller/service.go
@@ -34,7 +34,7 @@ import (
 
 // reconcileServices checks and updates services for each given TFReplicaSpec.
 // It will requeue the tfjob in case of an error while creating/deleting services.
-func (tc *TFJobController) reconcileServices(
+func (tc *TFController) reconcileServices(
 	tfjob *tfv1alpha2.TFJob,
 	services []*v1.Service,
 	rtype tfv1alpha2.TFReplicaType,
@@ -93,7 +93,7 @@ func getServiceSlices(services []*v1.Service, replicas int, logger *log.Entry) [
 }
 
 // createNewService creates a new service for the given index and type.
-func (tc *TFJobController) createNewService(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType, index string, spec *tfv1alpha2.TFReplicaSpec) error {
+func (tc *TFController) createNewService(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType, index string, spec *tfv1alpha2.TFReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))

--- a/pkg/controller.v2/tfcontroller/service_test.go
+++ b/pkg/controller.v2/tfcontroller/service_test.go
@@ -45,7 +45,7 @@ func TestAddService(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	ctr.tfJobInformerSynced = testutil.AlwaysReady
 	ctr.PodInformerSynced = testutil.AlwaysReady
 	ctr.ServiceInformerSynced = testutil.AlwaysReady

--- a/pkg/controller.v2/tfcontroller/status.go
+++ b/pkg/controller.v2/tfcontroller/status.go
@@ -119,7 +119,7 @@ func updateStatusSingle(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType,
 }
 
 // updateTFJobStatus updates the status of the given TFJob.
-func (tc *TFJobController) updateTFJobStatus(tfjob *tfv1alpha2.TFJob) error {
+func (tc *TFController) updateTFJobStatus(tfjob *tfv1alpha2.TFJob) error {
 	_, err := tc.tfJobClientSet.KubeflowV1alpha2().TFJobs(tfjob.Namespace).Update(tfjob)
 	return err
 }

--- a/pkg/controller.v2/tfcontroller/tfcontroller_test.go
+++ b/pkg/controller.v2/tfcontroller/tfcontroller_test.go
@@ -44,14 +44,14 @@ var (
 	tfJobSucceeded = tfv1alpha2.TFJobSucceeded
 )
 
-func newTFJobController(
+func newTFController(
 	config *rest.Config,
 	kubeClientSet kubeclientset.Interface,
 	tfJobClientSet tfjobclientset.Interface,
 	resyncPeriod controller.ResyncPeriodFunc,
 	option options.ServerOption,
 ) (
-	*TFJobController,
+	*TFController,
 	kubeinformers.SharedInformerFactory, tfjobinformers.SharedInformerFactory,
 ) {
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClientSet, resyncPeriod())
@@ -59,7 +59,7 @@ func newTFJobController(
 
 	tfJobInformer := NewUnstructuredTFJobInformer(config)
 
-	ctr := NewTFJobController(tfJobInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, option)
+	ctr := NewTFController(tfJobInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, option)
 	ctr.PodControl = &controller.FakePodControl{}
 	ctr.ServiceControl = &control.FakeServiceControl{}
 	return ctr, kubeInformerFactory, tfJobInformerFactory
@@ -222,7 +222,7 @@ func TestNormalPath(t *testing.T) {
 		}
 		option := options.ServerOption{}
 		tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-		ctr, kubeInformerFactory, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, option)
+		ctr, kubeInformerFactory, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, option)
 		ctr.tfJobInformerSynced = testutil.AlwaysReady
 		ctr.PodInformerSynced = testutil.AlwaysReady
 		ctr.ServiceInformerSynced = testutil.AlwaysReady
@@ -352,7 +352,7 @@ func TestRun(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	ctr.tfJobInformerSynced = testutil.AlwaysReady
 	ctr.PodInformerSynced = testutil.AlwaysReady
 	ctr.ServiceInformerSynced = testutil.AlwaysReady
@@ -383,7 +383,7 @@ func TestSyncPdb(t *testing.T) {
 	option := options.ServerOption{
 		EnableGangScheduling: true,
 	}
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, option)
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, option)
 
 	type testCase struct {
 		tfJob     *tfv1alpha2.TFJob

--- a/pkg/controller.v2/tfcontroller/tfjob.go
+++ b/pkg/controller.v2/tfcontroller/tfjob.go
@@ -20,7 +20,7 @@ const (
 )
 
 // When a pod is added, set the defaults and enqueue the current tfjob.
-func (tc *TFJobController) addTFJob(obj interface{}) {
+func (tc *TFController) addTFJob(obj interface{}) {
 	// Convert from unstructured object.
 	tfJob, err := tfJobFromUnstructured(obj)
 	if err != nil {
@@ -63,7 +63,7 @@ func (tc *TFJobController) addTFJob(obj interface{}) {
 }
 
 // When a pod is updated, enqueue the current tfjob.
-func (tc *TFJobController) updateTFJob(old, cur interface{}) {
+func (tc *TFController) updateTFJob(old, cur interface{}) {
 	oldTFJob, err := tfJobFromUnstructured(old)
 	if err != nil {
 		return
@@ -72,7 +72,7 @@ func (tc *TFJobController) updateTFJob(old, cur interface{}) {
 	tc.enqueueTFJob(cur)
 }
 
-func (tc *TFJobController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods []*v1.Pod) error {
+func (tc *TFController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods []*v1.Pod) error {
 	if len(pods) == 0 {
 		return nil
 	}
@@ -99,7 +99,7 @@ func (tc *TFJobController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods [
 	return nil
 }
 
-func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
+func (tc *TFController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 	currentTime := time.Now()
 	ttl := tfJob.Spec.TTLSecondsAfterFinished
 	if ttl == nil {
@@ -125,6 +125,6 @@ func (tc *TFJobController) cleanupTFJob(tfJob *tfv1alpha2.TFJob) error {
 }
 
 // deleteTFJob delets the given TFJob.
-func (tc *TFJobController) deleteTFJob(tfJob *tfv1alpha2.TFJob) error {
+func (tc *TFController) deleteTFJob(tfJob *tfv1alpha2.TFJob) error {
 	return tc.tfJobClientSet.KubeflowV1alpha2().TFJobs(tfJob.Namespace).Delete(tfJob.Name, &metav1.DeleteOptions{})
 }

--- a/pkg/controller.v2/tfcontroller/tfjob_test.go
+++ b/pkg/controller.v2/tfcontroller/tfjob_test.go
@@ -47,7 +47,7 @@ func TestAddTFJob(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	ctr.tfJobInformerSynced = testutil.AlwaysReady
 	ctr.PodInformerSynced = testutil.AlwaysReady
 	ctr.ServiceInformerSynced = testutil.AlwaysReady
@@ -106,7 +106,7 @@ func TestCopyLabelsAndAnnotation(t *testing.T) {
 		},
 	}
 	tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-	ctr, _, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+	ctr, _, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 	fakePodControl := &controller.FakePodControl{}
 	ctr.PodControl = fakePodControl
 	ctr.tfJobInformerSynced = testutil.AlwaysReady
@@ -285,7 +285,7 @@ func TestDeletePodsAndServices(t *testing.T) {
 			},
 		}
 		tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-		ctr, kubeInformerFactory, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+		ctr, kubeInformerFactory, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 		fakePodControl := &controller.FakePodControl{}
 		ctr.PodControl = fakePodControl
 		fakeServiceControl := &control.FakeServiceControl{}
@@ -439,7 +439,7 @@ func TestCleanupTFJob(t *testing.T) {
 			},
 		}
 		tfJobClientSet := tfjobclientset.NewForConfigOrDie(config)
-		ctr, kubeInformerFactory, _ := newTFJobController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
+		ctr, kubeInformerFactory, _ := newTFController(config, kubeClientSet, tfJobClientSet, controller.NoResyncPeriodFunc, options.ServerOption{})
 		fakePodControl := &controller.FakePodControl{}
 		ctr.PodControl = fakePodControl
 		fakeServiceControl := &control.FakeServiceControl{}


### PR DESCRIPTION
TFJobController is renamed to TFController for consistency. 
From https://github.com/kubeflow/tf-operator/pull/776#issuecomment-412421051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/777)
<!-- Reviewable:end -->
