### PR TITLE
Add an e2etest for testing restart policy

### DIFF
--- a/py/build_and_push_image.py
+++ b/py/build_and_push_image.py
@@ -14,12 +14,12 @@ import jinja2
 
 def GetGitHash(root_dir=None):
   # The image tag is based on the githash.
-  git_hash = subprocess.check_output(
-    ["git", "rev-parse", "--short", "HEAD"], cwd=root_dir).decode("utf-8")
+  git_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"],
+                                     cwd=root_dir).decode("utf-8")
   git_hash = git_hash.strip()
 
-  modified_files = subprocess.check_output(
-    ["git", "ls-files", "--modified"], cwd=root_dir)
+  modified_files = subprocess.check_output(["git", "ls-files", "--modified"],
+                                           cwd=root_dir)
   untracked_files = subprocess.check_output(
     ["git", "ls-files", "--others", "--exclude-standard"], cwd=root_dir)
   if modified_files or untracked_files:

--- a/py/cleanpod_policy_tests.py
+++ b/py/cleanpod_policy_tests.py
@@ -70,9 +70,9 @@ class CleanPodPolicyTests(test_util.TestCase):
     # Only running pods (PS) are deleted, completed pods are not.
     elif clean_pod_policy == "Running":
       tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "Chief", ["Completed"])
+        api_client, self.namespace, self.name, "Chief", ["Succeeded"])
       tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "Worker", ["Completed"])
+        api_client, self.namespace, self.name, "Worker", ["Succeeded"])
       pod_labels = tf_job_client.get_labels(self.name, "PS")
       pod_selector = tf_job_client.to_selector(pod_labels)
       k8s_util.wait_for_pods_to_be_deleted(api_client, self.namespace,
@@ -80,9 +80,9 @@ class CleanPodPolicyTests(test_util.TestCase):
     # No pods are deleted.
     elif clean_pod_policy == "None":
       tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "Chief", ["Completed"])
+        api_client, self.namespace, self.name, "Chief", ["Succeeded"])
       tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "Worker", ["Completed"])
+        api_client, self.namespace, self.name, "Worker", ["Succeeded"])
       tf_job_client.wait_for_replica_type_in_phases(
         api_client, self.namespace, self.name, "PS", ["Running"])
 

--- a/py/cleanpod_policy_tests.py
+++ b/py/cleanpod_policy_tests.py
@@ -11,7 +11,9 @@ CLEANPOD_ALL_COMPONENT_NAME = "clean_pod_all"
 CLEANPOD_RUNNING_COMPONENT_NAME = "clean_pod_running"
 CLEANPOD_NONE_COMPONENT_NAME = "clean_pod_none"
 
+
 class CleanPodPolicyTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -19,13 +21,15 @@ class CleanPodPolicyTests(test_util.TestCase):
     self.namespace = namespace
     self.tfjob_version = args.tfjob_version
     self.params = args.params
-    super(CleanPodPolicyTests, self).__init__(class_name="CleanPodPolicyTests", name=name)
+    super(CleanPodPolicyTests, self).__init__(
+      class_name="CleanPodPolicyTests", name=name)
 
   def run_tfjob_with_cleanpod_policy(self, component, clean_pod_policy):
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -34,14 +38,20 @@ class CleanPodPolicyTests(test_util.TestCase):
     # Wait for the job to either be in Running state or a terminal state
     logging.info("Wait for conditions Running, Succeeded, or Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
     # Wait for the job to complete.
     logging.info("Waiting for job to finish.")
     results = tf_job_client.wait_for_job(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
     logging.info("Final TFJob:\n %s", json.dumps(results, indent=2))
 
@@ -55,31 +65,37 @@ class CleanPodPolicyTests(test_util.TestCase):
     if clean_pod_policy == "All":
       pod_labels = tf_job_client.get_labels(self.name)
       pod_selector = tf_job_client.to_selector(pod_labels)
-      k8s_util.wait_for_pods_to_be_deleted(api_client, self.namespace, pod_selector)
+      k8s_util.wait_for_pods_to_be_deleted(api_client, self.namespace,
+                                           pod_selector)
     # Only running pods (PS) are deleted, completed pods are not.
     elif clean_pod_policy == "Running":
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "Chief", ["Completed"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "Worker", ["Completed"])
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "Chief", ["Completed"])
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "Worker", ["Completed"])
       pod_labels = tf_job_client.get_labels(self.name, "PS")
       pod_selector = tf_job_client.to_selector(pod_labels)
-      k8s_util.wait_for_pods_to_be_deleted(api_client, self.namespace, pod_selector)
+      k8s_util.wait_for_pods_to_be_deleted(api_client, self.namespace,
+                                           pod_selector)
     # No pods are deleted.
     elif clean_pod_policy == "None":
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "Chief", ["Completed"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "Worker", ["Completed"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "Chief", ["Completed"])
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "Worker", ["Completed"])
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
 
   # Verify that all pods are deleted when the job completes.
@@ -96,6 +112,7 @@ class CleanPodPolicyTests(test_util.TestCase):
   def test_cleanpod_none(self):
     return self.run_tfjob_with_cleanpod_policy(
       CLEANPOD_NONE_COMPONENT_NAME + "_" + self.tfjob_version, "None")
+
 
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/deploy.py
+++ b/py/deploy.py
@@ -86,8 +86,8 @@ def ks_deploy(app_dir, component, params, env=None, account=None):
       raise
 
   for k, v in params.iteritems():
-    util.run(
-      ["ks", "param", "set", "--env=" + env, component, k, v], cwd=app_dir)
+    util.run(["ks", "param", "set", "--env=" + env, component, k, v],
+             cwd=app_dir)
 
   apply_command = ["ks", "apply", env, "-c", component]
   if account:
@@ -201,7 +201,7 @@ def setup_kubeflow(args):
       "tfJobImage": args.image,
       "name": "kubeflow-core",
       "namespace": args.namespace,
-      "tfJobVersion":  args.tf_job_version,
+      "tfJobVersion": args.tf_job_version,
     }
 
     component = "core"
@@ -231,10 +231,14 @@ def setup_kubeflow(args):
     finally:
       # Run kubectl describe to get useful information about the deployment.
       # This will help troubleshoot any errors.
-      util.run(["kubectl", "-n", args.namespace, "describe", "deploy",
-                tf_job_deployment_name])
-      util.run(["kubectl", "-n", args.namespace, "describe", "pods", "-l",
-                "name=tf-job-operator"])
+      util.run([
+        "kubectl", "-n", args.namespace, "describe", "deploy",
+        tf_job_deployment_name
+      ])
+      util.run([
+        "kubectl", "-n", args.namespace, "describe", "pods", "-l",
+        "name=tf-job-operator"
+      ])
 
   # Reraise the exception so that the step fails because there's no point
   # continuing the test.
@@ -250,6 +254,7 @@ def setup_kubeflow(args):
     t.class_name = "GKE"
     gcs_client = storage.Client(project=args.project)
     test_util.create_junit_xml_file([t], args.junit_path, gcs_client)
+
 
 def teardown(args):
   """Teardown the resources."""

--- a/py/distributed_training_tests.py
+++ b/py/distributed_training_tests.py
@@ -8,7 +8,9 @@ from py import tf_job_client
 
 TFJOB_COMPONENT_NAME = "distributed_training"
 
