### PR TITLE
Set artifacts dir so that the output of invalid-job test will be picked up.

### DIFF
--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -501,7 +501,7 @@
               "test",
               "--app_dir=" + srcDir + "/test/workflows",
               "--params=name=invalid-tfjob,namespace=default",
-              "--junit_path=" + artifactsDir + "/junit_test-invalid-tfjob.xml",
+              "--artifacts_dir=" + artifactsDir,
             ]),  // invalid-tfjob
             $.parts(namespace, name).e2e(prow_env, bucket).buildTemplate("create-pr-symlink", [
               "python",


### PR DESCRIPTION

* Fix #816

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/817)
<!-- Reviewable:end -->
