### PR TITLE
Fix panic as pod is nil

### DIFF
--- a/pkg/common/jobcontroller/pod.go
+++ b/pkg/common/jobcontroller/pod.go
@@ -113,6 +113,10 @@ func (jc *JobController) UpdatePod(old, cur interface{}) {
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
 func (jc *JobController) DeletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
+	if pod == nil {
+		log.Errorf("DeletePod err, pod is nil")
+		return
+	}
 
 	logger := jclogger.LoggerForPod(pod, jc.Controller.GetAPIGroupVersionKind().Kind)
 


### PR DESCRIPTION
@richardsliu @gaocegege After testing v1 in our cluster, at some time when there are lots of tfjobs in cluster, and many pods/services  with running/error/complete state, will panic after restart tf-operator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1006)
<!-- Reviewable:end -->