+
 class DistributedTrainingJobTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -25,7 +27,8 @@ class DistributedTrainingJobTests(test_util.TestCase):
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -34,14 +37,20 @@ class DistributedTrainingJobTests(test_util.TestCase):
     # Wait for the job to either be in Running state or a terminal state
     logging.info("Wait for conditions Running, Succeeded, or Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
     # Wait for the job to complete.
     logging.info("Waiting for job to finish.")
     results = tf_job_client.wait_for_job(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
     logging.info("Final TFJob:\n %s", json.dumps(results, indent=2))
 
@@ -58,17 +67,23 @@ class DistributedTrainingJobTests(test_util.TestCase):
       logging.warning(creation_failures)
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
 
   # Run a distributed training TFJob, wait for it to complete, and check for pod/service
   # creation errors.
   def test_distributed_training_independent_worker(self):
-    self.run_distributed_training_job(TFJOB_COMPONENT_NAME + "_" + self.tfjob_version)
+    self.run_distributed_training_job(TFJOB_COMPONENT_NAME + "_" +
+                                      self.tfjob_version)
+
 
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/invalid_tfjob_tests.py
+++ b/py/invalid_tfjob_tests.py
@@ -9,7 +9,9 @@ from py import tf_job_client
 
 INVALID_TFJOB_COMPONENT_NAME = "invalid_tfjob"
 
+
 class InvalidTfJobTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -17,7 +19,8 @@ class InvalidTfJobTests(test_util.TestCase):
     self.namespace = namespace
     self.tfjob_version = args.tfjob_version
     self.params = args.params
-    super(InvalidTfJobTests, self).__init__(class_name="InvalidTfJobTests", name=name)
+    super(InvalidTfJobTests, self).__init__(
+      class_name="InvalidTfJobTests", name=name)
 
   def test_invalid_tfjob_spec(self):
     api_client = k8s_client.ApiClient()
@@ -25,7 +28,7 @@ class InvalidTfJobTests(test_util.TestCase):
 
     # Setup the ksonnet app
     ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
-      self.params)
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -33,8 +36,11 @@ class InvalidTfJobTests(test_util.TestCase):
 
     logging.info("Wait for conditions Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
 
     logging.info("Final TFJob:\n %s", json.dumps(results, indent=2))
 
@@ -54,12 +60,17 @@ class InvalidTfJobTests(test_util.TestCase):
       logging.error(self.failure)
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
+
 
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -22,10 +22,10 @@ def get_pod_start_time(client, namespace, pod_selector, index):
   """
   pods = list_pods(client, namespace, pod_selector)
   logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
-  #pod = pods.items[index]
-  for p in pods.items:
-    return pod.status.start_time
-  #return pod.status.start_time
+  pod = pods.items[index]
+  #for p in pods.items:
+  #  return pod.status.start_time
+  return pod.status.start_time
 
 
 def log_pods(pods):
@@ -34,13 +34,13 @@ def log_pods(pods):
     logging.info("Pod name=%s Phase=%s", p.metadata.name, p.status.phase)
 
 
-def wait_for_pods_to_be_in_phases(client,
-                                  namespace,
-                                  pod_selector,
-                                  phases,
-                                  timeout=datetime.timedelta(minutes=5),
-                                  polling_interval=datetime.timedelta(
-                                  seconds=30)):
+def wait_for_pods_to_be_in_phases(
+    client,
+    namespace,
+    pod_selector,
+    phases,
+    timeout=datetime.timedelta(minutes=5),
+    polling_interval=datetime.timedelta(seconds=30)):
   """Wait for the pods matching the selector to be in the specified state
 
   Args:
@@ -73,20 +73,20 @@ def wait_for_pods_to_be_in_phases(client,
     if datetime.datetime.now() + polling_interval > end_time:
       logging.info("Latest pod phases")
       log_pods(pods)
-      logging.error("Timeout waiting for pods to be in phase: %s",
-                    phases)
-      raise util.TimeoutError("Timeout waiting for pods to be in states %s" %
-                              phases)
+      logging.error("Timeout waiting for pods to be in phase: %s", phases)
+      raise util.TimeoutError(
+        "Timeout waiting for pods to be in states %s" % phases)
     time.sleep(polling_interval.seconds)
 
   return None
 
-def wait_for_pods_to_be_deleted(client,
-                                namespace,
-                                pod_selector,
-                                timeout=datetime.timedelta(minutes=5),
-                                polling_interval=datetime.timedelta(
-                                  seconds=30)):
+
+def wait_for_pods_to_be_deleted(
+    client,
+    namespace,
+    pod_selector,
+    timeout=datetime.timedelta(minutes=5),
+    polling_interval=datetime.timedelta(seconds=30)):
   """Wait for the specified job to be deleted.
 
   Args:
@@ -113,6 +113,7 @@ def wait_for_pods_to_be_deleted(client,
 
     time.sleep(polling_interval.seconds)
 
+
 def list_pods(client, namespace, label_selector):
   core = k8s_client.CoreV1Api(client)
   try:
@@ -134,9 +135,10 @@ def list_pods(client, namespace, label_selector):
       message = body.get("message")
 
     logging.exception(("Exception when calling DefaultApi->"
-                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-                  message)
+                       "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                      message)
     raise e
+
 
 def get_events(client, namespace, uid):
   """Get the events for the provided object."""
@@ -161,8 +163,8 @@ def get_events(client, namespace, uid):
       message = body.get("message")
 
     logging.exception(("Exception when calling DefaultApi->"
-                   "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
-                  message)
+                       "apis_fqdn_v1_namespaces_namespace_resource_post: %s"),
+                      message)
     raise e
 
   matching = []
@@ -173,6 +175,7 @@ def get_events(client, namespace, uid):
     matching.append(e)
 
   return matching
+
 
 def parse_events(events):
   """Parse events.

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -27,7 +27,7 @@ def get_container_start_time(client, namespace, pod_selector, index, phase):
   logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
   pod = pods.items[index]
 
-  if phase == "running":
+  if phase == "Running":
     container_start_time = pod.status.container_statuses[
       0].state.running.started_at
   else:

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -21,8 +21,11 @@ def get_pod_start_time(client, namespace, pod_selector, index):
     pod_start_time: pod start time in datetime datatype
   """
   pods = list_pods(client, namespace, pod_selector)
-  pod = pods.items[index]
-  return pod.status.start_time
+  logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
+  #pod = pods.items[index]
+  for p in pods.items:
+    return pod.status.start_time
+  #return pod.status.start_time
 
 
 def log_pods(pods):

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -11,9 +11,9 @@ from kubernetes.client import rest
 
 
 def get_container_start_time(client, namespace, pod_selector, index):
-  """ get start time of container in the pod with pod_name, 
+  """ get start time of container in the pod with pod_name,
   we assume there is only one container.
-  
+
   Args:
     client: K8s api client.
     namespace: Namespace.

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -56,6 +56,7 @@ def wait_for_pods_to_be_in_phases(
   """
   end_time = datetime.datetime.now() + timeout
   while True:
+    time.sleep(polling_interval.seconds)
     pods = list_pods(client, namespace, pod_selector)
 
     logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
@@ -78,7 +79,7 @@ def wait_for_pods_to_be_in_phases(
       logging.error("Timeout waiting for pods to be in phase: %s", phases)
       raise util.TimeoutError(
         "Timeout waiting for pods to be in states %s" % phases)
-    time.sleep(polling_interval.seconds)
+
 
   return None
 

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -9,6 +9,22 @@ from kubeflow.testing import util
 from kubernetes import client as k8s_client
 from kubernetes.client import rest
 
+
+def get_pod_start_time(client, namespace, pod_selector, index):
+  """ get start time of pod with pod_name 
+  Args:
+    client: K8s api client.
+    namespace: Namespace.
+    pod_selector: Selector for the pods.
+    index: Index of the pods
+  Returns:
+    pod_start_time: pod start time in datetime datatype
+  """
+  pods = list_pods(client, namespace, pod_selector)
+  pod = pods.items[index]
+  return pod.status.start_time
+
+
 def log_pods(pods):
   """Log information about pods."""
   for p in pods.items:

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -10,7 +10,7 @@ from kubernetes import client as k8s_client
 from kubernetes.client import rest
 
 
-def get_container_start_time(client, namespace, pod_selector, index):
+def get_container_start_time(client, namespace, pod_selector, index, phase):
   """ get start time of container in the pod with pod_name,
   we assume there is only one container.
 
@@ -19,6 +19,7 @@ def get_container_start_time(client, namespace, pod_selector, index):
     namespace: Namespace.
     pod_selector: Selector for the pods.
     index: Index of the pods
+    phase: expected of the phase when getting the start time
   Returns:
     container_start_time: container start time in datetime datatype
   """
@@ -26,7 +27,14 @@ def get_container_start_time(client, namespace, pod_selector, index):
   logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
   pod = pods.items[index]
 
-  return pod.status.container_statuses[0].state.running.started_at
+  if phase == "running":
+    container_start_time = pod.status.container_statuses[
+      0].state.running.started_at
+  else:
+    container_start_time = pod.status.container_statuses[
+      0].state.terminated.started_at
+
+  return container_start_time
 
 
 def log_pods(pods):

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -11,7 +11,9 @@ from kubernetes.client import rest
 
 
 def get_container_start_time(client, namespace, pod_selector, index):
-  """ get start time of container in the pod with pod_name, we assume there is only one container.
+  """ get start time of container in the pod with pod_name, 
+  we assume there is only one container.
+  
   Args:
     client: K8s api client.
     namespace: Namespace.

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -63,6 +63,8 @@ def wait_for_pods_to_be_in_phases(
     is_match = True
     for p in pods.items:
       if p.status.phase not in phases:
+        # for debug
+        logging.info("pod in phase %s", p.status.phase)
         is_match = False
 
     if is_match:

--- a/py/k8s_util.py
+++ b/py/k8s_util.py
@@ -25,8 +25,7 @@ def get_container_start_time(client, namespace, pod_selector, index):
   pods = list_pods(client, namespace, pod_selector)
   logging.info("%s pods matched %s pods", len(pods.items), pod_selector)
   pod = pods.items[index]
-  #for p in pods.items:
-  #  return pod.status.start_time
+
   return pod.status.container_statuses[0].state.running.started_at
 
 

--- a/py/ks_util.py
+++ b/py/ks_util.py
@@ -17,13 +17,12 @@ def setup_ks_app(app_dir, env, namespace, component, params):
     # Create a new environment for this run
     try:
       util.run(["ks", "env", "add", env, "--namespace=" + namespace],
-                cwd=app_dir)
+               cwd=app_dir)
     except subprocess.CalledProcessError as e:
       if not re.search(".*environment.*already exists.*", e.output):
         raise
 
     for pair in params.split(","):
       k, v = pair.split("=", 1)
-      util.run(
-        ["ks", "param", "set", "--env=" + env, component, k, v],
-        cwd=app_dir)
+      util.run(["ks", "param", "set", "--env=" + env, component, k, v],
+               cwd=app_dir)

--- a/py/py_checks.py
+++ b/py/py_checks.py
@@ -52,8 +52,8 @@ def run_lint(args):
       for f in fnmatch.filter(files, pat):
         full_path = os.path.join(root, f)
         try:
-          util.run(
-            ["pylint", "--rcfile=" + rc_file, full_path], cwd=args.src_dir)
+          util.run(["pylint", "--rcfile=" + rc_file, full_path],
+                   cwd=args.src_dir)
         except subprocess.CalledProcessError:
           failed_files.append(full_path[len(args.src_dir):])
 

--- a/py/release.py
+++ b/py/release.py
@@ -151,11 +151,14 @@ def build_operator_image(root_dir,
     "github.com/kubeflow/tf-operator/dashboard/backend",
   ]
   for t in targets:
-    if t in ["github.com/kubeflow/tf-operator/cmd/tf-operator.v2",
-             "github.com/kubeflow/tf-operator/cmd/tf-operator.v1beta1"]:
+    if t in [
+        "github.com/kubeflow/tf-operator/cmd/tf-operator.v2",
+        "github.com/kubeflow/tf-operator/cmd/tf-operator.v1beta1"
+    ]:
       util.run([
         "go", "install", "-ldflags",
-        "-X github.com/kubeflow/tf-operator/pkg/version.GitSHA={}".format(commit), t
+        "-X github.com/kubeflow/tf-operator/pkg/version.GitSHA={}".format(
+          commit), t
       ])
     util.run(["go", "install", t])
 
@@ -174,8 +177,7 @@ def build_operator_image(root_dir,
 
   # List of paths to copy relative to root.
   sources = [
-    "build/images/tf_operator/Dockerfile",
-    "examples/tf_sample/tf_smoke.py",
+    "build/images/tf_operator/Dockerfile", "examples/tf_sample/tf_smoke.py",
     os.path.join(go_path, bin_path, "tf-operator.v2"),
     os.path.join(go_path, bin_path, "tf-operator.v1beta1"),
     os.path.join(go_path, bin_path, "backend"), "dashboard/frontend/build"

--- a/py/release_test.py
+++ b/py/release_test.py
@@ -35,12 +35,8 @@ class ReleaseTest(unittest.TestCase):
   @mock.patch("py.release.util.install_go_deps")
   @mock.patch("py.release.util.clone_repo")
   @mock.patch("py.release.build_and_push")
-  def test_build_pr(# pylint: disable=no-self-use
-      self,
-      mock_build_and_push,
-      mock_clone,
-      _mock_install,
-      _mock_os,
+  def test_build_pr(  # pylint: disable=no-self-use
+      self, mock_build_and_push, mock_clone, _mock_install, _mock_os,
       _mock_makedirs):
     parser = release.build_parser()
     args = parser.parse_args(
@@ -78,6 +74,7 @@ rbac:
   install: false
   apiVersion: v1beta1"""
       self.assertEqual(expected, output)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -1,9 +1,7 @@
-import datetime
 import json
 import logging
 from kubernetes import client as k8s_client
 from kubeflow.testing import test_util, util
-from py import k8s_util
 from py import ks_util
 from py import test_runner
 from py import tf_job_client
@@ -51,7 +49,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     if replica_restart_policy == "Always" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
           self.name, self.namespace)
         logging.error(self.failure)
@@ -60,7 +58,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "Always" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
           self.name, self.namespace)
         logging.error(self.failure)
@@ -69,7 +67,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "OnFailure" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
           failed to restart the pod with exit_code 1".format(
           self.name, self.namespace)
@@ -79,7 +77,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "OnFailure" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
           failed to not to restart the pod with exit_code 0".format(
           self.name, self.namespace)
@@ -89,7 +87,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "Never" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy Never \
           failed to not to restart the pod with exit_code 1".format(
           self.name, self.namespace)
@@ -99,7 +97,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "Never" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy Never \
           failed to not to restart the pod with exit_code 0".format(
           self.name, self.namespace)
@@ -109,7 +107,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     elif replica_restart_policy == "ExitCode" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
           failed to not to restart the pod with exit_code 1".format(
           self.name, self.namespace)
@@ -119,7 +117,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     else:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res == False:
+      if res is False:
         self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
           failed to restart the pod with exit_code 128".format(
           self.name, self.namespace)
@@ -182,14 +180,14 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
 
   # Verify that the pod is not restarted after permanent error ( 1-127 ).
   # We terminate PS with exit_code=1, and verify its phase becomes Failed.
-  def test_restart_exitcode_permanent_error():
+  def test_restart_exitcode_permanent_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
       "ExitCode", 1)
 
   # Verify that the pod is not restarted after permanent error ( 128-255 ).
   # We terminate PS with exit_code=128, and verify it is restarted.
-  def test_restart_exitcode_retryable_error():
+  def test_restart_exitcode_retryable_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
       "ExitCode", 128)

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -1,9 +1,7 @@
-import datetime
 import json
 import logging
 from kubernetes import client as k8s_client
 from kubeflow.testing import test_util, util
-from py import k8s_util
 from py import ks_util
 from py import test_runner
 from py import tf_job_client

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -51,12 +51,12 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Succeeded"])
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(
-        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Succeeded"])
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
+                                                           self.name, "PS", 0)
       # for debug
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
@@ -71,18 +71,18 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Failed"])
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(
-        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Failed"])
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
+                                                           self.name, "PS", 0)
       # for debug
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
-        self.failure = "Job {0} in namespace {1} with restart policy OnFailure failed to restart the pod with exit_code 1".format(
-          self.name, self.namespace)
+        self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
+          failed to restart the pod with exit_code 1".format(self.name, self.namespace)
         logging.error(self.failure)
         return
 
@@ -103,18 +103,18 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Failed"])
-      tf_job_client.wait_for_replica_type_in_phases(
-        api_client, self.namespace, self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(
-        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Failed"])
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
+                                                           self.name, "PS", 0)
       # for debug
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
-        self.failure = "Job {0} in namespace {1} with restart policy ExitCode failed to restart the pod with exit_code 128".format(
-          self.name, self.namespace)
+        self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
+          failed to restart the pod with exit_code 128".format(self.name, self.namespace)
         logging.error(self.failure)
         return
 
@@ -163,7 +163,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
   def test_restart_exitcode_retryable_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
-      "ExitCode", 128)
+      "ExitCode", 130)
 
 
 if __name__ == "__main__":

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -51,8 +51,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Succeeded"])
+      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+      #                                              self.name, "PS", ["Succeeded"])
       tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
                                                     self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -71,8 +71,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Failed"])
+      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+      #                                              self.name, "PS", ["Failed"])
       tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
                                                     self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
@@ -103,8 +103,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Failed"])
+      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+      #                                              self.name, "PS", ["Failed"])
       tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
                                                     self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
@@ -114,7 +114,7 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
                    str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
-          failed to restart the pod with exit_code 128".format(self.name, self.namespace)
+          failed to restart the pod with exit_code 130".format(self.name, self.namespace)
         logging.error(self.failure)
         return
 

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -146,12 +146,12 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
       "ExitCode", 1)
 
-  # Verify that the pod is not restarted after permanent error ( 128-255 ).
-  # We terminate PS with exit_code=128, and verify it is restarted.
+  # Verify that the pod is not restarted after retryable error.
+  # We terminate PS with exit_code=130, and verify it is restarted.
   def test_restart_exitcode_retryable_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
-      "ExitCode", 128)
+      "ExitCode", 130)
 
 
 if __name__ == "__main__":

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -52,6 +52,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
       tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Succeeded"])
+      tf_job_client.wait_for_replica_type_in_phases(
         api_client, self.namespace, self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(
         api_client, self.namespace, self.name, "PS", 0)
@@ -69,6 +71,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Failed"])
       tf_job_client.wait_for_replica_type_in_phases(
         api_client, self.namespace, self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(
@@ -99,6 +103,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         api_client, self.namespace, self.name, "PS", 0)
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Failed"])
       tf_job_client.wait_for_replica_type_in_phases(
         api_client, self.namespace, self.name, "PS", ["Running"])
       restart_time = tf_job_client.get_start_time_by_index(

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -1,0 +1,135 @@
+import datetime
+import json
+import logging
+from kubernetes import client as k8s_client
+from kubeflow.testing import test_util, util
+from py import k8s_util
+from py import ks_util
+from py import test_runner
+from py import tf_job_client
+
+REPLICA_RESTART_POLICY_ALWAYS_COMPONENT_NAME = "replica_restart_policy_always"
+REPLICA_RESTART_POLICY_ONFAILURE_COMPONENT_NAME = "replica_restart_policy_onfailure"
+REPLICA_RESTART_POLICY_NEVER_COMPONENT_NAME = "replica_restart_policy_never"
+REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME = "replica_restart_policy_exitcode"
+
+class ReplicaRestartPolicyTests(test_util.TestCase):
+  def __init__(self, args):
+    namespace, name, env = test_runner.parse_runtime_params(args)
+    self.app_dir = args.app_dir
+    self.env = env
+    self.namespace = namespace
+    self.tfjob_version = args.tfjob_version
+    self.params = args.params
+    super(ReplicaRestartPolicyTests, self).__init__(class_name="ReplicaRestartPolicyTests", name=name)
+
+  def run_tfjob_with_replica_restart_policy(self, component, replica_restart_policy, exit_code):
+    api_client = k8s_client.ApiClient()
+
+    # Setup the ksonnet app
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+
+    # Create the TF job
+    util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
+    logging.info("Created job %s in namespaces %s", self.name, self.namespace)
+
+    # Wait for the job to either be in Running state or a terminal state
+    logging.info("Wait for conditions Running, Succeeded, or Failed")
+    results = tf_job_client.wait_for_condition(
+      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+    logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
+
+
+    if replica_restart_policy == "Always":
+      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      # for debug
+      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      if restart_time <= first_start_time:
+        self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
+          self.name, self.namespace)
+        logging.error(self.failure)
+        return
+
+    elif replica_restart_policy == "OnFailure":
+      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      # for debug
+      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      if restart_time <= first_start_time:
+        self.failure = "Job {0} in namespace {1} with restart policy OnFailure failed to restart the pod with exit_code 1".format(
+          self.name, self.namespace)
+        logging.error(self.failure)
+        return
+
+    elif replica_restart_policy == "Never":
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Failed"])
+
+    elif replica_restart_policy == "ExitCode" and exit_code == 1:
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Failed"])
+
+    else:
+      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
+                                                    self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      # for debug
+      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      if restart_time <= first_start_time:
+        self.failure = "Job {0} in namespace {1} with restart policy ExitCode failed to restart the pod with exit_code 128".format(
+          self.name, self.namespace)
+        logging.error(self.failure)
+        return
+
+    # Delete the TFJob.
+    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
+                 self.namespace)
+    tf_job_client.wait_for_delete(
+      api_client, self.namespace, self.name, self.tfjob_version,
+      status_callback=tf_job_client.log_status)
+
+  # Verify that the pod is restarted even after the container exits with success.
+  # We terminate PS with exit_code=0, and verify it is restarted.
+  def test_restart_always(self):
+    return self.run_tfjob_with_replica_restart_policy(
+      REPLICA_RESTART_POLICY_ALWAYS_COMPONENT_NAME + "_" + self.tfjob_version, "Always", 0)
+
+  # Verify that the pod is restarted after failure.
+  # We terminate PS with exit_code=1, and verify it is restarted.
+  def test_restart_onfailure(self):
+    return self.run_tfjob_with_replica_restart_policy(
+      REPLICA_RESTART_POLICY_ONFAILURE_COMPONENT_NAME + "_" + self.tfjob_version, "OnFailure", 1)
+
+  # Verify that the pod is never restarted.
+  # We terminate PS with exit_code=1, and verify that its phase becomes Failed.
+  def test_restart_never(self):
+    return self.run_tfjob_with_replica_restart_policy(
+      REPLICA_RESTART_POLICY_NEVER_COMPONENT_NAME + "_" + self.tfjob_version, "Never", 1)
+
+  # Verify that the pod is not restarted after permanent error ( 1-127 ).
+  # We terminate PS with exit_code=1, and verify its phase becomes Failed.
+  def test_restart_exitcode_permanent_error():
+    return self.run_tfjob_with_replica_restart_policy(
+      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 1)
+  
+  # Verify that the pod is not restarted after permanent error ( 128-255 ).
+  # We terminate PS with exit_code=128, and verify it is restarted.
+  def test_restart_exitcode_retryable_error():
+    return self.run_tfjob_with_replica_restart_policy(
+      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 128)
+  
+if __name__ == "__main__":
+  test_runner.main(module=__name__)

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -1,7 +1,9 @@
+import datetime
 import json
 import logging
 from kubernetes import client as k8s_client
 from kubeflow.testing import test_util, util
+from py import k8s_util
 from py import ks_util
 from py import test_runner
 from py import tf_job_client
@@ -49,80 +51,41 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     if replica_restart_policy == "Always" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     elif replica_restart_policy == "Always" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     elif replica_restart_policy == "OnFailure" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
-          failed to restart the pod with exit_code 1".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
+
 
     elif replica_restart_policy == "OnFailure" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
-          failed to not to restart the pod with exit_code 0".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     elif replica_restart_policy == "Never" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy Never \
-          failed to not to restart the pod with exit_code 1".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     elif replica_restart_policy == "Never" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy Never \
-          failed to not to restart the pod with exit_code 0".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     elif replica_restart_policy == "ExitCode" and exit_code == 1:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
-          failed to not to restart the pod with exit_code 1".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
 
     else:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
-      if res is False:
-        self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
-          failed to restart the pod with exit_code 128".format(
-          self.name, self.namespace)
-        logging.error(self.failure)
-        return
+
+    if res is False:
+      self.failure = "Job {0} in namespace {1} with restart policy {2} failed test \
+        with exit_code {4}".format(self.name, self.namespace, replica_restart_policy, exit_code)
+      logging.error(self.failure)
+      return
 
     # Delete the TFJob.
     tf_job_client.delete_tf_job(

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -47,19 +47,22 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
     if replica_restart_policy == "Always":
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
       first_start_time = tf_job_client.get_start_time_by_index(
         api_client, self.namespace, self.name, "PS", 0)
+
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-      #                                              self.name, "PS", ["Succeeded"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
-                                                           self.name, "PS", 0)
-      # for debug
+
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
+
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
           self.name, self.namespace)
@@ -67,22 +70,26 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         return
 
     elif replica_restart_policy == "OnFailure":
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
       first_start_time = tf_job_client.get_start_time_by_index(
         api_client, self.namespace, self.name, "PS", 0)
+
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-      #                                              self.name, "PS", ["Failed"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
-                                                           self.name, "PS", 0)
-      # for debug
+
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
+
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy OnFailure \
-          failed to restart the pod with exit_code 1".format(self.name, self.namespace)
+          failed to restart the pod with exit_code 1".format(
+          self.name, self.namespace)
         logging.error(self.failure)
         return
 
@@ -99,22 +106,26 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
                                                     self.name, "PS", ["Failed"])
 
     else:
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
       first_start_time = tf_job_client.get_start_time_by_index(
         api_client, self.namespace, self.name, "PS", 0)
+
       tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
                                        "ps", 1, exit_code)
-      #tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-      #                                              self.name, "PS", ["Failed"])
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace,
-                                                           self.name, "PS", 0)
-      # for debug
+
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+
       logging.info("First start time: %s, restart time: %s",
                    str(first_start_time), str(restart_time))
+
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy ExitCode \
-          failed to restart the pod with exit_code 130".format(self.name, self.namespace)
+          failed to restart the pod with exit_code 130".format(
+          self.name, self.namespace)
         logging.error(self.failure)
         return
 

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -121,13 +121,13 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
 
   # Verify that the pod is not restarted after permanent error ( 1-127 ).
   # We terminate PS with exit_code=1, and verify its phase becomes Failed.
-  def test_restart_exitcode_permanent_error():
+  def test_restart_exitcode_permanent_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 1)
   
   # Verify that the pod is not restarted after permanent error ( 128-255 ).
   # We terminate PS with exit_code=128, and verify it is restarted.
-  def test_restart_exitcode_retryable_error():
+  def test_restart_exitcode_retryable_error(self):
     return self.run_tfjob_with_replica_restart_policy(
       REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 128)
   

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -60,7 +60,6 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, True)
 
-
     elif replica_restart_policy == "OnFailure" and exit_code == 0:
       res = tf_job_client.terminate_and_verify_start_time(
         api_client, self.namespace, self.name, "ps", 0, exit_code, False)
@@ -83,7 +82,8 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
 
     if res is False:
       self.failure = "Job {0} in namespace {1} with restart policy {2} failed test \
-        with exit_code {4}".format(self.name, self.namespace, replica_restart_policy, exit_code)
+        with exit_code {3}".format(self.name, self.namespace,
+                                   replica_restart_policy, exit_code)
       logging.error(self.failure)
       return
 

--- a/py/replica_restart_policy_tests.py
+++ b/py/replica_restart_policy_tests.py
@@ -1,9 +1,7 @@
-import datetime
 import json
 import logging
 from kubernetes import client as k8s_client
 from kubeflow.testing import test_util, util
-from py import k8s_util
 from py import ks_util
 from py import test_runner
 from py import tf_job_client
@@ -13,7 +11,9 @@ REPLICA_RESTART_POLICY_ONFAILURE_COMPONENT_NAME = "replica_restart_policy_onfail
 REPLICA_RESTART_POLICY_NEVER_COMPONENT_NAME = "replica_restart_policy_never"
 REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME = "replica_restart_policy_exitcode"
 
+
 class ReplicaRestartPolicyTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -21,13 +21,16 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     self.namespace = namespace
     self.tfjob_version = args.tfjob_version
     self.params = args.params
-    super(ReplicaRestartPolicyTests, self).__init__(class_name="ReplicaRestartPolicyTests", name=name)
+    super(ReplicaRestartPolicyTests, self).__init__(
+      class_name="ReplicaRestartPolicyTests", name=name)
 
-  def run_tfjob_with_replica_restart_policy(self, component, replica_restart_policy, exit_code):
+  def run_tfjob_with_replica_restart_policy(self, component,
+                                            replica_restart_policy, exit_code):
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -36,19 +39,25 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
     # Wait for the job to either be in Running state or a terminal state
     logging.info("Wait for conditions Running, Succeeded, or Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
-
     if replica_restart_policy == "Always":
-      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      first_start_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
       # for debug
-      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      logging.info("First start time: %s, restart time: %s",
+                   str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy Always failed test".format(
           self.name, self.namespace)
@@ -56,13 +65,17 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         return
 
     elif replica_restart_policy == "OnFailure":
-      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      first_start_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
       # for debug
-      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      logging.info("First start time: %s, restart time: %s",
+                   str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy OnFailure failed to restart the pod with exit_code 1".format(
           self.name, self.namespace)
@@ -70,23 +83,29 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         return
 
     elif replica_restart_policy == "Never":
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "ps", 1, exit_code)
       tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
                                                     self.name, "PS", ["Failed"])
 
     elif replica_restart_policy == "ExitCode" and exit_code == 1:
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "ps", 1, exit_code)
       tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
                                                     self.name, "PS", ["Failed"])
 
     else:
-      first_start_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "ps", 1, exit_code)
-      tf_job_client.wait_for_replica_type_in_phases(api_client, self.namespace,
-                                                    self.name, "PS", ["Running"])
-      restart_time = tf_job_client.get_start_time_by_index(api_client, self.namespace, self.name, "PS", 0)
+      first_start_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "ps", 1, exit_code)
+      tf_job_client.wait_for_replica_type_in_phases(
+        api_client, self.namespace, self.name, "PS", ["Running"])
+      restart_time = tf_job_client.get_start_time_by_index(
+        api_client, self.namespace, self.name, "PS", 0)
       # for debug
-      logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+      logging.info("First start time: %s, restart time: %s",
+                   str(first_start_time), str(restart_time))
       if restart_time <= first_start_time:
         self.failure = "Job {0} in namespace {1} with restart policy ExitCode failed to restart the pod with exit_code 128".format(
           self.name, self.namespace)
@@ -94,42 +113,52 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
         return
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
 
   # Verify that the pod is restarted even after the container exits with success.
   # We terminate PS with exit_code=0, and verify it is restarted.
   def test_restart_always(self):
     return self.run_tfjob_with_replica_restart_policy(
-      REPLICA_RESTART_POLICY_ALWAYS_COMPONENT_NAME + "_" + self.tfjob_version, "Always", 0)
+      REPLICA_RESTART_POLICY_ALWAYS_COMPONENT_NAME + "_" + self.tfjob_version,
+      "Always", 0)
 
   # Verify that the pod is restarted after failure.
   # We terminate PS with exit_code=1, and verify it is restarted.
   def test_restart_onfailure(self):
     return self.run_tfjob_with_replica_restart_policy(
-      REPLICA_RESTART_POLICY_ONFAILURE_COMPONENT_NAME + "_" + self.tfjob_version, "OnFailure", 1)
+      REPLICA_RESTART_POLICY_ONFAILURE_COMPONENT_NAME + "_" +
+      self.tfjob_version, "OnFailure", 1)
 
   # Verify that the pod is never restarted.
   # We terminate PS with exit_code=1, and verify that its phase becomes Failed.
   def test_restart_never(self):
     return self.run_tfjob_with_replica_restart_policy(
-      REPLICA_RESTART_POLICY_NEVER_COMPONENT_NAME + "_" + self.tfjob_version, "Never", 1)
+      REPLICA_RESTART_POLICY_NEVER_COMPONENT_NAME + "_" + self.tfjob_version,
+      "Never", 1)
 
   # Verify that the pod is not restarted after permanent error ( 1-127 ).
   # We terminate PS with exit_code=1, and verify its phase becomes Failed.
   def test_restart_exitcode_permanent_error(self):
     return self.run_tfjob_with_replica_restart_policy(
-      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 1)
-  
+      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
+      "ExitCode", 1)
+
   # Verify that the pod is not restarted after permanent error ( 128-255 ).
   # We terminate PS with exit_code=128, and verify it is restarted.
   def test_restart_exitcode_retryable_error(self):
     return self.run_tfjob_with_replica_restart_policy(
-      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version, "ExitCode", 128)
-  
+      REPLICA_RESTART_POLICY_EXITCODE_COMPONENT_NAME + "_" + self.tfjob_version,
+      "ExitCode", 128)
+
+
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/shutdown_policy_tests.py
+++ b/py/shutdown_policy_tests.py
@@ -9,7 +9,9 @@ from py import tf_job_client
 MASTER_IS_CHIEF_COMPONENT_NAME = "master_is_chief"
 WORKER0_IS_CHIEF_COMPONENT_NAME = "worker0_is_chief"
 
+
 class ShutdownPolicyTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -17,13 +19,15 @@ class ShutdownPolicyTests(test_util.TestCase):
     self.namespace = namespace
     self.tfjob_version = args.tfjob_version
     self.params = args.params
-    super(ShutdownPolicyTests, self).__init__(class_name="ShutdownPolicyTests", name=name)
+    super(ShutdownPolicyTests, self).__init__(
+      class_name="ShutdownPolicyTests", name=name)
 
   def run_tfjob_with_shutdown_policy(self, component, shutdown_policy):
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -32,19 +36,27 @@ class ShutdownPolicyTests(test_util.TestCase):
     # Wait for the job to either be in Running state or a terminal state
     logging.info("Wait for conditions Running, Succeeded, or Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
     if shutdown_policy == "worker":
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "worker", 1)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "worker", 1)
     else:
-      tf_job_client.terminate_replicas(api_client, self.namespace, self.name, "chief", 1)
+      tf_job_client.terminate_replicas(api_client, self.namespace, self.name,
+                                       "chief", 1)
 
     # Wait for the job to complete.
     logging.info("Waiting for job to finish.")
     results = tf_job_client.wait_for_job(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
     logging.info("Final TFJob:\n %s", json.dumps(results, indent=2))
 
@@ -55,11 +67,15 @@ class ShutdownPolicyTests(test_util.TestCase):
       return
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
 
   # Tests launching a TFJob with a Chief replica. Terminate the chief replica, and
@@ -73,6 +89,7 @@ class ShutdownPolicyTests(test_util.TestCase):
   def test_shutdown_worker0(self):
     return self.run_tfjob_with_shutdown_policy(
       WORKER0_IS_CHIEF_COMPONENT_NAME + "_" + self.tfjob_version, "worker")
+
 
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/simple_tfjob_tests.py
+++ b/py/simple_tfjob_tests.py
@@ -9,7 +9,9 @@ from py import tf_job_client
 CPU_TFJOB_COMPONENT_NAME = "simple_tfjob"
 GPU_TFJOB_COMPONENT_NAME = "gpu_tfjob"
 
+
 class SimpleTfJobTests(test_util.TestCase):
+
   def __init__(self, args):
     namespace, name, env = test_runner.parse_runtime_params(args)
     self.app_dir = args.app_dir
@@ -17,14 +19,16 @@ class SimpleTfJobTests(test_util.TestCase):
     self.namespace = namespace
     self.tfjob_version = args.tfjob_version
     self.params = args.params
-    super(SimpleTfJobTests, self).__init__(class_name="SimpleTfJobTests", name=name)
+    super(SimpleTfJobTests, self).__init__(
+      class_name="SimpleTfJobTests", name=name)
 
   # Run a generic TFJob, wait for it to complete, and check for pod/service creation errors.
   def run_simple_tfjob(self, component):
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component, self.params)
+    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+                         self.params)
 
     # Create the TF job
     util.run(["ks", "apply", self.env, "-c", component], cwd=self.app_dir)
@@ -33,14 +37,20 @@ class SimpleTfJobTests(test_util.TestCase):
     # Wait for the job to either be in Running state or a terminal state
     logging.info("Wait for conditions Running, Succeeded, or Failed")
     results = tf_job_client.wait_for_condition(
-      api_client, self.namespace, self.name, ["Running", "Succeeded", "Failed"],
-      version=self.tfjob_version, status_callback=tf_job_client.log_status)
+      api_client,
+      self.namespace,
+      self.name, ["Running", "Succeeded", "Failed"],
+      version=self.tfjob_version,
+      status_callback=tf_job_client.log_status)
     logging.info("Current TFJob:\n %s", json.dumps(results, indent=2))
 
     # Wait for the job to complete.
     logging.info("Waiting for job to finish.")
     results = tf_job_client.wait_for_job(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
     logging.info("Final TFJob:\n %s", json.dumps(results, indent=2))
 
@@ -62,11 +72,15 @@ class SimpleTfJobTests(test_util.TestCase):
       logging.warning(creation_failures)
 
     # Delete the TFJob.
-    tf_job_client.delete_tf_job(api_client, self.namespace, self.name, version=self.tfjob_version)
-    logging.info("Waiting for job %s in namespaces %s to be deleted.", self.name,
-                 self.namespace)
+    tf_job_client.delete_tf_job(
+      api_client, self.namespace, self.name, version=self.tfjob_version)
+    logging.info("Waiting for job %s in namespaces %s to be deleted.",
+                 self.name, self.namespace)
     tf_job_client.wait_for_delete(
-      api_client, self.namespace, self.name, self.tfjob_version,
+      api_client,
+      self.namespace,
+      self.name,
+      self.tfjob_version,
       status_callback=tf_job_client.log_status)
 
   # Run a generic TFJob, wait for it to complete, and check for pod/service creation errors.
@@ -76,6 +90,7 @@ class SimpleTfJobTests(test_util.TestCase):
   # Run a generic TFJob, wait for it to complete, and check for pod/service creation errors.
   def test_simple_tfjob_gpu(self):
     self.run_simple_tfjob(GPU_TFJOB_COMPONENT_NAME + "_" + self.tfjob_version)
+
 
 if __name__ == "__main__":
   test_runner.main(module=__name__)

--- a/py/test_runner.py
+++ b/py/test_runner.py
@@ -19,8 +19,8 @@ from py import util as tf_operator_util
 # between retries is because we have multiple tests running in parallel
 # that are all modifying the same ksonnet app via ks. I think this can
 # lead to failures.
-@retrying.retry(stop_max_attempt_number=10, wait_random_min=1000,
-                wait_random_max=10000)
+@retrying.retry(
+  stop_max_attempt_number=10, wait_random_min=1000, wait_random_max=10000)
 def run_test(test_case, test_func, args):  # pylint: disable=too-many-branches,too-many-statements
   """Run a test."""
   gcs_client = storage.Client(project=args.project)
@@ -41,7 +41,7 @@ def run_test(test_case, test_func, args):  # pylint: disable=too-many-branches,t
 
   start = time.time()
 
-  try: # pylint: disable=too-many-nested-blocks
+  try:  # pylint: disable=too-many-nested-blocks
     # We repeat the test multiple times.
     # This ensures that if we delete the job we can create a new job with the
     # same name.
@@ -77,9 +77,11 @@ def run_test(test_case, test_func, args):  # pylint: disable=too-many-branches,t
   finally:
     test_case.time = time.time() - start
     if args.artifacts_path:
-      test_util.create_junit_xml_file([test_case],
+      test_util.create_junit_xml_file(
+        [test_case],
         args.artifacts_path + "/junit_" + test_func.__name__ + ".xml",
         gcs_client)
+
 
 def parse_runtime_params(args):
   salt = uuid.uuid4().hex[0:4]
@@ -106,6 +108,7 @@ def parse_runtime_params(args):
     raise ValueError("namespace must be provided as a parameter.")
 
   return namespace, name, env
+
 
 def add_common_args(parser):
   """Add a set of common parser arguments."""
@@ -156,7 +159,7 @@ def add_common_args(parser):
     default=None,
     type=str,
     help="(Optional) the name for the ksonnet environment; if not specified "
-         "a random one is created.")
+    "a random one is created.")
 
   parser.add_argument(
     "--num_trials",
@@ -177,7 +180,8 @@ def main(module=None):  # pylint: disable=too-many-locals
     level=logging.INFO,
     format=('%(levelname)s|%(asctime)s'
             '|%(pathname)s|%(lineno)d| %(message)s'),
-    datefmt='%Y-%m-%dT%H:%M:%S',)
+    datefmt='%Y-%m-%dT%H:%M:%S',
+  )
 
   util.maybe_activate_service_account()
 

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -400,4 +400,4 @@ def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type,
   """
   pod_labels = get_labels(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  return k8s_util.get_pod_start_time(api_client, namespace, pod_selector, index)
+  return k8s_util.get_container_start_time(api_client, namespace, pod_selector, index)

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -420,6 +420,8 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
    exit_code: exit_code for the pod to exit with.
    expect_restart: expectation of whether the pod will restart after being terminated
   """
+  wait_for_replica_type_in_phases(api_client, namespace, name, "ps",
+                                    ["Running"])
   first_start_time = get_start_time_by_index(api_client, namespace, name,
                                              replica_type, replica_index, "Running")
   terminate_replicas(api_client, namespace, name, "ps", 1, exit_code)

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -403,6 +403,7 @@ def get_start_time_by_index(api_client, namespace, name, replica_type,
   return k8s_util.get_container_start_time(api_client, namespace, pod_selector,
                                            replica_index)
 
+
 def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
                                     replica_index, exit_code, expect_restart):
   """ Return True for passing the test and False for failing the test.
@@ -425,8 +426,8 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
   if expect_restart:
     wait_for_replica_type_in_phases(api_client, namespace, name, "ps",
                                     ["Running"])
-    restart_time = get_start_time_by_index(api_client, namespace, name,
-                                           replica_type, replica_index)
+    restart_time = get_start_time_by_index(
+      api_client, namespace, name, replica_type, replica_index, "Running")
     logging.info("First start time: %s, restart time: %s",
                  str(first_start_time), str(restart_time))
     if restart_time <= first_start_time:
@@ -435,8 +436,8 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
   elif expect_restart is False and exit_code == 0:
     wait_for_replica_type_in_phases(api_client, namespace, name, "ps",
                                     ["Succeeded"])
-    restart_time = get_start_time_by_index(api_client, namespace, name,
-                                           replica_type, replica_index)
+    restart_time = get_start_time_by_index(
+      api_client, namespace, name, replica_type, replica_index, "Succeeded")
     logging.info("First start time: %s, restart time: %s",
                  str(first_start_time), str(restart_time))
     if restart_time != first_start_time:
@@ -444,8 +445,8 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
   else:
     wait_for_replica_type_in_phases(api_client, namespace, name, "ps",
                                     ["Failed"])
-    restart_time = get_start_time_by_index(api_client, namespace, name,
-                                           replica_type, replica_index)
+    restart_time = get_start_time_by_index(
+      api_client, namespace, name, replica_type, replica_index, "Failed")
     logging.info("First start time: %s, restart time: %s",
                  str(first_start_time), str(restart_time))
     if restart_time != first_start_time:

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -388,7 +388,7 @@ def get_creation_failures_from_tfjob(api_client, namespace, tfjob):
 
 
 def get_start_time_by_index(api_client, namespace, name, replica_type,
-                            replica_index):
+                            replica_index, phase):
   """Returns the start time of the specified pod.
 
   Args:
@@ -397,11 +397,12 @@ def get_start_time_by_index(api_client, namespace, name, replica_type,
     name: TFJob name.
     replica_type: Replica type (chief, worker, ps).
     replica_index: Index of the replicas.
+    phase: expected of the phase when getting the start time
   """
   pod_labels = get_labels(name, replica_type)
   pod_selector = to_selector(pod_labels)
   return k8s_util.get_container_start_time(api_client, namespace, pod_selector,
-                                           replica_index)
+                                           replica_index, phase)
 
 
 def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
@@ -420,7 +421,7 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
    expect_restart: expectation of whether the pod will restart after being terminated
   """
   first_start_time = get_start_time_by_index(api_client, namespace, name,
-                                             replica_type, replica_index)
+                                             replica_type, replica_index, "Running")
   terminate_replicas(api_client, namespace, name, "ps", 1, exit_code)
 
   if expect_restart:

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -404,7 +404,8 @@ def get_start_time_by_index(api_client, namespace, name, replica_type,
                                            replica_index)
 
 
-def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type, index):
+def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type,
+                            index):
   """Returns the start time of the specified pod.
 
   Args:
@@ -416,41 +417,45 @@ def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type, ind
   """
   pod_labels = get_labels(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  return k8s_util.get_pod_start_time(api_client, namespace,
-                                     pod_selector,
-                                     index)
+  return k8s_util.get_pod_start_time(api_client, namespace, pod_selector, index)
 
-def terminate_and_verify_start_time(api_client,
-                                    namespace,
-                                    tfjob_name,
-                                    replica_type,
-                                    replica_index,
-                                    exit_code,
-                                    expect_restart)
+
+def terminate_and_verify_start_time(api_client, namespace, tfjob_name,
+                                    replica_type, replica_index, exit_code,
+                                    expect_restart):
   # if expect_restart is true, check that the second restart time is after the first.
   # if expect_restart is false, check that the restart time has not changed.
-  first_start_time = get_start_time_by_index(api_client, namespace, name, replica_type, replica_index)
+  first_start_time = get_start_time_by_index(api_client, namespace, name,
+                                             replica_type, replica_index)
   terminate_replicas(api_client, namespace, name, "ps", 1, exit_code)
 
   if expect_restart:
-    wait_for_replica_type_in_phases(api_client, namespace, name, "PS", ["Running"])
-    restart_time = get_start_time_by_index(api_client, namespace, name, replica_type, replica_index)
-    logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+    wait_for_replica_type_in_phases(api_client, namespace, name, "PS",
+                                    ["Running"])
+    restart_time = get_start_time_by_index(api_client, namespace, name,
+                                           replica_type, replica_index)
+    logging.info("First start time: %s, restart time: %s",
+                 str(first_start_time), str(restart_time))
     if restart_time <= first_start_time:
       return False
 
   elif expect_restart is False and exit_code == 0:
-    wait_for_replica_type_in_phases(api_client, namespace, name, "PS", ["Succeeded"])
-    restart_time = get_start_time_by_index(api_client, namespace, name, replica_type, replica_index)
-    logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+    wait_for_replica_type_in_phases(api_client, namespace, name, "PS",
+                                    ["Succeeded"])
+    restart_time = get_start_time_by_index(api_client, namespace, name,
+                                           replica_type, replica_index)
+    logging.info("First start time: %s, restart time: %s",
+                 str(first_start_time), str(restart_time))
     if restart_time != first_start_time:
       return False
   else:
-    wait_for_replica_type_in_phases(api_client, namespace, name, "PS", ["Failed"])
-    restart_time = get_start_time_by_index(api_client, namespace, name, replica_type, replica_index)
-    logging.info("First start time: %s, restart time: %s", str(first_start_time), str(restart_time))
+    wait_for_replica_type_in_phases(api_client, namespace, name, "PS",
+                                    ["Failed"])
+    restart_time = get_start_time_by_index(api_client, namespace, name,
+                                           replica_type, replica_index)
+    logging.info("First start time: %s, restart time: %s",
+                 str(first_start_time), str(restart_time))
     if restart_time != first_start_time:
       return False
 
   return True
-

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -434,10 +434,8 @@ def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
   if expect_restart:
     if restart_time <= first_start_time:
       return False
-    else:
-      return True
   else:
     if restart_time != first_start_time:
       return False
-    else:
-      return True
+
+  return True

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -400,4 +400,5 @@ def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type,
   """
   pod_labels = get_labels(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  return k8s_util.get_container_start_time(api_client, namespace, pod_selector, index)
+  return k8s_util.get_container_start_time(api_client, namespace, pod_selector,
+                                           index)

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -403,24 +403,6 @@ def get_start_time_by_index(api_client, namespace, name, replica_type,
   return k8s_util.get_container_start_time(api_client, namespace, pod_selector,
                                            replica_index)
 
-
-def get_start_time_by_index(api_client, namespace, name, replica_type,
-                            replica_index):
-  """Returns the start time of the specified pod.
-
-  Args:
-    api_client: The K8s API client.
-    namespace: The K8s namespace.
-    name: TFJob name.
-    replica_type: Replica type (chief, worker, ps).
-    replica_index: Index of the replicas.
-  """
-  pod_labels = get_labels(name, replica_type)
-  pod_selector = to_selector(pod_labels)
-  return k8s_util.get_pod_start_time(api_client, namespace, pod_selector,
-                                     replica_index)
-
-
 def terminate_and_verify_start_time(api_client, namespace, name, replica_type,
                                     replica_index, exit_code, expect_restart):
   """ Return True for passing the test and False for failing the test.

--- a/py/tf_job_client.py
+++ b/py/tf_job_client.py
@@ -14,13 +14,13 @@ from kubernetes.client import rest
 from py import k8s_util
 from py import util
 
-
 TF_JOB_GROUP = "kubeflow.org"
 TF_JOB_PLURAL = "tfjobs"
 TF_JOB_KIND = "TFJob"
 
 # How long to wait in seconds for requests to the ApiServer
 TIMEOUT = 120
+
 
 def create_tf_job(client, spec, version="v1beta1"):
   """Create a TFJob.
@@ -69,10 +69,16 @@ def delete_tf_job(client, namespace, name, version="v1beta1"):
     }
     logging.info("Deleting job %s.%s", namespace, name)
     thread = crd_api.delete_namespaced_custom_object(
-      TF_JOB_GROUP, version, namespace, TF_JOB_PLURAL, name, body,
+      TF_JOB_GROUP,
+      version,
+      namespace,
+      TF_JOB_PLURAL,
+      name,
+      body,
       async_req=True)
     api_response = thread.get(TIMEOUT)
-    logging.info("Deleting job %s.%s returned: %s", namespace, name, api_response)
+    logging.info("Deleting job %s.%s returned: %s", namespace, name,
+                 api_response)
     return api_response
   except rest.ApiException as e:
     message = ""
@@ -99,22 +105,24 @@ def delete_tf_job(client, namespace, name, version="v1beta1"):
 def log_status(tf_job):
   """A callback to use with wait_for_job."""
   all_conditions = tf_job.get("status", {}).get("conditions", [])
-  conditions = [] if all_conditions is None else [c.get("type", "") for c in all_conditions]
+  conditions = [] if all_conditions is None else [
+    c.get("type", "") for c in all_conditions
+  ]
   logging.info("Job %s in namespace %s; uid=%s; conditions=%s",
                tf_job.get("metadata", {}).get("name"),
                tf_job.get("metadata", {}).get("namespace"),
-               tf_job.get("metadata", {}).get("uid"),
-               conditions)
+               tf_job.get("metadata", {}).get("uid"), conditions)
+
 
 # pylint: disable=too-many-arguments
 def wait_for_condition(client,
-                        namespace,
-                        name,
-                        expected_condition,
-                        version="v1beta1",
-                        timeout=datetime.timedelta(minutes=10),
-                        polling_interval=datetime.timedelta(seconds=30),
-                        status_callback=None):
+                       namespace,
+                       name,
+                       expected_condition,
+                       version="v1beta1",
+                       timeout=datetime.timedelta(minutes=10),
+                       polling_interval=datetime.timedelta(seconds=30),
+                       status_callback=None):
   """Waits until any of the specified conditions occur.
 
   Args:
@@ -163,14 +171,14 @@ def wait_for_condition(client,
     if datetime.datetime.now() + polling_interval > end_time:
       raise util.JobTimeoutError(
         "Timeout waiting for job {0} in namespace {1} to enter one of the "
-        "conditions {2}.".format(
-          name, namespace, conditions), results)
+        "conditions {2}.".format(name, namespace, conditions), results)
 
     time.sleep(polling_interval.seconds)
 
   # Linter complains if we don't have a return statement even though
   # this code is unreachable.
   return None
+
 
 def wait_for_job(client,
                  namespace,
@@ -192,11 +200,13 @@ def wait_for_job(client,
       is the job.
   """
   return wait_for_condition(
-            client, namespace, name, ["Succeeded", "Failed"],
-            version=version,
-            timeout=timeout,
-            polling_interval=polling_interval,
-            status_callback=status_callback)
+    client,
+    namespace,
+    name, ["Succeeded", "Failed"],
+    version=version,
+    timeout=timeout,
+    polling_interval=polling_interval,
+    status_callback=status_callback)
 
 
 def wait_for_delete(client,
@@ -223,8 +233,7 @@ def wait_for_delete(client,
   while True:
     try:
       results = crd_api.get_namespaced_custom_object(
-        TF_JOB_GROUP, version, namespace,
-        TF_JOB_PLURAL, name)
+        TF_JOB_GROUP, version, namespace, TF_JOB_PLURAL, name)
     except rest.ApiException as e:
       if e.status == httplib.NOT_FOUND:
         return
@@ -240,6 +249,7 @@ def wait_for_delete(client,
 
     time.sleep(polling_interval.seconds)
 
+
 def get_labels(name, replica_type=None, replica_index=None):
   """Return labels.
   """
@@ -248,11 +258,12 @@ def get_labels(name, replica_type=None, replica_index=None):
     "tf_job_name": name,
   }
   if replica_type:
-    labels["tf-replica-type"] = replica_type
+    labels["tf-replica-type"] = str.lower(replica_type)
 
   if replica_index:
     labels["tf-replica-index"] = replica_index
   return labels
+
 
 def to_selector(labels):
   parts = []
@@ -261,14 +272,18 @@ def to_selector(labels):
 
   return ",".join(parts)
 
-def wait_for_replica_type_in_phases(api_client, namespace, tfjob_name, replica_type, phases):
+
+def wait_for_replica_type_in_phases(api_client, namespace, tfjob_name,
+                                    replica_type, phases):
   pod_labels = get_labels(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  k8s_util.wait_for_pods_to_be_in_phases(api_client, namespace,
-                                         pod_selector,
-                                         phases,
-                                         timeout=datetime.timedelta(
-                                         minutes=4))
+  k8s_util.wait_for_pods_to_be_in_phases(
+    api_client,
+    namespace,
+    pod_selector,
+    phases,
+    timeout=datetime.timedelta(minutes=4))
+
 
 @retrying.retry(wait_fixed=10, stop_max_delay=60)
 def terminate_replica(master_host, namespace, target, exit_code=0):
@@ -285,7 +300,13 @@ def terminate_replica(master_host, namespace, target, exit_code=0):
   }
   util.send_request(master_host, namespace, target, "exit", params)
 
-def terminate_replicas(api_client, namespace, name, replica, num_targets, exit_code=0):
+
+def terminate_replicas(api_client,
+                       namespace,
+                       name,
+                       replica,
+                       num_targets,
+                       exit_code=0):
   """Terminates the specified replica(s).
 
   Args:
@@ -305,11 +326,11 @@ def terminate_replicas(api_client, namespace, name, replica, num_targets, exit_c
   # TODO(jlewi): We are get pods using a label selector so there is
   # a risk that the pod we actual care about isn't present.
   logging.info("Waiting for pods to be running before shutting down.")
-  k8s_util.wait_for_pods_to_be_in_phases(api_client, namespace,
-                                         pod_selector,
-                                         ["Running"],
-                                         timeout=datetime.timedelta(
-                                         minutes=4))
+  k8s_util.wait_for_pods_to_be_in_phases(
+    api_client,
+    namespace,
+    pod_selector, ["Running"],
+    timeout=datetime.timedelta(minutes=4))
   logging.info("Pods are ready")
   logging.info("Issuing the terminate request")
   for num in range(num_targets):
@@ -346,7 +367,8 @@ def get_creation_failures_from_tfjob(api_client, namespace, tfjob):
 
   num_expected = 0
   for replicakey in tfjob.get("spec", {}).get("tfReplicaSpecs", {}):
-    replica_spec = tfjob.get("spec", {}).get("tfReplicaSpecs", {}).get(replicakey, {})
+    replica_spec = tfjob.get("spec", {}).get("tfReplicaSpecs", {}).get(
+      replicakey, {})
     if replica_spec:
       num_expected += replica_spec.get("replicas", 1)
 
@@ -358,13 +380,15 @@ def get_creation_failures_from_tfjob(api_client, namespace, tfjob):
 
   if len(created_services) != num_expected:
     message = ("Expected {0} services to be created but only "
-               "got {1} create events.").format(num_expected, len(created_services))
+               "got {1} create events.").format(num_expected,
+                                                len(created_services))
     creation_failures.append(message)
 
   return creation_failures
 
 
-def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type, index):
+def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type,
+                            index):
   """Returns the start time of the specified pod.
 
   Args:
@@ -376,6 +400,4 @@ def get_start_time_by_index(api_client, namespace, tfjob_name, replica_type, ind
   """
   pod_labels = get_labels(tfjob_name, replica_type)
   pod_selector = to_selector(pod_labels)
-  return k8s_util.get_pod_start_time(api_client, namespace, 
-                                     pod_selector, 
-                                     index)
+  return k8s_util.get_pod_start_time(api_client, namespace, pod_selector, index)

--- a/py/util.py
+++ b/py/util.py
@@ -46,10 +46,7 @@ def run(command, cwd=None, env=None, dryrun=False):
 
   # In case the release is done from a non-linux machine
   # we enforce correct GOOS and GOARCH
-  extra_envs = {
-    "GOOS": "linux",
-    "GOARCH": "amd64"
-    }
+  extra_envs = {"GOOS": "linux", "GOARCH": "amd64"}
 
   if not env:
     env = os.environ.copy()
@@ -116,17 +113,15 @@ def send_request(master_host, namespace, target, rpc, params):
   }
   url = ("{master}/api/v1/namespaces/{namespace}/services/{service}:2222"
          "/proxy/{rpc}").format(
-          master=master_host, namespace=namespace, service=target, rpc=rpc)
-  r = requests.get(url,
-                   headers=headers, params=params,
-                   verify=False)
+           master=master_host, namespace=namespace, service=target, rpc=rpc)
+  r = requests.get(url, headers=headers, params=params, verify=False)
 
   if r.status_code == requests.codes.NOT_FOUND:
     logging.info("Request to %s returned 404", url)
     return ""
   if r.status_code != requests.codes.OK:
-    msg = "Request to {0} exited with status code: {1}".format(url,
-          r.status_code)
+    msg = "Request to {0} exited with status code: {1}".format(
+      url, r.status_code)
     logging.error(msg)
     raise RuntimeError(msg)
 
@@ -164,22 +159,20 @@ def clone_repo(dest,
 
   if branches:
     for b in branches:
-      run(
-        [
-          "git",
-          "fetch",
-          "origin",
-          b,
-        ], cwd=dest)
+      run([
+        "git",
+        "fetch",
+        "origin",
+        b,
+      ], cwd=dest)
 
     if not sha:
       b = branches[-1].split(":", 1)[-1]
-      run(
-        [
-          "git",
-          "checkout",
-          b,
-        ], cwd=dest)
+      run([
+        "git",
+        "checkout",
+        b,
+      ], cwd=dest)
 
   if sha:
     run(["git", "checkout", sha], cwd=dest)
@@ -338,8 +331,9 @@ def wait_for_deployment(api_client, namespace, name):
     logging.info("Waiting for deployment %s in namespace %s", name, namespace)
     time.sleep(10)
 
-  logging.error("Timeout waiting for deployment %s in namespace %s to be "
-                "ready", name, namespace)
+  logging.error(
+    "Timeout waiting for deployment %s in namespace %s to be "
+    "ready", name, namespace)
   raise TimeoutError(
     "Timeout waiting for deployment {0} in namespace {1}".format(
       name, namespace))
@@ -372,8 +366,9 @@ def wait_for_statefulset(api_client, namespace, name):
     logging.info("Waiting for Statefulset %s in namespace %s", name, namespace)
     time.sleep(10)
 
-  logging.error("Timeout waiting for statefulset %s in namespace %s to be "
-                "ready", name, namespace)
+  logging.error(
+    "Timeout waiting for statefulset %s in namespace %s to be "
+    "ready", name, namespace)
   raise TimeoutError(
     "Timeout waiting for statefulset {0} in namespace {1}".format(
       name, namespace))
@@ -460,6 +455,7 @@ def setup_cluster(api_client):
 class TimeoutError(Exception):  # pylint: disable=redefined-builtin
   """An error indicating an operation timed out."""
 
+
 class JobTimeoutError(TimeoutError):
   """An error indicating the job timed out.
 
@@ -469,6 +465,7 @@ class JobTimeoutError(TimeoutError):
   def __init__(self, message, job):
     super(JobTimeoutError, self).__init__(message)
     self.job = job
+
 
 GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
 

--- a/test/workflows/components/params.libsonnet
+++ b/test/workflows/components/params.libsonnet
@@ -128,5 +128,25 @@
     "invalid_tfjob_v1beta1": {
       name: "invalid-tfjob",
     },
+    replica_restart_policy_always_v1beta1: {
+       name: "replica-restart-policy-always",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_onfailure_v1beta1: {
+       name: "replica-restart-policy-onfailure",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_never_v1beta1: {
+       name: "replica-restart-policy-never",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_exitcode_v1beta1: {
+       name: "replica-restart-policy-exitcode",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
   },
 }

--- a/test/workflows/components/params.libsonnet
+++ b/test/workflows/components/params.libsonnet
@@ -61,6 +61,26 @@
     "invalid_tfjob_v1alpha2": {
       name: "invalid-tfjob",
     },
+    replica_restart_policy_always_v1alpha2: {
+       name: "replica-restart-policy-always",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_onfailure_v1alpha2: {
+       name: "replica-restart-policy-onfailure",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_never_v1alpha2: {
+       name: "replica-restart-policy-never",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
+    replica_restart_policy_exitcode_v1alpha2: {
+       name: "replica-restart-policy-exitcode",
+       namespace: "kubeflow-test-infra",
+       image: "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest"
+    },
     // v1beta1 components
     simple_tfjob_v1beta1: {
       name: "simple-001",

--- a/test/workflows/components/replica_restart_policy_always_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_always_v1alpha2.jsonnet
@@ -1,0 +1,53 @@
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1alpha2.jsonnet;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1alpha2",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "Always",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "Always",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_always_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_always_v1alpha2.jsonnet
@@ -1,4 +1,4 @@
-local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1alpha2.jsonnet;
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1alpha2;
 
 local k = import "k.libsonnet";
 

--- a/test/workflows/components/replica_restart_policy_always_v1beta1.jsonnet
+++ b/test/workflows/components/replica_restart_policy_always_v1beta1.jsonnet
@@ -1,0 +1,53 @@
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1alpha2;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1alpha2",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "Always",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "Always",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_always_v1beta1.jsonnet
+++ b/test/workflows/components/replica_restart_policy_always_v1beta1.jsonnet
@@ -1,4 +1,4 @@
-local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1alpha2;
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_always_v1beta1;
 
 local k = import "k.libsonnet";
 
@@ -9,7 +9,7 @@ local parts(namespace, name, image) = {
     image
   else defaultTestImage,
   job:: {
-    apiVersion: "kubeflow.org/v1alpha2",
+    apiVersion: "kubeflow.org/v1beta1",
     kind: "TFJob",
     metadata: {
       name: name,

--- a/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
@@ -1,5 +1,5 @@
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components.replica_restart_policy_exitcode_v1alpha2.jsonnet;
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_exitcode_v1alpha2;
 
 local k = import "k.libsonnet";
 

--- a/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
@@ -1,0 +1,54 @@
+local env = std.extVar("__ksonnet/environments");
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_exitcode_v1alpha2.jsonnet;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1alpha2",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "ExitCode",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "ExitCode",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_exitcode_v1alpha2.jsonnet
@@ -1,4 +1,3 @@
-local env = std.extVar("__ksonnet/environments");
 local params = std.extVar("__ksonnet/params").components.replica_restart_policy_exitcode_v1alpha2;
 
 local k = import "k.libsonnet";

--- a/test/workflows/components/replica_restart_policy_exitcode_v1beta1.jsonnet
+++ b/test/workflows/components/replica_restart_policy_exitcode_v1beta1.jsonnet
@@ -1,0 +1,53 @@
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_exitcode_v1beta1;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1beta1",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "ExitCode",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "ExitCode",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
@@ -1,0 +1,54 @@
+local env = std.extVar("__ksonnet/environments");
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_never_v1alpha2.jsonnet;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1alpha2",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "Never",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "Never",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
@@ -1,5 +1,5 @@
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components.replica_restart_policy_never_v1alpha2.jsonnet;
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_never_v1alpha2;
 
 local k = import "k.libsonnet";
 

--- a/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_never_v1alpha2.jsonnet
@@ -1,4 +1,3 @@
-local env = std.extVar("__ksonnet/environments");
 local params = std.extVar("__ksonnet/params").components.replica_restart_policy_never_v1alpha2;
 
 local k = import "k.libsonnet";

--- a/test/workflows/components/replica_restart_policy_never_v1beta1.jsonnet
+++ b/test/workflows/components/replica_restart_policy_never_v1beta1.jsonnet
@@ -1,0 +1,53 @@
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_never_v1beta1;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1beta1",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "Never",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "Never",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
@@ -1,5 +1,5 @@
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components.replica_restart_policy_onfailure_v1alpha2.jsonnet;
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_onfailure_v1alpha2;
 
 local k = import "k.libsonnet";
 

--- a/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
@@ -1,0 +1,54 @@
+local env = std.extVar("__ksonnet/environments");
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_onfailure_v1alpha2.jsonnet;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1alpha2",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "OnFailure",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "OnFailure",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
+++ b/test/workflows/components/replica_restart_policy_onfailure_v1alpha2.jsonnet
@@ -1,4 +1,3 @@
-local env = std.extVar("__ksonnet/environments");
 local params = std.extVar("__ksonnet/params").components.replica_restart_policy_onfailure_v1alpha2;
 
 local k = import "k.libsonnet";

--- a/test/workflows/components/replica_restart_policy_onfailure_v1beta1.jsonnet
+++ b/test/workflows/components/replica_restart_policy_onfailure_v1beta1.jsonnet
@@ -1,0 +1,53 @@
+local params = std.extVar("__ksonnet/params").components.replica_restart_policy_onfailure_v1beta1;
+
+local k = import "k.libsonnet";
+
+local defaultTestImage = "gcr.io/kubeflow-images-staging/tf-operator-test-server:latest";
+
+local parts(namespace, name, image) = {
+  local actualImage = if image != "" then
+    image
+  else defaultTestImage,
+  job:: {
+    apiVersion: "kubeflow.org/v1beta1",
+    kind: "TFJob",
+    metadata: {
+      name: name,
+      namespace: namespace,
+    },
+    spec: {
+      tfReplicaSpecs: {
+        PS: {
+          replicas: 1,
+          restartPolicy: "OnFailure",
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "tensorflow",
+                  image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+        Worker: {
+          replicas: 2,
+          restartPolicy: "OnFailure",
+          template: {
+            spec: {
+              containers: [
+                {
+                    name: "tensorflow",
+                    image: actualImage,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+std.prune(k.core.v1.list.new([parts(params.namespace, params.name, params.image).job]))

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -284,6 +284,11 @@
                     template: "invalid-tfjob-tests",
                     dependencies: ["setup-kubeflow"],
                   },
+                  {
+                    name: "replica-restart-policy-tests",
+                    template: "replica-restart-policy-tests",
+                    dependencies: ["setup-kubeflow"],
+                  },
                 ],  //tasks
               },
             },
@@ -382,6 +387,8 @@
               "distributed-training-tests"),
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTestTemplate(
               "invalid-tfjob-tests"),
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTestTemplate(
+              "replica-restart-policy-tests"),
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("create-pr-symlink", [
               "python",
               "-m",


### PR DESCRIPTION
Fixes #639

This PR does the following things:
1. add replicas restart policy test by comparing the start time of the container in the pod
2. fixed the pod_selector in py/tf_job_client.py by modifying
`labels["tf-replica-type"] = replica_type` to
`labels["tf-replica-type"] = str.lower(replica_type)`
3. wait a time interval before fetching the pods' phase in py/k8s_util.py
4. fixed bugs in clean pod policy test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/873)
<!-- Reviewable:end -->
