### PR TITLE
Adding corev1 scheme to Events

### DIFF
--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -127,7 +127,9 @@ func Run(opt *options.ServerOption) error {
 
 	// Prepare event clients.
 	eventBroadcaster := record.NewBroadcaster()
-	v1.AddToScheme(scheme.Scheme)
+	if err := v1.AddToScheme(scheme.Scheme); err != nil {
+		return log.Errorf("CoreV1 Add Scheme failed: %v", err)
+	}
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "tf-operator"})
 
 	rl := &resourcelock.EndpointsLock{

--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -127,8 +127,8 @@ func Run(opt *options.ServerOption) error {
 
 	// Prepare event clients.
 	eventBroadcaster := record.NewBroadcaster()
-	if err := v1.AddToScheme(scheme.Scheme); err != nil {
-		return log.Errorf("CoreV1 Add Scheme failed: %v", err)
+	if err = v1.AddToScheme(scheme.Scheme); err != nil {
+		return fmt.Errorf("CoreV1 Add Scheme failed: %v", err)
 	}
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "tf-operator"})
 

--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -127,6 +127,7 @@ func Run(opt *options.ServerOption) error {
 
 	// Prepare event clients.
 	eventBroadcaster := record.NewBroadcaster()
+	v1.AddToScheme(scheme.Scheme)
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "tf-operator"})
 
 	rl := &resourcelock.EndpointsLock{

--- a/pkg/controller.v2/jobcontroller/pod.go
+++ b/pkg/controller.v2/jobcontroller/pod.go
@@ -98,7 +98,7 @@ func (jc *JobController) UpdatePod(old, cur interface{}) {
 		if job == nil {
 			return
 		}
-		logger.Infof("pod has a ControllerRef: %v, %v", curPod, oldPod)
+		logger.Debugf("pod has a ControllerRef: %v, %v", curPod, oldPod)
 		jobKey, err := controller.KeyFunc(job)
 		if err != nil {
 			return


### PR DESCRIPTION
One error log appears during the leader election at startup.  

`Could not construct reference to: '&v1.Endpoints{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"tf-job-operator", GenerateName:"", Namespace:"default", SelfLink:"/api/v1/namespaces/default/endpoints/tf-job-operator", UID:"feb0f9ab-6e64-11e8-bdd9-42010aa00072", ResourceVersion:"18879593", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63664420868, loc:(*time.Location)(0x1b5df80)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"control-plane.alpha.kubernetes.io/leader":"{\"holderIdentity\":\"tf-job-operator-5864544fcb-d8c9m\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2018-09-03T12:22:38Z\",\"renewTime\":\"2018-09-03T12:22:38Z\",\"leaderTransitions\":39}"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Subsets:[]v1.EndpointSubset(nil)}' due to: 'no kind is registered for the type v1.Endpoints'. Will not report event: 'Normal' 'LeaderElection' '`


This is because endpoints schema was not added during the initialization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/821)
<!-- Reviewable:end -->
