### PR TITLE
Refactor E2E tests (part 1)

### DIFF
--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -5,7 +5,6 @@ import httplib
 import logging
 import json
 import re
-import retrying
 import time
 from kubeflow.testing import util
 from kubernetes import client as k8s_client

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -1,7 +1,6 @@
 """K8s util class for E2E tests."""
 
 import datetime
-import httplib
 import logging
 import json
 import re

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -1,0 +1,233 @@
+"""K8s util class for E2E tests."""
+
+import datetime
+import httplib
+import logging
+import json
+import re
+import retrying
+import time
+from kubeflow.testing import util
+from kubernetes import client as k8s_client
+from kubernetes.client import rest
+from py import tf_job_client
+
+
+def wait_for_delete(client,
+                    namespace,
+                    name,
+                    version="v1alpha1",
+                    timeout=datetime.timedelta(minutes=5),
+                    polling_interval=datetime.timedelta(seconds=30),
+                    status_callback=None):
+  """Wait for the specified job to be deleted.
+
+  Args:
+    client: K8s api client.
+    namespace: namespace for the job.
+    name: Name of the job.
+    timeout: How long to wait for the job.
+    polling_interval: How often to poll for the status of the job.
+    status_callback: (Optional): Callable. If supplied this callable is
+      invoked after we poll the job. Callable takes a single argument which
+      is the job.
+  """
+  crd_api = k8s_client.CustomObjectsApi(client)
+  end_time = datetime.datetime.now() + timeout
+  while True:
+    try:
+      results = crd_api.get_namespaced_custom_object(
+        tf_job_client.TF_JOB_GROUP, version, namespace,
+        tf_job_client.TF_JOB_PLURAL, name)
+    except rest.ApiException as e:
+      if e.status == httplib.NOT_FOUND:
+        return
+      logging.exception("rest.ApiException thrown")
+      raise
+    if status_callback:
+      status_callback(results)
+
+    if datetime.datetime.now() + polling_interval > end_time:
+      raise util.TimeoutError(
+        "Timeout waiting for job {0} in namespace {1} to be deleted.".format(
+          name, namespace))
+
+    time.sleep(polling_interval.seconds)
+
+
+def log_pods(pods):
+  """Log information about pods."""
+  for p in pods.items:
+    logging.info("Pod name=%s Phase=%s", p.metadata.name, p.status.phase)
+
+
+def wait_for_pods_to_be_in_phases(client,
+                                  namespace,
+                                  pod_selector,
+                                  phases,
+                                  timeout=datetime.timedelta(minutes=5),
+                                  polling_interval=datetime.timedelta(
+                                  seconds=30)):
+  """Wait for the pods matching the selector to be in the specified state
+
+  Args:
+    client: K8s api client.
+    namespace: Namespace.
+    pod_selector: Selector for the pods.
+    phases: List of desired phases
+    timeout: How long to wait for the job.
+    polling_interval: How often to poll for the status of the job.
+    status_callback: (Optional): Callable. If supplied this callable is
+      invoked after we poll the job. Callable takes a single argument which
+      is the job.
+  """
+  end_time = datetime.datetime.now() + timeout
+  while True:
+    pods = list_pods(client, namespace, pod_selector)
+
+    logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
+
+    is_match = True
+    for p in pods.items:
+      if p.status.phase not in phases:
+        is_match = False
+
+    if is_match:
+      logging.info("All pods in phase %s", phases)
+      log_pods(pods)
+      return pods
+
+    if datetime.datetime.now() + polling_interval > end_time:
+      logging.info("Latest pod phases")
+      log_pods(pods)
+      logging.error("Timeout waiting for pods to be in phase: %s",
+                    phases)
+      raise util.TimeoutError("Timeout waiting for pods to be in states %s" %
+                              phases)
+    time.sleep(polling_interval.seconds)
+
+  return None
+
+def wait_for_pods_to_be_deleted(client,
+                                namespace,
+                                pod_selector,
+                                timeout=datetime.timedelta(minutes=5),
+                                polling_interval=datetime.timedelta(
+                                  seconds=30)):
+  """Wait for the specified job to be deleted.
+
+  Args:
+    client: K8s api client.
+    namespace: Namespace.
+    pod_selector: Selector for the pods.
+    timeout: How long to wait for the job.
+    polling_interval: How often to poll for the status of the job.
+    status_callback: (Optional): Callable. If supplied this callable is
+      invoked after we poll the job. Callable takes a single argument which
+      is the job.
+  """
+  end_time = datetime.datetime.now() + timeout
+  while True:
+    pods = list_pods(client, namespace, pod_selector)
+
+    logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
+
+    if not pods.items:
+      return
+
+    if datetime.datetime.now() + polling_interval > end_time:
+      raise util.TimeoutError("Timeout waiting for pods to be deleted.")
+
+    time.sleep(polling_interval.seconds)
+
+def list_pods(client, namespace, label_selector):
+  core = k8s_client.CoreV1Api(client)
+  try:
+    pods = core.list_namespaced_pod(namespace, label_selector=label_selector)
+    return pods
+  except rest.ApiException as e:
+    message = ""
+    if e.message:
+      message = e.message
+    if e.body:
+      try:
+        body = json.loads(e.body)
+      except ValueError:
+        # There was a problem parsing the body of the response as json.
+        logging.exception(
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
+        raise
+      message = body.get("message")
+
+    logging.exception(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
+    raise e
+
+def get_events(client, namespace, uid):
+  """Get the events for the provided object."""
+  core = k8s_client.CoreV1Api(client)
+  try:
+    # We can't filter by labels because events don't appear to have anyone
+    # and I didn't see an easy way to get them.
+    events = core.list_namespaced_event(namespace, limit=500)
+  except rest.ApiException as e:
+    message = ""
+    if e.message:
+      message = e.message
+    if e.body:
+      try:
+        body = json.loads(e.body)
+      except ValueError:
+        # There was a problem parsing the body of the response as json.
+        logging.exception(
+          ("Exception when calling DefaultApi->"
+           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
+        raise
+      message = body.get("message")
+
+    logging.exception(("Exception when calling DefaultApi->"
+                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                  message)
+    raise e
+
+  matching = []
+
+  for e in events.items:
+    if e.involved_object.uid != uid:
+      continue
+    matching.append(e)
+
+  return matching
+
+def parse_events(events):
+  """Parse events.
+
+  Args:
+    events: List of events.
+
+  Returns
+    pods_created: Set of unique pod names created.
+    services_created: Set of unique services created.
+  """
+  pattern = re.compile(".*Created.*(pod|Service).*: (.*)", re.IGNORECASE)
+
+  pods = set()
+  services = set()
+  for e in events:
+    m = re.match(pattern, e.message)
+    if not m:
+      continue
+
+    kind = m.group(1)
+    name = m.group(2)
+
+    if kind.lower() == "pod":
+      pods.add(name)
+    elif kind.lower() == "service":
+      services.add(name)
+
+  return pods, services
+
+

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -9,50 +9,6 @@ import time
 from kubeflow.testing import util
 from kubernetes import client as k8s_client
 from kubernetes.client import rest
-from py import tf_job_client
-
-
-def wait_for_delete(client,
-                    namespace,
-                    name,
-                    version="v1alpha1",
-                    timeout=datetime.timedelta(minutes=5),
-                    polling_interval=datetime.timedelta(seconds=30),
-                    status_callback=None):
-  """Wait for the specified job to be deleted.
-
-  Args:
-    client: K8s api client.
-    namespace: namespace for the job.
-    name: Name of the job.
-    timeout: How long to wait for the job.
-    polling_interval: How often to poll for the status of the job.
-    status_callback: (Optional): Callable. If supplied this callable is
-      invoked after we poll the job. Callable takes a single argument which
-      is the job.
-  """
-  crd_api = k8s_client.CustomObjectsApi(client)
-  end_time = datetime.datetime.now() + timeout
-  while True:
-    try:
-      results = crd_api.get_namespaced_custom_object(
-        tf_job_client.TF_JOB_GROUP, version, namespace,
-        tf_job_client.TF_JOB_PLURAL, name)
-    except rest.ApiException as e:
-      if e.status == httplib.NOT_FOUND:
-        return
-      logging.exception("rest.ApiException thrown")
-      raise
-    if status_callback:
-      status_callback(results)
-
-    if datetime.datetime.now() + polling_interval > end_time:
-      raise util.TimeoutError(
-        "Timeout waiting for job {0} in namespace {1} to be deleted.".format(
-          name, namespace))
-
-    time.sleep(polling_interval.seconds)
-
 
 def log_pods(pods):
   """Log information about pods."""
@@ -228,5 +184,3 @@ def parse_events(events):
       services.add(name)
 
   return pods, services
-
-

--- a/py/ks_util.py
+++ b/py/ks_util.py
@@ -1,0 +1,57 @@
+"""Utility for ksonnet operations."""
+import filelock
+import logging
+import os
+import re
+import subprocess
+import uuid
+from kubeflow.testing import util
+
+
+def setup_ks_app(args):
+  """Setup the ksonnet app"""
+  salt = uuid.uuid4().hex[0:4]
+
+  lock_file = os.path.join(args.app_dir, "app.lock")
+  logging.info("Acquiring lock on file: %s", lock_file)
+  lock = filelock.FileLock(lock_file, timeout=60)
+  with lock:
+    # Create a new environment for this run
+    if "environment" in args and args.environment:
+      env = args.environment
+    else:
+      env = "test-env-{0}".format(salt)
+
+    name = None
+    namespace = None
+    for pair in args.params.split(","):
+      k, v = pair.split("=", 1)
+      if k == "name":
+        name = v
+
+      if k == "namespace":
+        namespace = v
+
+    if not name:
+      raise ValueError("name must be provided as a parameter.")
+
+    if not namespace:
+      raise ValueError("namespace must be provided as a parameter.")
+
+    try:
+      util.run(["ks", "env", "add", env, "--namespace=" + namespace],
+                cwd=args.app_dir)
+    except subprocess.CalledProcessError as e:
+      if not re.search(".*environment.*already exists.*", e.output):
+        raise
+
+    for pair in args.params.split(","):
+      k, v = pair.split("=", 1)
+      util.run(
+        ["ks", "param", "set", "--env=" + env, args.component, k, v],
+        cwd=args.app_dir)
+
+    return namespace, name, env
+
+  return "", "", ""
+

--- a/py/ks_util.py
+++ b/py/ks_util.py
@@ -54,4 +54,3 @@ def setup_ks_app(args):
     return namespace, name, env
 
   return "", "", ""
-

--- a/py/test_invalid_job.py
+++ b/py/test_invalid_job.py
@@ -15,7 +15,7 @@ from kubernetes import client as k8s_client
 
 from kubeflow.testing import test_helper
 from kubeflow.testing import util
-from py import test_runner
+from py import ks_util
 from py import test_util
 from py import tf_job_client
 from py import util as tf_operator_util
@@ -34,7 +34,7 @@ def run_test(args, test_case):  # pylint: disable=too-many-branches,too-many-sta
 
   t = test_util.TestCase()
   t.class_name = "tfjob_test"
-  namespace, name, env = test_runner.setup_ks_app(args)
+  namespace, name, env = ks_util.setup_ks_app(args)
   t.name = os.path.basename(name)
 
   try: # pylint: disable=too-many-nested-blocks

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -315,7 +315,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
 
       logging.info("Waiting for job %s in namespaces %s to be deleted.", name,
                    namespace)
-      k8s_util.wait_for_delete(
+      tf_job_client.wait_for_delete(
         api_client, namespace, name, args.tfjob_version, status_callback=tf_job_client.log_status)
 
     # TODO(jlewi):

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -19,290 +19,10 @@ from kubernetes.client import rest
 
 from google.cloud import storage  # pylint: disable=no-name-in-module
 from kubeflow.testing import util
+from py import k8s_util
 from py import test_util
 from py import tf_job_client
 from py import util as tf_operator_util
-
-def wait_for_delete(client,
-                    namespace,
-                    name,
-                    version="v1alpha1",
-                    timeout=datetime.timedelta(minutes=5),
-                    polling_interval=datetime.timedelta(seconds=30),
-                    status_callback=None):
-  """Wait for the specified job to be deleted.
-
-  Args:
-    client: K8s api client.
-    namespace: namespace for the job.
-    name: Name of the job.
-    timeout: How long to wait for the job.
-    polling_interval: How often to poll for the status of the job.
-    status_callback: (Optional): Callable. If supplied this callable is
-      invoked after we poll the job. Callable takes a single argument which
-      is the job.
-  """
-  crd_api = k8s_client.CustomObjectsApi(client)
-  end_time = datetime.datetime.now() + timeout
-  while True:
-    try:
-      results = crd_api.get_namespaced_custom_object(
-        tf_job_client.TF_JOB_GROUP, version, namespace,
-        tf_job_client.TF_JOB_PLURAL, name)
-    except rest.ApiException as e:
-      if e.status == httplib.NOT_FOUND:
-        return
-      logging.exception("rest.ApiException thrown")
-      raise
-    if status_callback:
-      status_callback(results)
-
-    if datetime.datetime.now() + polling_interval > end_time:
-      raise util.TimeoutError(
-        "Timeout waiting for job {0} in namespace {1} to be deleted.".format(
-          name, namespace))
-
-    time.sleep(polling_interval.seconds)
-
-
-def log_pods(pods):
-  """Log information about pods."""
-  for p in pods.items:
-    logging.info("Pod name=%s Phase=%s", p.metadata.name, p.status.phase)
-
-def wait_for_pods_to_be_in_phases(client,
-                                  namespace,
-                                  pod_selector,
-                                  phases,
-                                  timeout=datetime.timedelta(minutes=5),
-                                  polling_interval=datetime.timedelta(
-                                  seconds=30)):
-  """Wait for the pods matching the selector to be in the specified state
-
-  Args:
-    client: K8s api client.
-    namespace: Namespace.
-    pod_selector: Selector for the pods.
-    phases: List of desired phases
-    timeout: How long to wait for the job.
-    polling_interval: How often to poll for the status of the job.
-    status_callback: (Optional): Callable. If supplied this callable is
-      invoked after we poll the job. Callable takes a single argument which
-      is the job.
-  """
-  end_time = datetime.datetime.now() + timeout
-  while True:
-    pods = list_pods(client, namespace, pod_selector)
-
-    logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
-
-    is_match = True
-    for p in pods.items:
-      if p.status.phase not in phases:
-        is_match = False
-
-    if is_match:
-      logging.info("All pods in phase %s", phases)
-      log_pods(pods)
-      return pods
-
-    if datetime.datetime.now() + polling_interval > end_time:
-      logging.info("Latest pod phases")
-      log_pods(pods)
-      logging.error("Timeout waiting for pods to be in phase: %s",
-                    phases)
-      raise util.TimeoutError("Timeout waiting for pods to be in states %s" %
-                              phases)
-    time.sleep(polling_interval.seconds)
-
-  return None
-
-def wait_for_pods_to_be_deleted(client,
-                                namespace,
-                                pod_selector,
-                                timeout=datetime.timedelta(minutes=5),
-                                polling_interval=datetime.timedelta(
-                                  seconds=30)):
-  """Wait for the specified job to be deleted.
-
-  Args:
-    client: K8s api client.
-    namespace: Namespace.
-    pod_selector: Selector for the pods.
-    timeout: How long to wait for the job.
-    polling_interval: How often to poll for the status of the job.
-    status_callback: (Optional): Callable. If supplied this callable is
-      invoked after we poll the job. Callable takes a single argument which
-      is the job.
-  """
-  end_time = datetime.datetime.now() + timeout
-  while True:
-    pods = list_pods(client, namespace, pod_selector)
-
-    logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
-
-    if not pods.items:
-      return
-
-    if datetime.datetime.now() + polling_interval > end_time:
-      raise util.TimeoutError("Timeout waiting for pods to be deleted.")
-
-    time.sleep(polling_interval.seconds)
-
-
-def get_labels(name, runtime_id, replica_type=None, replica_index=None):
-  """Return labels.
-  """
-  labels = {
-    "kubeflow.org": "",
-    "tf_job_name": name,
-    "runtime_id": runtime_id,
-  }
-  if replica_type:
-    labels["job_type"] = replica_type
-
-  if replica_index:
-    labels["task_index"] = replica_index
-  return labels
-
-def get_labels_v1alpha2(name, replica_type=None,
-                        replica_index=None):
-  """Return labels.
-  """
-  labels = {
-    "group_name": "kubeflow.org",
-    "tf_job_name": name,
-  }
-  if replica_type:
-    labels["tf-replica-type"] = replica_type
-
-  if replica_index:
-    labels["tf-replica-index"] = replica_index
-  return labels
-
-def to_selector(labels):
-  parts = []
-  for k, v in labels.iteritems():
-    parts.append("{0}={1}".format(k, v))
-
-  return ",".join(parts)
-
-
-def list_pods(client, namespace, label_selector):
-  core = k8s_client.CoreV1Api(client)
-  try:
-    pods = core.list_namespaced_pod(namespace, label_selector=label_selector)
-    return pods
-  except rest.ApiException as e:
-    message = ""
-    if e.message:
-      message = e.message
-    if e.body:
-      try:
-        body = json.loads(e.body)
-      except ValueError:
-        # There was a problem parsing the body of the response as json.
-        logging.exception(
-          ("Exception when calling DefaultApi->"
-           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
-        raise
-      message = body.get("message")
-
-    logging.exception(("Exception when calling DefaultApi->"
-                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-                  message)
-    raise e
-
-def wait_for_replica_type_in_phases(api_client, namespace, tfjob_name, replica_type, phases):
-  pod_labels = get_labels_v1alpha2(tfjob_name, replica_type)
-  pod_selector = to_selector(pod_labels)
-  wait_for_pods_to_be_in_phases(api_client, namespace,
-                                pod_selector,
-                                phases,
-                                timeout=datetime.timedelta(
-                                  minutes=4))
-
-def get_events(client, namespace, uid):
-  """Get the events for the provided object."""
-  core = k8s_client.CoreV1Api(client)
-  try:
-    # We can't filter by labels because events don't appear to have anyone
-    # and I didn't see an easy way to get them.
-    events = core.list_namespaced_event(namespace, limit=500)
-  except rest.ApiException as e:
-    message = ""
-    if e.message:
-      message = e.message
-    if e.body:
-      try:
-        body = json.loads(e.body)
-      except ValueError:
-        # There was a problem parsing the body of the response as json.
-        logging.exception(
-          ("Exception when calling DefaultApi->"
-           "apis_fqdn_v1_namespaces_namespace_resource_post. body: %s"), e.body)
-        raise
-      message = body.get("message")
-
-    logging.exception(("Exception when calling DefaultApi->"
-                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-                  message)
-    raise e
-
-  matching = []
-
-  for e in events.items:
-    if e.involved_object.uid != uid:
-      continue
-    matching.append(e)
-
-  return matching
-
-
-def parse_events(events):
-  """Parse events.
-
-  Args:
-    events: List of events.
-
-  Returns
-    pods_created: Set of unique pod names created.
-    services_created: Set of unique services created.
-  """
-  pattern = re.compile(".*Created.*(pod|Service).*: (.*)", re.IGNORECASE)
-
-  pods = set()
-  services = set()
-  for e in events:
-    m = re.match(pattern, e.message)
-    if not m:
-      continue
-
-    kind = m.group(1)
-    name = m.group(2)
-
-    if kind.lower() == "pod":
-      pods.add(name)
-    elif kind.lower() == "service":
-      services.add(name)
-
-  return pods, services
-
-
-@retrying.retry(wait_fixed=10, stop_max_delay=60)
-def terminate_replica(master_host, namespace, target, exit_code=0):
-  """Issue a request to terminate the requested TF replica running test_app.
-
-  Args:
-    master_host: The IP address of the master e.g. https://35.188.37.10
-    namespace: The namespace
-    target: The K8s service corresponding to the pod to terminate.
-    exit_code: What exit code to terminate the pod with.
-  """
-  params = {
-    "exitCode": exit_code,
-  }
-  tf_operator_util.send_request(master_host, namespace, target, "exit", params)
 
 
 def get_runconfig(master_host, namespace, target):
@@ -519,16 +239,16 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
         # TODO(jlewi): We are get pods using a label selector so there is
         # a risk that the pod we actual care about isn't present.
         logging.info("Waiting for pods to be running before shutting down.")
-        wait_for_pods_to_be_in_phases(api_client, namespace,
-                                      pod_selector,
-                                      ["Running"],
-                                      timeout=datetime.timedelta(
-                                        minutes=4))
+        k8s_util.wait_for_pods_to_be_in_phases(api_client, namespace,
+                                               pod_selector,
+                                               ["Running"],
+                                               timeout=datetime.timedelta(
+                                               minutes=4))
         logging.info("Pods are ready")
         logging.info("Issuing the terminate request")
         for num in range(num_targets):
           full_target = target + "-{0}".format(num)
-          terminate_replica(masterHost, namespace, full_target)
+          tf_job_client.terminate_replica(masterHost, namespace, full_target)
 
       # TODO(richardsliu):
       # There are lots of verifications in this file, consider refactoring them.
@@ -542,7 +262,7 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
         verify_runconfig(masterHost, namespace, name, "ps", num_ps, num_workers)
 
         # Terminate the chief worker to complete the job.
-        terminate_replica(masterHost, namespace, "{name}-chief-0".format(name=name))
+        tf_job_client.terminate_replica(masterHost, namespace, "{name}-chief-0".format(name=name))
 
       logging.info("Waiting for job to finish.")
       results = tf_job_client.wait_for_job(
@@ -611,38 +331,38 @@ def run_test(args):  # pylint: disable=too-many-branches,too-many-statements
         # error.
         logging.warning(creation_failures)
       if args.tfjob_version == "v1alpha1":
-        pod_labels = get_labels(name, runtime_id)
-        pod_selector = to_selector(pod_labels)
+        pod_labels = tf_job_client.get_labels(name, runtime_id)
+        pod_selector = tf_job_client.to_selector(pod_labels)
       else:
-        pod_labels = get_labels_v1alpha2(name)
-        pod_selector = to_selector(pod_labels)
+        pod_labels = tf_job_client.get_labels_v1alpha2(name)
+        pod_selector = tf_job_client.to_selector(pod_labels)
 
       # In v1alpha1 all pods are deleted. In v1alpha2, this depends on the pod
       # cleanup policy.
       if args.tfjob_version == "v1alpha1":
-        wait_for_pods_to_be_deleted(api_client, namespace, pod_selector)
+        k8s_util.wait_for_pods_to_be_deleted(api_client, namespace, pod_selector)
       else:
         # All pods are deleted.
         if args.verify_clean_pod_policy == "All":
-          wait_for_pods_to_be_deleted(api_client, namespace, pod_selector)
+          k8s_util.wait_for_pods_to_be_deleted(api_client, namespace, pod_selector)
         # Only running pods (PS) are deleted, completed pods are not.
         elif args.verify_clean_pod_policy == "Running":
-          wait_for_replica_type_in_phases(api_client, namespace, name, "Chief", ["Completed"])
-          wait_for_replica_type_in_phases(api_client, namespace, name, "Worker", ["Completed"])
-          ps_pod_labels = get_labels_v1alpha2(name, "PS")
-          ps_pod_selector = to_selector(ps_pod_labels)
-          wait_for_pods_to_be_deleted(api_client, namespace, ps_pod_selector)
+          tf_job_client.wait_for_replica_type_in_phases(api_client, namespace, name, "Chief", ["Completed"])
+          tf_job_client.wait_for_replica_type_in_phases(api_client, namespace, name, "Worker", ["Completed"])
+          ps_pod_labels = tf_job_client.get_labels_v1alpha2(name, "PS")
+          ps_pod_selector = tf_job_client.to_selector(ps_pod_labels)
+          k8s_util.wait_for_pods_to_be_deleted(api_client, namespace, ps_pod_selector)
         # No pods are deleted.
         elif args.verify_clean_pod_policy == "None":
-          wait_for_replica_type_in_phases(api_client, namespace, name, "Chief", ["Completed"])
-          wait_for_replica_type_in_phases(api_client, namespace, name, "Worker", ["Completed"])
-          wait_for_replica_type_in_phases(api_client, namespace, name, "PS", ["Running"])
+          tf_job_client.wait_for_replica_type_in_phases(api_client, namespace, name, "Chief", ["Completed"])
+          tf_job_client.wait_for_replica_type_in_phases(api_client, namespace, name, "Worker", ["Completed"])
+          tf_job_client.wait_for_replica_type_in_phases(api_client, namespace, name, "PS", ["Running"])
 
       tf_job_client.delete_tf_job(api_client, namespace, name, version=args.tfjob_version)
 
       logging.info("Waiting for job %s in namespaces %s to be deleted.", name,
                    namespace)
-      wait_for_delete(
+      k8s_util.wait_for_delete(
         api_client, namespace, name, args.tfjob_version, status_callback=tf_job_client.log_status)
 
     # TODO(jlewi):

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -11,6 +11,8 @@ from kubernetes import client as k8s_client
 from kubernetes.client.rest import ApiException
 
 from py import util
+from py import util as tf_operator_util
+
 
 TF_JOB_GROUP = "kubeflow.org"
 TF_JOB_PLURAL = "tfjobs"

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -1,6 +1,7 @@
 """Some utility functions for working with TFJobs."""
 
 import datetime
+import httplib
 import json
 import logging
 import multiprocessing

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -10,8 +10,8 @@ import time
 from kubernetes import client as k8s_client
 from kubernetes.client.rest import ApiException
 
+from py import k8s_util
 from py import util
-from py import util as tf_operator_util
 
 
 TF_JOB_GROUP = "kubeflow.org"
@@ -338,15 +338,14 @@ def to_selector(labels):
 
   return ",".join(parts)
 
-
 def wait_for_replica_type_in_phases(api_client, namespace, tfjob_name, replica_type, phases):
   pod_labels = get_labels_v1alpha2(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  wait_for_pods_to_be_in_phases(api_client, namespace,
-                                pod_selector,
-                                phases,
-                                timeout=datetime.timedelta(
-                                  minutes=4))
+  k8s_util.wait_for_pods_to_be_in_phases(api_client, namespace,
+                                         pod_selector,
+                                         phases,
+                                         timeout=datetime.timedelta(
+                                         minutes=4))
 
 @retrying.retry(wait_fixed=10, stop_max_delay=60)
 def terminate_replica(master_host, namespace, target, exit_code=0):
@@ -361,4 +360,4 @@ def terminate_replica(master_host, namespace, target, exit_code=0):
   params = {
     "exitCode": exit_code,
   }
-  tf_operator_util.send_request(master_host, namespace, target, "exit", params)
+  util.send_request(master_host, namespace, target, "exit", params)


### PR DESCRIPTION
This is part 1 of the work to refactor E2E tests and make them easier to write.

This part removes the common util methods from test_runner.py and places them in helper libraries.
- k8s_util for operations with k8s (e.g. services, pods)
- tf_job_client for interacting with the TFJob resource(including replicas)
- ks_util for operations with ksonnet

Next steps:
- Remove the v1alpha1 tests
- Refactor the methods specific to shutdown policy, runtime config, and clean pod policy to separate test runner classes
- Create a buildTestTemplate function in workflows.libsonnet.

The long term plan is each test should be in a self-contained python file that creates a tfjob, executes some commands, and verify results. Boiler plate code should be reduced to a minimum.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/845)
<!-- Reviewable:end -->
