### PR TITLE
Set worker 0 completed if pod's phase goto succeeded

### DIFF
--- a/pkg/controller.v1/tensorflow/pod.go
+++ b/pkg/controller.v1/tensorflow/pod.go
@@ -120,7 +120,8 @@ func (tc *TFController) reconcilePods(
 			}
 
 			// Check whether worker 0 is exited without error.
-			if rtype == tfv1.TFReplicaTypeWorker && index == 0 && exitCode == 0 {
+			if rtype == tfv1.TFReplicaTypeWorker && index == 0 &&
+				exitCode == 0 && pod.Status.Phase == v1.PodSucceeded {
 				worker0Completed = true
 			}
 			updateTFJobReplicaStatuses(tfjob, rtype, pod)

--- a/pkg/controller.v1beta2/tensorflow/pod.go
+++ b/pkg/controller.v1beta2/tensorflow/pod.go
@@ -120,7 +120,8 @@ func (tc *TFController) reconcilePods(
 			}
 
 			// Check whether worker 0 is exited without error.
-			if rtype == tfv1beta2.TFReplicaTypeWorker && index == 0 && exitCode == 0 {
+			if rtype == tfv1beta2.TFReplicaTypeWorker && index == 0 &&
+				exitCode == 0 && pod.Status.Phase == v1.PodSucceeded {
 				worker0Completed = true
 			}
 			updateTFJobReplicaStatuses(tfjob, rtype, pod)


### PR DESCRIPTION
I want to delete `Running` PS pods automatically but leave `Completed` Worker pods as there are some logs for debugging, so i set `CleanPodPolicy`=`Running` but it will delete all pods after TFJob is  completed.

I check out the code and find the root cause: we set worker 0 completed if it's exit code is zero but kubelet maybe not set the phase to `Succeeded` immediately so it still in `Running` phase when call function `deletePodsAndServices`.

@richardsliu @gaocegege PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1042)
<!-- Reviewable:end -->
