### PR TITLE
Typo in TTLSecondsAfterFinished json field

### DIFF
--- a/pkg/apis/tensorflow/v1alpha2/openapi_generated.go
+++ b/pkg/apis/tensorflow/v1alpha2/openapi_generated.go
@@ -428,7 +428,7 @@ func schema_pkg_apis_tensorflow_v1alpha2_TFJobSpec(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
-					"ttlSecondsAfterFinishing": {
+					"ttlSecondsAfterFinished": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TTLSecondsAfterFinished is the TTL to clean up tf-jobs (temporary before kubernetes adds the cleanup controller). It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.",
 							Type:        []string{"integer"},

--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -53,7 +53,7 @@ type TFJobSpec struct {
 	// It may take extra ReconcilePeriod seconds for the cleanup, since
 	// reconcile gets called periodically.
 	// Default to infinite.
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinishing,omitempty"`
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
 	// TFReplicaSpecs is map of TFReplicaType and TFReplicaSpec
 	// specifies the TF replicas to run.


### PR DESCRIPTION
The field name is ttlSecondsAfterFinished, but the 'json field' name is ttlSecondsAfterFinishing.
This patch makes them consistent to be ttlSecondsAfterFinished

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/799)
<!-- Reviewable:end -->
