### PR TITLE
show correct namespace and name when deleting job through dashboard

### DIFF
--- a/dashboard/frontend/src/components/AppBar.js
+++ b/dashboard/frontend/src/components/AppBar.js
@@ -37,6 +37,9 @@ class AppBar extends Component {
     ];
 
     let rightMenu = null;
+    let ns = null;
+    let name = null;
+
     if (this.props.location.pathname !== "/new") {
       rightMenu = (
         <div style={this.styles.rightMenu}>
@@ -49,6 +52,10 @@ class AppBar extends Component {
           />
         </div>
       );
+      let path = this.props.location.pathname.replace("/", "");
+      path = path.split("/");
+      ns = path[0];
+      name = path[1];
     }
     return (
       <div>
@@ -63,7 +70,7 @@ class AppBar extends Component {
           modal={true}
           open={this.state.isModalVisible}
         >
-          {'Are you sure you want to delete TFJob "test" in namespace "test"?'}
+          {'Are you sure you want to delete TFJob "' + name + '" in namespace "' + ns + '"?'}
         </Dialog>
       </div>
     );


### PR DESCRIPTION
When I try to delete job through the dashboard, I notice that the message is always:

> Are you sure you want to delete TFJob "test" in namespace "test"?

So I replace "test" with real namespace and name of the job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1043)
<!-- Reviewable:end -->
