### PR TITLE
set annotation automatically when EnableGangScheduling is set to true

### DIFF
--- a/pkg/controller.v1/tensorflow/pod.go
+++ b/pkg/controller.v1/tensorflow/pod.go
@@ -192,6 +192,12 @@ func (tc *TFController) createNewPod(tfjob *tfv1.TFJob, rt, index string, spec *
 		} else {
 			podTemplate.Spec.SchedulerName = gangSchedulerName
 		}
+
+		if podTemplate.Annotations == nil {
+			podTemplate.Annotations = map[string]string{}
+		}
+		// we create the podGroup with the same name as the tfjob
+		podTemplate.Annotations["scheduling.k8s.io/group-name"] = tfjob.Name
 	}
 
 	err = tc.PodControl.CreatePodsWithControllerRef(tfjob.Namespace, podTemplate, tfjob, controllerRef)


### PR DESCRIPTION
To allow the gang-scheduling with using kube-batch, we need to create podGroup and set the annotation `scheduling.k8s.io/group-name: $PODGROUP_NAME` to each pod.

When EnableGangScheduling is set to true tf-operator create the podGroup automatically but doesn't set the annotation.
This PR fixes the problem by setting the annotation when create the pods.

fix #1031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1032)
<!-- Reviewable:end -->
