### PR TITLE
Renaming the labels to consistent format

### DIFF
--- a/dashboard/backend/handler/api_handler.go
+++ b/dashboard/backend/handler/api_handler.go
@@ -25,7 +25,7 @@ type APIHandler struct {
 // if any and related pods
 type TFJobDetail struct {
 	TFJob *v1beta1.TFJob `json:"tfJob"`
-	Pods  []v1.Pod        `json:"pods"`
+	Pods  []v1.Pod       `json:"pods"`
 }
 
 // TFJobList is a list of TFJobs
@@ -160,7 +160,7 @@ func (apiHandler *APIHandler) handleGetTFJobDetail(request *restful.Request, res
 
 	// Get associated pods
 	pods, err := apiHandler.cManager.ClientSet.CoreV1().Pods(namespace).List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("group_name=kubeflow.org,tf_job_name=%s", name),
+		LabelSelector: fmt.Sprintf("group-name=kubeflow.org,tf-job-name=%s", name),
 	})
 	if err != nil {
 		log.Warningf("failed to list pods for TFJob %v under namespace %v: %v", name, namespace, err)

--- a/pkg/common/jobcontroller/jobcontroller.go
+++ b/pkg/common/jobcontroller/jobcontroller.go
@@ -52,7 +52,7 @@ type ControllerInterface interface {
 	// Returns the Replica Index(value) in the labels of the job
 	GetReplicaIndexLabelKey() string
 
-	//Returns the Job Role(key) in the labels of the job
+	// Returns the Job Role(key) in the labels of the job
 	GetJobRoleKey() string
 
 	// Returns the Job from Informer Cache

--- a/pkg/common/jobcontroller/jobcontroller.go
+++ b/pkg/common/jobcontroller/jobcontroller.go
@@ -52,6 +52,9 @@ type ControllerInterface interface {
 	// Returns the Replica Index(value) in the labels of the job
 	GetReplicaIndexLabelKey() string
 
+	//Returns the Job Role(key) in the labels of the job
+	GetJobRoleKey() string
+
 	// Returns the Job from Informer Cache
 	GetJobFromInformerCache(namespace, name string) (metav1.Object, error)
 

--- a/pkg/common/util/v1beta1/testutil/util.go
+++ b/pkg/common/util/v1beta1/testutil/util.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	LabelGroupName = "group_name"
-	LabelTFJobName = "tf_job_name"
+	LabelGroupName = "group-name"
+	LabelTFJobName = "tf-job-name"
 )
 
 var (

--- a/pkg/common/util/v1beta2/testutil/util.go
+++ b/pkg/common/util/v1beta2/testutil/util.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	LabelGroupName = "group_name"
-	LabelTFJobName = "tf_job_name"
+	LabelGroupName = "group-name"
+	LabelTFJobName = "tf-job-name"
 )
 
 var (

--- a/pkg/controller.v1beta1/tensorflow/controller.go
+++ b/pkg/controller.v1beta1/tensorflow/controller.go
@@ -47,9 +47,9 @@ const (
 	// labels for pods and servers.
 	tfReplicaTypeLabel  = "tf-replica-type"
 	tfReplicaIndexLabel = "tf-replica-index"
-	labelGroupName      = "group_name"
-	labelTFJobName      = "tf_job_name"
-	labelTFJobRole      = "tf_job_role"
+	labelGroupName      = "group-name"
+	labelTFJobName      = "tf-job-name"
+	labelTFJobRole      = "tf-job-role"
 )
 
 var (
@@ -464,6 +464,10 @@ func (tc *TFController) GetReplicaTypeLabelKey() string {
 
 func (tc *TFController) GetReplicaIndexLabelKey() string {
 	return tfReplicaIndexLabel
+}
+
+func (tc *TFController) GetJobRoleKey() string {
+	return labelTFJobRole
 }
 
 func (tc *TFController) ControllerName() string {

--- a/pkg/controller.v1beta1/tensorflow/controller_test.go
+++ b/pkg/controller.v1beta1/tensorflow/controller_test.go
@@ -423,7 +423,7 @@ func TestSyncPdb(t *testing.T) {
 					MinAvailable: &minAvailable,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"tf_job_name": "test-sync-pdb",
+							"tf-job-name": "test-sync-pdb",
 						},
 					},
 				},

--- a/pkg/controller.v1beta2/tensorflow/controller.go
+++ b/pkg/controller.v1beta2/tensorflow/controller.go
@@ -47,9 +47,9 @@ const (
 	// labels for pods and servers.
 	tfReplicaTypeLabel  = "tf-replica-type"
 	tfReplicaIndexLabel = "tf-replica-index"
-	labelGroupName      = "group_name"
-	labelTFJobName      = "tf_job_name"
-	labelTFJobRole      = "tf_job_role"
+	labelGroupName      = "group-name"
+	labelTFJobName      = "tf-job-name"
+	labelTFJobRole      = "tf-job-role"
 )
 
 var (
@@ -464,6 +464,10 @@ func (tc *TFController) GetReplicaTypeLabelKey() string {
 
 func (tc *TFController) GetReplicaIndexLabelKey() string {
 	return tfReplicaIndexLabel
+}
+
+func (tc *TFController) GetJobRoleKey() string {
+	return labelTFJobRole
 }
 
 func (tc *TFController) ControllerName() string {

--- a/pkg/controller.v1beta2/tensorflow/controller_test.go
+++ b/pkg/controller.v1beta2/tensorflow/controller_test.go
@@ -423,7 +423,7 @@ func TestSyncPdb(t *testing.T) {
 					MinAvailable: &minAvailable,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"tf_job_name": "test-sync-pdb",
+							"tf-job-name": "test-sync-pdb",
 						},
 					},
 				},

--- a/py/kubeflow/tf_operator/tf_job_client.py
+++ b/py/kubeflow/tf_operator/tf_job_client.py
@@ -15,7 +15,7 @@ from kubernetes.client import rest
 TF_JOB_GROUP = "kubeflow.org"
 TF_JOB_PLURAL = "tfjobs"
 TF_JOB_KIND = "TFJob"
-TF_JOB_NAME_LABEL = "tf_job_name"
+TF_JOB_NAME_LABEL = "tf-job-name"
 
 # How long to wait in seconds for requests to the ApiServer
 TIMEOUT = 120
@@ -253,7 +253,7 @@ def get_labels(name, replica_type=None, replica_index=None):
   """Return labels.
   """
   labels = {
-    "group_name": "kubeflow.org",
+    "group-name": "kubeflow.org",
     TF_JOB_NAME_LABEL: name,
   }
   if replica_type:


### PR DESCRIPTION
Related: https://github.com/kubeflow/pytorch-operator/issues/140

All labels are renamed to use hyphens instead of underscores.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/951)
<!-- Reviewable:end -->