### PR TITLE
Fix tf-operator presubmit failures by installing go manually

### DIFF
--- a/build/images/tf_operator/Dockerfile
+++ b/build/images/tf_operator/Dockerfile
@@ -2,7 +2,10 @@ FROM centos:7
 
 ENV GOLANG_VERSION 1.8.3
 
-RUN yum -y install go && yum clean all
+RUN curl -LO https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz &&\
+    tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz
+
+ENV PATH $PATH:/usr/local/go/bin
 
 # TODO(jlewi): We should probably change the directory to /opt/kubeflow.
 RUN mkdir -p /opt/tensorflow_k8s/dashboard/


### PR DESCRIPTION
Presubmits were failing due to Go installation error:

```
Step 2/15 : ENV GOLANG_VERSION 1.8.3
---> Running in b613b7584fbe
Removing intermediate container b613b7584fbe
---> 966d561c20b7
Step 3/15 : RUN yum -y install go && yum clean all
---> Running in 3e92d32ce757
Loaded plugins: fastestmirror, ovl
Determining fastest mirrors
* base: mirrors.ocf.berkeley.edu
* extras: mirrors.ocf.berkeley.edu
* updates: mirror.sjc02.svwh.net
No package go available.
Error: Nothing to do
The command '/bin/sh -c yum -y install go && yum clean all' returned a non-zero code: 1
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1
```

Fix is to install Go (same version) manually.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/885)
<!-- Reviewable:end -->
