### PR TITLE
Remove gosimple, go 1.8 and add gotype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: go
 
 go:
-  # we cannot enable `gotyp` in gometalinter while at the same time
-  # keep 1.8 here. so I (jiay) went with removing `gotype` for now.
-  # see open issues:
-  # - https://github.com/alecthomas/gometalinter/issues/358
-  # - https://github.com/golang/go/issues/21712
-  # TODO jiayu: re-evaluate the pending issues and add back `gotype`
-  - "1.8"
   - "1.9"
   - "1.10"
 

--- a/cmd/tf-operator.v1beta1/app/server.go
+++ b/cmd/tf-operator.v1beta1/app/server.go
@@ -122,7 +122,7 @@ func Run(opt *options.ServerOption) error {
 
 	id, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("Failed to get hostname: %v", err)
+		return fmt.Errorf("failed to get hostname: %v", err)
 	}
 
 	// Prepare event clients.

--- a/cmd/tf-operator.v2/app/server.go
+++ b/cmd/tf-operator.v2/app/server.go
@@ -122,13 +122,13 @@ func Run(opt *options.ServerOption) error {
 
 	id, err := os.Hostname()
 	if err != nil {
-		return fmt.Errorf("Failed to get hostname: %v", err)
+		return fmt.Errorf("failed to get hostname: %v", err)
 	}
 
 	// Prepare event clients.
 	eventBroadcaster := record.NewBroadcaster()
 	if err = v1.AddToScheme(scheme.Scheme); err != nil {
-		return fmt.Errorf("CoreV1 Add Scheme failed: %v", err)
+		return fmt.Errorf("coreV1 Add Scheme failed: %v", err)
 	}
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "tf-operator"})
 

--- a/linter_config.json
+++ b/linter_config.json
@@ -9,8 +9,8 @@
     "goimports",
     "varcheck",
     "gosec",
+    "gotype",
     "staticcheck",
-    "gosimple",
     "lll",
     "unconvert",
     "misspell",
@@ -36,6 +36,6 @@
     "pkg/controller.v2/controller_utils.go",
     "dashboard/backend/handler/api_handler.go"
   ],
-  "Deadline": "300s",
+  "Deadline": "500s",
   "Skip": ["pkg/client"]
 }

