### PR TITLE
Cleanup unused functions

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -21,13 +21,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // for gcp auth
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	tfv1alpha1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1alpha1"
 )
 
 // RecommendedConfigPathEnvVar is a environment variable for path configuration
@@ -83,22 +80,6 @@ func IsKubernetesResourceAlreadyExistError(err error) bool {
 // IsKubernetesResourceNotFoundError throws error when there is no kubernetes resource found.
 func IsKubernetesResourceNotFoundError(err error) bool {
 	return apierrors.IsNotFound(err)
-}
-
-// JobListOpt returns a list of options after assigning the label selector for a given cluster name
-func JobListOpt(clusterName string) metav1.ListOptions {
-	return metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(LabelsForJob(clusterName)).String(),
-	}
-}
-
-// LabelsForJob returns map which stores the tf_job name and app label.
-func LabelsForJob(jobName string) map[string]string {
-	return map[string]string{
-		// TODO(jlewi): Need to set appropriate labels for TF.
-		"tf_job": jobName,
-		"app":    tfv1alpha1.AppLabel,
-	}
 }
 
 // TODO(jlewi): CascadeDeletOptions are part of garbage collection policy.


### PR DESCRIPTION
The unused functions are removed. K8sutil package must contain only k8s utility functions and has to be independent of tf code. It can be then shared across operators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/827)
<!-- Reviewable:end -->
