### PR TITLE
reconcileTFJobs is always triggered even with no update

### DIFF
--- a/pkg/controller.v2/tfcontroller/tfjob.go
+++ b/pkg/controller.v2/tfcontroller/tfjob.go
@@ -66,6 +66,17 @@ func (tc *TFController) addTFJob(obj interface{}) {
 func (tc *TFController) updateTFJob(old, cur interface{}) {
 	oldTFJob, err := tfJobFromUnstructured(old)
 	if err != nil {
+		log.Errorf("failed to convert old tfjob from unstructured %v, %v", old, err)
+		return
+	}
+	curTFJob, err := tfJobFromUnstructured(cur)
+	if err != nil {
+		log.Errorf("failed to convert cur tfjob from unstructured %v, %v", cur, err)
+		return
+	}
+	if curTFJob.ResourceVersion == oldTFJob.ResourceVersion {
+		// Periodic resync will send update events for all known TFJobs.
+		// Two different versions of the same TFJob will always have different RVs
 		return
 	}
 	log.Infof("Updating tfjob: %s", oldTFJob.Name)


### PR DESCRIPTION
Found that reconcileTFJobs continuously gets triggered even with no update.

This patch fixes that

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/796)
<!-- Reviewable:end -->
