### PR TITLE
Adding master role label 

### DIFF
--- a/pkg/apis/tensorflow/v1beta1/util.go
+++ b/pkg/apis/tensorflow/v1beta1/util.go
@@ -18,3 +18,8 @@ package v1beta1
 func IsChieforMaster(typ TFReplicaType) bool {
 	return typ == TFReplicaTypeChief || typ == TFReplicaTypeMaster
 }
+
+// IsWorker returns true if the type is Worker
+func IsWorker(typ TFReplicaType) bool {
+	return typ == TFReplicaTypeWorker
+}

--- a/pkg/controller.v1beta1/tensorflow/controller.go
+++ b/pkg/controller.v1beta1/tensorflow/controller.go
@@ -49,6 +49,7 @@ const (
 	tfReplicaIndexLabel = "tf-replica-index"
 	labelGroupName      = "group_name"
 	labelTFJobName      = "tf_job_name"
+	labelTFJobRole      = "tf_job_role"
 )
 
 var (


### PR DESCRIPTION
New master role label is set in the pod which acts as master of the job.   In katib, this label is useful to track the master who is responsible for logging. 


Sets new label 'tf_job_role':'master' to the

1.  master pod if master pod is present
2. first worker pod if master pod is not present

Related: https://github.com/kubeflow/katib/issues/294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/896)
<!-- Reviewable:end -->