### PR TITLE
Add more detailed events/messages for TFJobs

### DIFF
--- a/pkg/controller.v1beta1/tensorflow/pod.go
+++ b/pkg/controller.v1beta1/tensorflow/pod.go
@@ -121,7 +121,7 @@ func (tc *TFController) reconcilePods(
 		}
 	}
 
-	return updateStatusSingle(tfjob, rtype, replicas, restart, worker0Completed)
+	return tc.updateStatusSingle(tfjob, rtype, replicas, restart, worker0Completed)
 }
 
 // createNewPod creates a new pod for the given index and type.


### PR DESCRIPTION
Adding events for TFJobs completion/failure/restarts. Also includes debug information for the pod types that failed.

Fixes #869 