### PR TITLE
Fix a bunch of issues with logging.

### DIFF
--- a/pkg/controller.v2/tfcontroller/pod.go
+++ b/pkg/controller.v2/tfcontroller/pod.go
@@ -81,12 +81,14 @@ func (tc *TFController) reconcilePods(
 				state := status.State
 				if status.Name == tfv1alpha2.DefaultContainerName && state.Terminated != nil {
 					exitCode = state.Terminated.ExitCode
+					logger.Infof("Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
+					tc.Recorder.Eventf(tfjob, v1.EventTypeNormal, "Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
 				}
 			}
 			// Check if the pod is retryable.
 			if spec.RestartPolicy == tfv1alpha2.RestartPolicyExitCode {
 				if pod.Status.Phase == v1.PodFailed && train_util.IsRetryableExitCode(exitCode) {
-					logger.Infof("Need to restart the pod: %s-%d", rt, index)
+					logger.Infof("Need to restart the pod: %v.%v", pod.Namespace, pod.Name)
 					if err := tc.PodControl.DeletePod(pod.Namespace, pod.Name, tfjob); err != nil {
 						return err
 					}

--- a/pkg/controller.v2/tfcontroller/tfjob.go
+++ b/pkg/controller.v2/tfcontroller/tfjob.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	failedMarshalTFJobReason = "FailedMarshalTFJob"
-	terminatedTFJobReason    = "TFJobTerminated"
 )
 
 // When a pod is added, set the defaults and enqueue the current tfjob.

--- a/pkg/controller.v2/tfcontroller/tfjob.go
+++ b/pkg/controller.v2/tfcontroller/tfjob.go
@@ -87,8 +87,6 @@ func (tc *TFController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods []*v
 	if len(pods) == 0 {
 		return nil
 	}
-	tc.Recorder.Event(tfJob, v1.EventTypeNormal, terminatedTFJobReason,
-		"TFJob is terminated, deleting pods and services")
 
 	// Delete nothing when the cleanPodPolicy is None.
 	if *tfJob.Spec.CleanPodPolicy == tfv1alpha2.CleanPodPolicyNone {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -26,8 +26,8 @@ import (
 func LoggerForReplica(job metav1.Object, rtype string) *log.Entry {
 	return log.WithFields(log.Fields{
 		// We use job to match the key used in controller.go
-		// In controller.go we log the key used with the workqueue.
-		"job":          job.GetNamespace() + "/" + job.GetName(),
+		// Its more common in K8s to use a period to indicate namespace.name. So that's what we use.
+		"job":          job.GetNamespace() + "." + job.GetName(),
 		"uid":          job.GetUID(),
 		"replica-type": rtype,
 	})
@@ -36,8 +36,8 @@ func LoggerForReplica(job metav1.Object, rtype string) *log.Entry {
 func LoggerForJob(job metav1.Object) *log.Entry {
 	return log.WithFields(log.Fields{
 		// We use job to match the key used in controller.go
-		// In controller.go we log the key used with the workqueue.
-		"job": job.GetNamespace() + "/" + job.GetName(),
+		// Its more common in K8s to use a period to indicate namespace.name. So that's what we use.
+		"job": job.GetNamespace() + "." + job.GetName(),
 		"uid": job.GetUID(),
 	})
 }


### PR DESCRIPTION
* I ran into these issues while trying to understand why my job was
  marked as failed even though there was no useful informatin about
  why the pod failed.

* Log events that indicate exit code of pods.

* In the json payload use the syntax namespace + "." + name not
  namespace + "/" + name; use of a period is more consistent in K8s

* Don't log an event TFJob is terminated, deleting pods and services;
  this event ends up being triggered repeatedly because of CleanPodPolicy
  the number of completed pods is non zero so the event statement kept
  getting called; the event is unnecessary because we will create
  events corresponding to actual services/events deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/811)
<!-- Reviewable:end -->
