### PR TITLE
Fix typo in developer_guide.md

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -114,7 +114,7 @@ To verify local operator is working, create an example job and you should see jo
 # If you are using v1beta1
 cd ./examples/v1beta1/dist-mnist
 docker build -f Dockerfile -t kubeflow/tf-dist-mnist-test:1.0 .
-kubectl create -f ./tf-job-mnist.yaml
+kubectl create -f ./tf_job_mnist.yaml
 ```
 
 Or
@@ -123,7 +123,7 @@ Or
 # If you are using v1alpha2
 cd ./examples/v1alpha2/dist-mnist
 docker build -f Dockerfile -t kubeflow/tf-dist-mnist-test:1.0 .
-kubectl create -f ./tf-job-mnist.yaml
+kubectl create -f ./tf_job_mnist.yaml
 ```
 
 ## Go version


### PR DESCRIPTION
Notice there's a typo in develop guide, should be `_` rather than `-`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/878)
<!-- Reviewable:end -->