--- a/pkg/apis/tensorflow/v1alpha2/defaults.go
+++ b/pkg/apis/tensorflow/v1alpha2/defaults.go
@@ -78,7 +78,7 @@ func setTypeNamesToCamelCase(tfJob *TFJob) {
 // E.g. from ps to PS; from WORKER to Worker.
 func setTypeNameToCamelCase(tfJob *TFJob, typ TFReplicaType) {
 	for t := range tfJob.Spec.TFReplicaSpecs {
-		if strings.ToLower(string(t)) == strings.ToLower(string(typ)) && t != typ {
+		if strings.EqualFold(string(t), string(typ)) && t != typ {
 			spec := tfJob.Spec.TFReplicaSpecs[t]
 			delete(tfJob.Spec.TFReplicaSpecs, t)
 			tfJob.Spec.TFReplicaSpecs[typ] = spec

--- a/pkg/apis/tensorflow/v1beta1/defaults.go
+++ b/pkg/apis/tensorflow/v1beta1/defaults.go
@@ -79,7 +79,7 @@ func setTypeNamesToCamelCase(tfJob *TFJob) {
 // E.g. from ps to PS; from WORKER to Worker.
 func setTypeNameToCamelCase(tfJob *TFJob, typ TFReplicaType) {
 	for t := range tfJob.Spec.TFReplicaSpecs {
-		if strings.ToLower(string(t)) == strings.ToLower(string(typ)) && t != typ {
+		if strings.EqualFold(string(t), string(typ)) && t != typ {
 			spec := tfJob.Spec.TFReplicaSpecs[t]
 			delete(tfJob.Spec.TFReplicaSpecs, t)
 			tfJob.Spec.TFReplicaSpecs[typ] = spec

--- a/pkg/apis/tensorflow/validation/validation.go
+++ b/pkg/apis/tensorflow/validation/validation.go
@@ -63,10 +63,10 @@ func validateBetaOneReplicaSpecs(specs map[tfv1beta1.TFReplicaType]*common.Repli
 		}
 	}
 	if foundChief > 1 {
-		return fmt.Errorf("More than 1 chief/master found")
+		return fmt.Errorf("more than 1 chief/master found")
 	}
 	if foundEvaluator > 1 {
-		return fmt.Errorf("More than 1 evaluator found")
+		return fmt.Errorf("more than 1 evaluator found")
 	}
 	return nil
 }
@@ -110,10 +110,10 @@ func validateAlphaTwoReplicaSpecs(specs map[tfv2.TFReplicaType]*tfv2.TFReplicaSp
 		}
 	}
 	if foundChief > 1 {
-		return fmt.Errorf("More than 1 chief/master found")
+		return fmt.Errorf("more than 1 chief/master found")
 	}
 	if foundEvaluator > 1 {
-		return fmt.Errorf("More than 1 evaluator found")
+		return fmt.Errorf("more than 1 evaluator found")
 	}
 	return nil
 }

--- a/pkg/control/service_control.go
+++ b/pkg/control/service_control.go
@@ -161,7 +161,7 @@ func (f *FakeServiceControl) CreateServices(namespace string, service *v1.Servic
 	defer f.Unlock()
 	f.CreateCallCount++
 	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
-		return fmt.Errorf("Not creating service, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
+		return fmt.Errorf("not creating service, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
 	}
 	f.Templates = append(f.Templates, *service)
 	if f.Err != nil {
@@ -175,7 +175,7 @@ func (f *FakeServiceControl) CreateServicesWithControllerRef(namespace string, s
 	defer f.Unlock()
 	f.CreateCallCount++
 	if f.CreateLimit != 0 && f.CreateCallCount > f.CreateLimit {
-		return fmt.Errorf("Not creating service, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
+		return fmt.Errorf("not creating service, limit %d already reached (create call %d)", f.CreateLimit, f.CreateCallCount)
 	}
 	f.Templates = append(f.Templates, *service)
 	f.ControllerRefs = append(f.ControllerRefs, *controllerRef)

--- a/pkg/control/service_ref_manager_test.go
+++ b/pkg/control/service_ref_manager_test.go
@@ -33,9 +33,7 @@ func TestClaimServices(t *testing.T) {
 		name     string
 		manager  *ServiceControllerRefManager
 		services []*v1.Service
-		filters  []func(*v1.Service) bool
 		claimed  []*v1.Service
-		released []*v1.Service
 	}
 	var tests = []test{
 		func() test {

--- a/pkg/controller.v1beta1/tensorflow/controller.go
+++ b/pkg/controller.v1beta1/tensorflow/controller.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -252,7 +252,7 @@ func (tc *TFController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("Error syncing tfjob: %v", err))
+	utilruntime.HandleError(fmt.Errorf("error syncing tfjob: %v", err))
 	tc.WorkQueue.AddRateLimited(key)
 
 	return true
@@ -261,7 +261,7 @@ func (tc *TFController) processNextWorkItem() bool {
 func (tc *TFController) enqueueTFJob(tfjob interface{}) {
 	key, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return
 	}
 
@@ -375,7 +375,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1beta1.TFJob) error {
 		// At this point the pods may have been deleted, so if the job succeeded, we need to manually set the replica status.
 		// If any replicas are still Active, set their status to succeeded.
 		if isSucceeded(tfjob.Status) {
-			for rtype, _ := range tfjob.Status.ReplicaStatuses {
+			for rtype := range tfjob.Status.ReplicaStatuses {
 				tfjob.Status.ReplicaStatuses[rtype].Succeeded += tfjob.Status.ReplicaStatuses[rtype].Active
 				tfjob.Status.ReplicaStatuses[rtype].Active = 0
 			}
@@ -413,7 +413,7 @@ func (tc *TFController) satisfiedExpectations(tfjob *tfv1beta1.TFJob) bool {
 	satisfied := false
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return false
 	}
 

--- a/pkg/controller.v1beta1/tensorflow/informer.go
+++ b/pkg/controller.v1beta1/tensorflow/informer.go
@@ -26,9 +26,9 @@ const (
 )
 
 var (
-	errGetFromKey    = fmt.Errorf("Failed to get TFJob from key")
-	errNotExists     = fmt.Errorf("The object is not found")
-	errFailedMarshal = fmt.Errorf("Failed to marshal the object to TFJob")
+	errGetFromKey    = fmt.Errorf("failed to get TFJob from key")
+	errNotExists     = fmt.Errorf("the object is not found")
+	errFailedMarshal = fmt.Errorf("failed to marshal the object to TFJob")
 )
 
 func NewUnstructuredTFJobInformer(restConfig *restclientset.Config, namespace string) tfjobinformersv1beta1.TFJobInformer {

--- a/pkg/controller.v1beta1/tensorflow/pod.go
+++ b/pkg/controller.v1beta1/tensorflow/pod.go
@@ -128,7 +128,7 @@ func (tc *TFController) reconcilePods(
 func (tc *TFController) createNewPod(tfjob *tfv1beta1.TFJob, rt, index string, spec *common.ReplicaSpec, masterRole bool) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return err
 	}
 	expectationPodsKey := jobcontroller.GenExpectationPodsKey(tfjobKey, rt)

--- a/pkg/controller.v1beta1/tensorflow/service.go
+++ b/pkg/controller.v1beta1/tensorflow/service.go
@@ -70,7 +70,7 @@ func (tc *TFController) reconcileServices(
 func (tc *TFController) createNewService(tfjob *tfv1beta1.TFJob, rtype tfv1beta1.TFReplicaType, index string, spec *common.ReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return err
 	}
 

--- a/pkg/controller.v1beta1/tensorflow/util.go
+++ b/pkg/controller.v1beta1/tensorflow/util.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	errPortNotFound = fmt.Errorf("Failed to found the port")
+	errPortNotFound = fmt.Errorf("failed to found the port")
 )
 
 // GetPortFromTFJob gets the port of tensorflow container.

--- a/pkg/controller.v2/tensorflow/controller.go
+++ b/pkg/controller.v2/tensorflow/controller.go
@@ -253,7 +253,7 @@ func (tc *TFController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("Error syncing tfjob: %v", err))
+	utilruntime.HandleError(fmt.Errorf("error syncing tfjob: %v", err))
 	tc.WorkQueue.AddRateLimited(key)
 
 	return true
@@ -262,7 +262,7 @@ func (tc *TFController) processNextWorkItem() bool {
 func (tc *TFController) enqueueTFJob(tfjob interface{}) {
 	key, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return
 	}
 
@@ -408,7 +408,7 @@ func (tc *TFController) satisfiedExpectations(tfjob *tfv1alpha2.TFJob) bool {
 	satisfied := false
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return false
 	}
 

--- a/pkg/controller.v2/tensorflow/informer.go
+++ b/pkg/controller.v2/tensorflow/informer.go
@@ -26,9 +26,9 @@ const (
 )
 
 var (
-	errGetFromKey    = fmt.Errorf("Failed to get TFJob from key")
-	errNotExists     = fmt.Errorf("The object is not found")
-	errFailedMarshal = fmt.Errorf("Failed to marshal the object to TFJob")
+	errGetFromKey    = fmt.Errorf("failed to get TFJob from key")
+	errNotExists     = fmt.Errorf("the object is not found")
+	errFailedMarshal = fmt.Errorf("failed to marshal the object to TFJob")
 )
 
 func NewUnstructuredTFJobInformer(restConfig *restclientset.Config, namespace string) tfjobinformersv1alpha2.TFJobInformer {

--- a/pkg/controller.v2/tensorflow/pod.go
+++ b/pkg/controller.v2/tensorflow/pod.go
@@ -113,7 +113,7 @@ func (tc *TFController) reconcilePods(
 func (tc *TFController) createNewPod(tfjob *tfv1alpha2.TFJob, rt, index string, spec *tfv1alpha2.TFReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return err
 	}
 	expectationPodsKey := jobcontroller.GenExpectationPodsKey(tfjobKey, rt)

--- a/pkg/controller.v2/tensorflow/service.go
+++ b/pkg/controller.v2/tensorflow/service.go
@@ -69,7 +69,7 @@ func (tc *TFController) reconcileServices(
 func (tc *TFController) createNewService(tfjob *tfv1alpha2.TFJob, rtype tfv1alpha2.TFReplicaType, index string, spec *tfv1alpha2.TFReplicaSpec) error {
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for tfjob object %#v: %v", tfjob, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
 		return err
 	}
 

--- a/pkg/controller.v2/tensorflow/util.go
+++ b/pkg/controller.v2/tensorflow/util.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	errPortNotFound = fmt.Errorf("Failed to found the port")
+	errPortNotFound = fmt.Errorf("failed to found the port")
 )
 
 // GetPortFromTFJob gets the port of tensorflow container.

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -30,12 +30,6 @@ import (
 // RecommendedConfigPathEnvVar is a environment variable for path configuration
 const RecommendedConfigPathEnvVar = "KUBECONFIG"
 
-// TODO(jlewi): I think this function is used to add an owner to a resource. I think we we should use this
-// addOwnerRefToObject method to ensure all resources created for the TFJob are owned by the TFJob.
-func addOwnerRefToObject(o metav1.Object, r metav1.OwnerReference) {
-	o.SetOwnerReferences(append(o.GetOwnerReferences(), r))
-}
-
 // MustNewKubeClient returns new kubernetes client for cluster configuration
 func MustNewKubeClient() kubernetes.Interface {
 	cfg, err := GetClusterConfig()
@@ -93,15 +87,5 @@ func CascadeDeleteOptions(gracePeriodSeconds int64) *metav1.DeleteOptions {
 			foreground := metav1.DeletePropagationForeground
 			return &foreground
 		}(),
-	}
-}
-
-// mergeLabels merges l2 into l1. Conflicting labels will be skipped.
-func mergeLabels(l1, l2 map[string]string) {
-	for k, v := range l2 {
-		if _, ok := l1[k]; ok {
-			continue
-		}
-		l1[k] = v
 	}
 }


### PR DESCRIPTION
This PR addresses Travis CI build failure by fixing below items.

1. Upstream gometalinter removed gosimple [here](https://github.com/alecthomas/gometalinter/commit/96c7e2a871d86b852b5d76f76e365b3a63e7dcaa)
2. Removing support for go@1.8 Travis CI test.
3. Adding back gotype as it was removed in (#254) due to go@1.8 support.
4. Increased the deadline timeout to 500s as go@1.9 Travis CI test sometimes takes more than 300s.
5. Refactored code to align with staticcheck warnings.

Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/919)
<!-- Reviewable:end -->