### PR TITLE
build backend in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 script:
   - go build -o tf-operator.v2 github.com/kubeflow/tf-operator/cmd/tf-operator.v2
   - go build -o tf-operator.v1beta1 github.com/kubeflow/tf-operator/cmd/tf-operator.v1beta1
+  - go build -o backend github.com/kubeflow/tf-operator/dashboard/backend
   - gometalinter --config=linter_config.json --vendor ./...
   # We customize the build step because by default
   # Travis runs go test -v ./... which will include the vendor


### PR DESCRIPTION
In the docker image, there are three binaries, but travis ci only builds two of them.

Adding the backend binary to travis ci to improve the ci build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/892)
<!-- Reviewable:end -->
