### PR TITLE
Add SchedulerName in V1alpha2

### DIFF
--- a/cmd/tf-operator.v2/app/options/options.go
+++ b/cmd/tf-operator.v2/app/options/options.go
@@ -16,6 +16,7 @@ package options
 
 import (
 	"flag"
+
 	"k8s.io/api/core/v1"
 )
 

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,6 +48,9 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
+	// SchedulerName specifies the name of scheduler which should handle the TFJob
+	SchedulerName string `json:"schedulerName,omitempty"`
+
 	// TTLSecondsAfterFinished is the TTL to clean up tf-jobs (temporary
 	// before kubernetes adds the cleanup controller).
 	// It may take extra ReconcilePeriod seconds for the cleanup, since

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,7 +48,7 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
-	// SchedulerName specifies the name of scheduler which should handle the TFJob
+	// SchedulerName specifies the name of scheduler which should handle the TFJob.
 	SchedulerName string `json:"schedulerName,omitempty"`
 
 	// TTLSecondsAfterFinished is the TTL to clean up tf-jobs (temporary

--- a/pkg/controller.v2/tfcontroller/pod.go
+++ b/pkg/controller.v2/tfcontroller/pod.go
@@ -157,7 +157,7 @@ func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, 
 	for key, value := range labels {
 		podTemplate.Labels[key] = value
 	}
-
+	setSchedulerName(podTemplateSpec, tfjob)
 	if err := setClusterSpec(podTemplate, tfjob, rt, index); err != nil {
 		return err
 	}
@@ -185,6 +185,10 @@ func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, 
 		return err
 	}
 	return nil
+}
+
+func setSchedulerName(podTemplateSpec *v1.PodTemplateSpec, tfjob *tfv1alpha2.TFJob) {
+	podTemplateSpec.Spec.SchedulerName = tfjob.Spec.SchedulerName
 }
 
 func setClusterSpec(podTemplateSpec *v1.PodTemplateSpec, tfjob *tfv1alpha2.TFJob, rt, index string) error {

--- a/pkg/controller.v2/tfcontroller/pod.go
+++ b/pkg/controller.v2/tfcontroller/pod.go
@@ -157,7 +157,7 @@ func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, 
 	for key, value := range labels {
 		podTemplate.Labels[key] = value
 	}
-	setSchedulerName(podTemplateSpec, tfjob)
+	setSchedulerName(podTemplate, tfjob)
 	if err := setClusterSpec(podTemplate, tfjob, rt, index); err != nil {
 		return err
 	}


### PR DESCRIPTION
We have enablingGangScheduling option, so we add schedulerName option to TFJobSpec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/787)
<!-- Reviewable:end -->
