### PR TITLE
remove schedulerName from tfjob spec

### DIFF
--- a/pkg/apis/tensorflow/v1alpha2/types.go
+++ b/pkg/apis/tensorflow/v1alpha2/types.go
@@ -48,9 +48,6 @@ type TFJobSpec struct {
 	// Default to Running.
 	CleanPodPolicy *CleanPodPolicy `json:"cleanPodPolicy,omitempty"`
 
-	// SchedulerName specifies the name of scheduler which should handle the TFJob.
-	SchedulerName string `json:"schedulerName,omitempty"`
-
 	// TTLSecondsAfterFinished is the TTL to clean up tf-jobs (temporary
 	// before kubernetes adds the cleanup controller).
 	// It may take extra ReconcilePeriod seconds for the cleanup, since

--- a/pkg/controller.v2/tensorflow/pod.go
+++ b/pkg/controller.v2/tensorflow/pod.go
@@ -142,7 +142,7 @@ func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, 
 	for key, value := range labels {
 		podTemplate.Labels[key] = value
 	}
-	setSchedulerName(podTemplate, tfjob)
+
 	if err := setClusterSpec(podTemplate, tfjob, rt, index); err != nil {
 		return err
 	}
@@ -170,10 +170,6 @@ func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, 
 		return err
 	}
 	return nil
-}
-
-func setSchedulerName(podTemplateSpec *v1.PodTemplateSpec, tfjob *tfv1alpha2.TFJob) {
-	podTemplateSpec.Spec.SchedulerName = tfjob.Spec.SchedulerName
 }
 
 func setClusterSpec(podTemplateSpec *v1.PodTemplateSpec, tfjob *tfv1alpha2.TFJob, rt, index string) error {


### PR DESCRIPTION
According to the discussion in #801 , we remove the schedulerName from tfjob spec to prevent confusing users.

Fixed #801

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/823)
<!-- Reviewable:end -->
