### PR TITLE
Minor restructuring

### DIFF
--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -35,7 +35,7 @@ import (
 	tfjobclientset "github.com/kubeflow/tf-operator/pkg/client/clientset/versioned"
 	"github.com/kubeflow/tf-operator/pkg/client/clientset/versioned/scheme"
 	tfjobinformers "github.com/kubeflow/tf-operator/pkg/client/informers/externalversions"
-	controller "github.com/kubeflow/tf-operator/pkg/controller.v2/tfcontroller"
+	controller "github.com/kubeflow/tf-operator/pkg/controller.v2/tensorflow"
 	"github.com/kubeflow/tf-operator/pkg/util/signals"
 	"github.com/kubeflow/tf-operator/pkg/version"
 )

--- a/pkg/controller.v2/tensorflow/controller.go
+++ b/pkg/controller.v2/tensorflow/controller.go
@@ -372,6 +372,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1alpha2.TFJob) error {
 		initializeTFReplicaStatuses(tfjob, tfv1alpha2.TFReplicaTypeWorker)
 		initializeTFReplicaStatuses(tfjob, tfv1alpha2.TFReplicaTypePS)
 		initializeTFReplicaStatuses(tfjob, tfv1alpha2.TFReplicaTypeChief)
+		initializeTFReplicaStatuses(tfjob, tfv1alpha2.TFReplicaTypeMaster)
 		return tc.updateStatusHandler(tfjob)
 	}
 

