### PR TITLE
Fix the name of the "JobTime(out)Error" class

### DIFF
--- a/py/util.py
+++ b/py/util.py
@@ -426,14 +426,14 @@ def setup_cluster(api_client):
 class TimeoutError(Exception):  # pylint: disable=redefined-builtin
   """An error indicating an operation timed out."""
 
-class JobTimeError(TimeoutError):
+class JobTimeoutError(TimeoutError):
   """An error indicating the job timed out.
 
   The job spec/status can be found in .job.
   """
 
   def __init__(self, message, job):
-    super(JobTimeError, self).__init__(message)
+    super(JobTimeoutError, self).__init__(message)
     self.job = job
 
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")


### PR DESCRIPTION
PR #771 introduced the "JobTimeError" class along with several references to a "JobTimeoutError" class (note the additional "out" text).

Presumably, the new references were meant to refer to the newly defined class, but the names differed.

Since there were more callers than definitions, and the callers are all to `JobTimeoutError`, I believe that was the intended name, and `JobTimeError` was a typo.

This change fixes that by switching the class name to the longer `JobTimeoutError`.