### PR TITLE
fix ERROR: logging before flag.Parse issue

### DIFF
--- a/dashboard/backend/main.go
+++ b/dashboard/backend/main.go
@@ -5,11 +5,14 @@ import (
 	"net/http"
 	"os"
 
+	"flag"
+
 	"github.com/kubeflow/tf-operator/dashboard/backend/client"
 	"github.com/kubeflow/tf-operator/dashboard/backend/handler"
 )
 
 func main() {
+	flag.Parse()
 	log.SetOutput(os.Stdout)
 	cm, err := client.NewClientManager()
 	if err != nil {


### PR DESCRIPTION
the log always print `ERROR: logging before flag.Parse if `
this fix it 
Note: need add  flag  -logtostderr=true when  start  backend ,if you want  it to work like before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/834)
<!-- Reviewable:end -->
