### PR TITLE
Remove trailing spaces in distributed_tfjob.yaml

### DIFF
--- a/examples/distribution_strategy/distributed_tfjob.yaml
+++ b/examples/distribution_strategy/distributed_tfjob.yaml
@@ -7,7 +7,7 @@ spec:
   cleanPodPolicy: None
   tfReplicaSpecs:
     Worker:
-      replicas: 3 
+      replicas: 3
       restartPolicy: Never
       template:
         metadata:
@@ -16,4 +16,4 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: gcr.io/kubeflow-examples/distributed_worker:v20181031-513e107c 
+              image: gcr.io/kubeflow-examples/distributed_worker:v20181031-513e107c


### PR DESCRIPTION
Came across these during yaml lint check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/983)
<!-- Reviewable:end -->
