### PR TITLE
fix bug: When executing `tf-operator.v1 -version`, GitSHA is always 'not provided'

### DIFF
--- a/py/kubeflow/tf_operator/release.py
+++ b/py/kubeflow/tf_operator/release.py
@@ -151,7 +151,7 @@ def build_operator_image(root_dir,
   ]
   for t in targets:
     if t in [
-        "github.com/kubeflow/tf-operator/cmd/tf-operator.v1beta2"
+        "github.com/kubeflow/tf-operator/cmd/tf-operator.v1beta2",
         "github.com/kubeflow/tf-operator/cmd/tf-operator.v1"
     ]:
       util.run([
@@ -159,6 +159,7 @@ def build_operator_image(root_dir,
         "-X github.com/kubeflow/tf-operator/pkg/version.GitSHA={}".format(
           commit), t
       ])
+      continue
     util.run(["go", "install", t])
 
   # Dashboard's frontend:


### PR DESCRIPTION
After fix a small bug in release scripts, the git commit id can be set into GitSHA variable.
The GitSHA is not 'Not provided' anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1046)
<!-- Reviewable:end -->