--- a/pkg/controller.v2/tensorflow/controller_test.go
+++ b/pkg/controller.v2/tensorflow/controller_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"reflect"
@@ -433,7 +433,7 @@ func TestSyncPdb(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		pdb, _ := ctr.SyncPdb(c.tfJob)
+		pdb, _ := ctr.SyncPdb(c.tfJob, getTotalReplicas(c.tfJob))
 		if pdb == nil && c.expectPdb != nil {
 			t.Errorf("Got nil, want %v", c.expectPdb.Spec)
 		}

--- a/pkg/controller.v2/tensorflow/informer.go
+++ b/pkg/controller.v2/tensorflow/informer.go
@@ -1,4 +1,4 @@
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"

--- a/pkg/controller.v2/tensorflow/job.go
+++ b/pkg/controller.v2/tensorflow/job.go
@@ -1,4 +1,4 @@
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"
@@ -16,6 +16,7 @@ import (
 
 const (
 	failedMarshalTFJobReason = "FailedMarshalTFJob"
+	terminatedTFJobReason    = "TFJobTerminated"
 )
 
 // When a pod is added, set the defaults and enqueue the current tfjob.
@@ -33,7 +34,7 @@ func (tc *TFController) addTFJob(obj interface{}) {
 		if err == errFailedMarshal {
 			errMsg := fmt.Sprintf("Failed to unmarshal the object to TFJob object: %v", err)
 			logger.Warn(errMsg)
-			tc.Recorder.Event(un, v1.EventTypeWarning, failedMarshalTFJobReason, errMsg)
+			tc.Recorder.Event(tfJob, v1.EventTypeWarning, failedMarshalTFJobReason, errMsg)
 		}
 		return
 	}
@@ -65,6 +66,17 @@ func (tc *TFController) addTFJob(obj interface{}) {
 func (tc *TFController) updateTFJob(old, cur interface{}) {
 	oldTFJob, err := tfJobFromUnstructured(old)
 	if err != nil {
+		log.Errorf("failed to convert old tfjob from unstructured %v, %v", old, err)
+		return
+	}
+	curTFJob, err := tfJobFromUnstructured(cur)
+	if err != nil {
+		log.Errorf("failed to convert cur tfjob from unstructured %v, %v", cur, err)
+		return
+	}
+	if curTFJob.ResourceVersion == oldTFJob.ResourceVersion {
+		// Periodic resync will send update events for all known TFJobs.
+		// Two different versions of the same TFJob will always have different RVs
 		return
 	}
 	log.Infof("Updating tfjob: %s", oldTFJob.Name)
@@ -75,6 +87,8 @@ func (tc *TFController) deletePodsAndServices(tfJob *tfv1alpha2.TFJob, pods []*v
 	if len(pods) == 0 {
 		return nil
 	}
+	tc.Recorder.Event(tfJob, v1.EventTypeNormal, terminatedTFJobReason,
+		"TFJob is terminated, deleting pods and services")
 
 	// Delete nothing when the cleanPodPolicy is None.
 	if *tfJob.Spec.CleanPodPolicy == tfv1alpha2.CleanPodPolicyNone {

--- a/pkg/controller.v2/tensorflow/job_test.go
+++ b/pkg/controller.v2/tensorflow/job_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tfcontroller
+package tensorflow
 
 import (
 	"testing"

--- a/pkg/controller.v2/tensorflow/pod.go
+++ b/pkg/controller.v2/tensorflow/pod.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"
@@ -81,14 +81,12 @@ func (tc *TFController) reconcilePods(
 				state := status.State
 				if status.Name == tfv1alpha2.DefaultContainerName && state.Terminated != nil {
 					exitCode = state.Terminated.ExitCode
-					logger.Infof("Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
-					tc.Recorder.Eventf(tfjob, v1.EventTypeNormal, "Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
 				}
 			}
 			// Check if the pod is retryable.
 			if spec.RestartPolicy == tfv1alpha2.RestartPolicyExitCode {
 				if pod.Status.Phase == v1.PodFailed && train_util.IsRetryableExitCode(exitCode) {
-					logger.Infof("Need to restart the pod: %v.%v", pod.Namespace, pod.Name)
+					logger.Infof("Need to restart the pod: %s-%d", rt, index)
 					if err := tc.PodControl.DeletePod(pod.Namespace, pod.Name, tfjob); err != nil {
 						return err
 					}

--- a/pkg/controller.v2/tensorflow/pod.go
+++ b/pkg/controller.v2/tensorflow/pod.go
@@ -81,12 +81,14 @@ func (tc *TFController) reconcilePods(
 				state := status.State
 				if status.Name == tfv1alpha2.DefaultContainerName && state.Terminated != nil {
 					exitCode = state.Terminated.ExitCode
+					logger.Infof("Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
+					tc.Recorder.Eventf(tfjob, v1.EventTypeNormal, "Pod: %v.%v exited with code %v", pod.Namespace, pod.Name, exitCode)
 				}
 			}
 			// Check if the pod is retryable.
 			if spec.RestartPolicy == tfv1alpha2.RestartPolicyExitCode {
 				if pod.Status.Phase == v1.PodFailed && train_util.IsRetryableExitCode(exitCode) {
-					logger.Infof("Need to restart the pod: %s-%d", rt, index)
+					logger.Infof("Need to restart the pod: %v.%v", pod.Namespace, pod.Name)
 					if err := tc.PodControl.DeletePod(pod.Namespace, pod.Name, tfjob); err != nil {
 						return err
 					}

--- a/pkg/controller.v2/tensorflow/pod_test.go
+++ b/pkg/controller.v2/tensorflow/pod_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"testing"

--- a/pkg/controller.v2/tensorflow/service.go
+++ b/pkg/controller.v2/tensorflow/service.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"

--- a/pkg/controller.v2/tensorflow/service_test.go
+++ b/pkg/controller.v2/tensorflow/service_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"testing"

--- a/pkg/controller.v2/tensorflow/status.go
+++ b/pkg/controller.v2/tensorflow/status.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"
@@ -53,10 +53,8 @@ func updateStatusSingle(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType,
 		tfjob.Status.StartTime = &now
 	}
 
-	// If the TFJob contains Chief or Master spec, then we will update the status
-	// according to the Chief/Master spec.
-	if ContainChieforMasterSpec(tfjob) {
-		if tfv1alpha2.IsChieforMaster(rtype) {
+	if ContainChiefSpec(tfjob) {
+		if rtype == tfv1alpha2.TFReplicaTypeChief {
 			if running > 0 {
 				msg := fmt.Sprintf("TFJob %s is running.", tfjob.Name)
 				err := updateTFJobConditions(tfjob, tfv1alpha2.TFJobRunning, tfJobRunningReason, msg)

--- a/pkg/controller.v2/tensorflow/status.go
+++ b/pkg/controller.v2/tensorflow/status.go
@@ -53,8 +53,10 @@ func updateStatusSingle(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType,
 		tfjob.Status.StartTime = &now
 	}
 
-	if ContainChiefSpec(tfjob) {
-		if rtype == tfv1alpha2.TFReplicaTypeChief {
+	// If the TFJob contains Chief or Master spec, then we will update the status
+	// according to the Chief/Master spec.
+	if ContainChieforMasterSpec(tfjob) {
+		if tfv1alpha2.IsChieforMaster(rtype) {
 			if running > 0 {
 				msg := fmt.Sprintf("TFJob %s is running.", tfjob.Name)
 				err := updateTFJobConditions(tfjob, tfv1alpha2.TFJobRunning, tfJobRunningReason, msg)

--- a/pkg/controller.v2/tensorflow/status_test.go
+++ b/pkg/controller.v2/tensorflow/status_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"testing"

--- a/pkg/controller.v2/tensorflow/tensorflow.go
+++ b/pkg/controller.v2/tensorflow/tensorflow.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package controller provides a Kubernetes controller for a TFJob resource.
-package tfcontroller
+package tensorflow
 
 import (
 	"encoding/json"

--- a/pkg/controller.v2/tensorflow/util.go
+++ b/pkg/controller.v2/tensorflow/util.go
@@ -40,8 +40,11 @@ func GetPortFromTFJob(tfJob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType) (
 	return -1, errPortNotFound
 }
 
-func ContainChiefSpec(tfJob *tfv1alpha2.TFJob) bool {
+// ContainChieforMasterSpec returns true if the tfjob contains chief or master spec.
+func ContainChieforMasterSpec(tfJob *tfv1alpha2.TFJob) bool {
 	if _, ok := tfJob.Spec.TFReplicaSpecs[tfv1alpha2.TFReplicaTypeChief]; ok {
+		return true
+	} else if _, ok := tfJob.Spec.TFReplicaSpecs[tfv1alpha2.TFReplicaTypeMaster]; ok {
 		return true
 	}
 	return false

--- a/pkg/controller.v2/tensorflow/util.go
+++ b/pkg/controller.v2/tensorflow/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tfcontroller
+package tensorflow
 
 import (
 	"fmt"
@@ -40,11 +40,8 @@ func GetPortFromTFJob(tfJob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType) (
 	return -1, errPortNotFound
 }
 
-// ContainChieforMasterSpec returns true if the tfjob contains chief or master spec.
-func ContainChieforMasterSpec(tfJob *tfv1alpha2.TFJob) bool {
+func ContainChiefSpec(tfJob *tfv1alpha2.TFJob) bool {
 	if _, ok := tfJob.Spec.TFReplicaSpecs[tfv1alpha2.TFReplicaTypeChief]; ok {
-		return true
-	} else if _, ok := tfJob.Spec.TFReplicaSpecs[tfv1alpha2.TFReplicaTypeMaster]; ok {
 		return true
 	}
 	return false

--- a/pkg/controller.v2/tensorflow/util_test.go
+++ b/pkg/controller.v2/tensorflow/util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tfcontroller
+package tensorflow
 
 import (
 	"testing"


### PR DESCRIPTION
1. Renaming tfcontroller to tensorflow (it is already in controller folder). Naming is now consistent with the Pytorch repo
2. Removed GetTotalReplicas from Controller interface as it is not necessary for all operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/812)
<!-- Reviewable:end -->
