### PR TITLE
Fix incorrect event message for PodGroup deletion

### DIFF
--- a/pkg/controller.v1beta2/tensorflow/controller.go
+++ b/pkg/controller.v1beta2/tensorflow/controller.go
@@ -410,7 +410,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1beta2.TFJob) error {
 				tc.Recorder.Eventf(tfjob, v1.EventTypeWarning, "FailedDeletePodGroup", "Error deleting: %v", err)
 				return err
 			} else {
-				tc.Recorder.Eventf(tfjob, v1.EventTypeNormal, "SuccessfulDeletePodGroup", "Deleted pdb: %v", tfjob.Name)
+				tc.Recorder.Eventf(tfjob, v1.EventTypeNormal, "SuccessfulDeletePodGroup", "Deleted PodGroup: %v", tfjob.Name)
 
 			}
 		}


### PR DESCRIPTION
This should be pod group instead of pdb.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/978)
<!-- Reviewable:end -->
