### PR TITLE
Remove usage of crd client for checking CRD existence

### DIFF
--- a/pkg/common/util/v1beta2/unstructured/informer.go
+++ b/pkg/common/util/v1beta2/unstructured/informer.go
@@ -50,10 +50,10 @@ func newFilteredUnstructuredInformer(resource schema.GroupVersionResource, clien
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return client.Resource(resource).List(options)
+				return client.Resource(resource).Namespace(namespace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return client.Resource(resource).Watch(options)
+				return client.Resource(resource).Namespace(namespace).Watch(options)
 			},
 		},
 		&unstructured.Unstructured{},


### PR DESCRIPTION
CRD client requires cluster scope access. Hence it is removed. Instead, error is checked for List API access.

Fixes: #929 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/961)
<!-- Reviewable:end -->
