### PR TITLE
make resyncPeriod configurable

### DIFF
--- a/cmd/tf-operator.v1/app/options/options.go
+++ b/cmd/tf-operator.v1/app/options/options.go
@@ -16,9 +16,12 @@ package options
 
 import (
 	"flag"
+	"time"
 
 	"k8s.io/api/core/v1"
 )
+
+const DefaultResyncPeriod = 12 * time.Hour
 
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
@@ -29,6 +32,7 @@ type ServerOption struct {
 	JSONLogFormat        bool
 	EnableGangScheduling bool
 	Namespace            string
+	ResyncPeriod         time.Duration
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -55,4 +59,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.JSONLogFormat, "json-log-format", true,
 		"Set true to use json style log format. Set false to use plaintext style log format")
 	fs.BoolVar(&s.EnableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling by kube-batch.")
+
+	fs.DurationVar(&s.ResyncPeriod, "resyc-period", DefaultResyncPeriod, "Resync interval of the tf-operator")
 }

--- a/cmd/tf-operator.v1/app/server.go
+++ b/cmd/tf-operator.v1/app/server.go
@@ -50,7 +50,6 @@ var (
 	leaseDuration = 15 * time.Second
 	renewDuration = 5 * time.Second
 	retryPeriod   = 3 * time.Second
-	resyncPeriod  = 30 * time.Second
 )
 
 const RecommendedKubeConfigPathEnv = "KUBECONFIG"
@@ -101,8 +100,8 @@ func Run(opt *options.ServerOption) error {
 		os.Exit(1)
 	}
 	// Create informer factory.
-	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClientSet, resyncPeriod, opt.Namespace, nil)
-	tfJobInformerFactory := tfjobinformers.NewSharedInformerFactory(tfJobClientSet, resyncPeriod)
+	kubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClientSet, opt.ResyncPeriod, opt.Namespace, nil)
+	tfJobInformerFactory := tfjobinformers.NewSharedInformerFactory(tfJobClientSet, opt.ResyncPeriod)
 
 	unstructuredInformer := controller.NewUnstructuredTFJobInformer(kcfg, opt.Namespace)
 


### PR DESCRIPTION
For now, the default value for `resyncPeriod` is 30s and it is too short and we do not rely on  the resync of reflector to sync our tfjob, So make the resyncPeriod  configurable and update the default value to 12 hour

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1013)
<!-- Reviewable:end -->
