### PR TITLE
Scope tf-operator to a namespace

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -811,6 +811,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b88207f848c206b81fca12791c3aa5f0c82fdfbf25133787ad41d3509220a500"
+  inputs-digest = "c8b466bb24140c3a8702ae3433378bb0c235ddc05549bd62776be0e0b2a70fcd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/tf-operator.v2/app/options/options.go
+++ b/cmd/tf-operator.v2/app/options/options.go
@@ -16,6 +16,7 @@ package options
 
 import (
 	"flag"
+	"k8s.io/api/core/v1"
 )
 
 // ServerOption is the main context object for the controller manager.
@@ -41,7 +42,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 		`The url of the Kubernetes API server,
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)
 
-	fs.StringVar(&s.Namespace, "namespace", "",
+	fs.StringVar(&s.Namespace, "namespace", v1.NamespaceAll,
 		`The namespace to monitor tfjobs. If unset, it monitors all namespaces cluster-wide. 
                 If set, it only monitors tfjobs in the given namespace.`)
 

--- a/cmd/tf-operator.v2/app/options/options.go
+++ b/cmd/tf-operator.v2/app/options/options.go
@@ -26,6 +26,7 @@ type ServerOption struct {
 	PrintVersion         bool
 	JSONLogFormat        bool
 	EnableGangScheduling bool
+	Namespace            string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -39,6 +40,10 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.MasterURL, "master", "",
 		`The url of the Kubernetes API server,
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)
+
+	fs.StringVar(&s.Namespace, "namespace", "",
+		`The namespace to monitor tfjobs. If unset, it monitors all namespaces cluster-wide. 
+                If set, it only monitors tfjobs in the given namespace.`)
 
 	fs.IntVar(&s.Threadiness, "threadiness", 1,
 		`How many threads to process the main logic`)

--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -65,8 +65,7 @@ func Run(opt *options.ServerOption) error {
 		log.Infof("EnvKubeflowNamespace not set, use default namespace")
 		namespace = metav1.NamespaceDefault
 	}
-	if len(opt.Namespace) == 0 {
-		opt.Namespace = v1.NamespaceAll
+	if opt.Namespace == v1.NamespaceAll {
 		log.Info("Using cluster scoped operator")
 	} else {
 		log.Infof("Scoping operator to namespace %s", opt.Namespace)

--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -61,17 +61,15 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	namespace := os.Getenv(v1alpha2.EnvKubeflowNamespace)
-	informerNamespace := namespace
 	if len(namespace) == 0 {
 		log.Infof("EnvKubeflowNamespace not set, use default namespace")
 		namespace = metav1.NamespaceDefault
-		informerNamespace = v1.NamespaceAll
 	}
-
-	if informerNamespace == v1.NamespaceAll {
+	if len(opt.Namespace) == 0 {
+		opt.Namespace = v1.NamespaceAll
 		log.Info("Using cluster scoped operator")
 	} else {
-		log.Infof("Scoping operator to namespace %s", informerNamespace)
+		log.Infof("Scoping operator to namespace %s", opt.Namespace)
 	}
 
 	// To help debugging, immediately log version.
@@ -100,10 +98,10 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	// Create informer factory.
-	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClientSet, resyncPeriod, informerNamespace, nil)
+	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClientSet, resyncPeriod, opt.Namespace, nil)
 	tfJobInformerFactory := tfjobinformers.NewSharedInformerFactory(tfJobClientSet, resyncPeriod)
 
-	unstructuredInformer := controller.NewUnstructuredTFJobInformer(kcfg, informerNamespace)
+	unstructuredInformer := controller.NewUnstructuredTFJobInformer(kcfg, opt.Namespace)
 
 	// Create tf controller.
 	tc := controller.NewTFController(unstructuredInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, *opt)

--- a/pkg/controller.v2/tfcontroller/informer.go
+++ b/pkg/controller.v2/tfcontroller/informer.go
@@ -31,7 +31,7 @@ var (
 	errFailedMarshal = fmt.Errorf("Failed to marshal the object to TFJob")
 )
 
-func NewUnstructuredTFJobInformer(restConfig *restclientset.Config) tfjobinformersv1alpha2.TFJobInformer {
+func NewUnstructuredTFJobInformer(restConfig *restclientset.Config, namespace string) tfjobinformersv1alpha2.TFJobInformer {
 	dynClientPool := dynamic.NewDynamicClientPool(restConfig)
 	dclient, err := dynClientPool.ClientForGroupVersionKind(tfv1alpha2.SchemeGroupVersionKind)
 	if err != nil {
@@ -47,7 +47,7 @@ func NewUnstructuredTFJobInformer(restConfig *restclientset.Config) tfjobinforme
 	informer := unstructured.NewTFJobInformer(
 		resource,
 		dclient,
-		metav1.NamespaceAll,
+		namespace,
 		resyncPeriod,
 		cache.Indexers{},
 	)

--- a/pkg/controller.v2/tfcontroller/tfcontroller_test.go
+++ b/pkg/controller.v2/tfcontroller/tfcontroller_test.go
@@ -57,7 +57,7 @@ func newTFController(
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClientSet, resyncPeriod())
 	tfJobInformerFactory := tfjobinformers.NewSharedInformerFactory(tfJobClientSet, resyncPeriod())
 
-	tfJobInformer := NewUnstructuredTFJobInformer(config)
+	tfJobInformer := NewUnstructuredTFJobInformer(config, metav1.NamespaceAll)
 
 	ctr := NewTFController(tfJobInformer, kubeClientSet, tfJobClientSet, kubeInformerFactory, tfJobInformerFactory, option)
 	ctr.PodControl = &controller.FakePodControl{}


### PR DESCRIPTION
Based on the KUBEFLOW_NAMESPACE, tf-operator will be scoped to a
particular namespace.

If `--namespace` flag is not set or left as empty, tf-operator will be
scoped to cluster-wide. If it is set to a namespace value, tf-operator
will only operate in the namespace

Fixes #759

/cc @gaocegege @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/789)
<!-- Reviewable:end -->
