### PR TITLE
Fix ineffassign error in masterRole assignment

### DIFF
--- a/pkg/controller.v1beta2/tensorflow/pod.go
+++ b/pkg/controller.v1beta2/tensorflow/pod.go
@@ -67,13 +67,12 @@ func (tc *TFController) reconcilePods(
 	replicas := int(*spec.Replicas)
 	restart := false
 	worker0Completed := false
-	masterRole := false
+	var masterRole bool
 
 	initializeTFReplicaStatuses(tfjob, rtype)
 
 	podSlices := tc.GetPodSlices(pods, replicas, logger)
 	for index, podSlice := range podSlices {
-		masterRole = false
 		if len(podSlice) > 1 {
 			logger.Warningf("We have too many pods for %s %d", rt, index)
 			// TODO(gaocegege): Kill some pods.


### PR DESCRIPTION
`golangci-lint` throws error `ineffectual assignment to masterRole`. Removed unnecessary assignments here. Default for `bool` is `false` in Go anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/974)
<!-- Reviewable:end -->
