### PR TITLE
Avoid unnecessary update when tfjob is complete

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kubeflow/tf-operator/pkg/util/k8sutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -433,7 +434,8 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1.TFJob) error {
 			}
 		}
 		// no need to update the tfjob if the status hasn't changed since last time even the tfjob is not running.
-		if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+
+		if !apiequality.Semantic.DeepEqual(*oldStatus, tfjob.Status) {
 			return tc.updateStatusHandler(tfjob)
 		}
 		return nil

--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -432,7 +432,11 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1.TFJob) error {
 				tfjob.Status.ReplicaStatuses[rtype].Active = 0
 			}
 		}
-		return tc.updateStatusHandler(tfjob)
+		// no need to update the tfjob if the status hasn't changed since last time even the tfjob is not running.
+		if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+			return tc.updateStatusHandler(tfjob)
+		}
+		return nil
 	}
 
 	if tc.Config.EnableGangScheduling {

--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -17,7 +17,6 @@ package tensorflow
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -469,7 +468,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1.TFJob) error {
 	}
 
 	// no need to update the tfjob if the status hasn't changed since last time.
-	if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+	if !apiequality.Semantic.DeepEqual(*oldStatus, tfjob.Status) {
 		return tc.updateStatusHandler(tfjob)
 	}
 	return nil

--- a/pkg/controller.v1/tensorflow/status.go
+++ b/pkg/controller.v1/tensorflow/status.go
@@ -22,7 +22,6 @@ import (
 	common "github.com/kubeflow/tf-operator/pkg/apis/common/v1"
 	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
-	"github.com/labstack/gommon/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	v1 "k8s.io/api/core/v1"
@@ -175,7 +174,8 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 func (tc *TFController) updateTFJobStatus(tfjob *tfv1.TFJob) error {
 	startTime := time.Now()
 	defer func() {
-		log.Infof("Finished updating TFJobs Status %q (%v)", tfjob.Name, time.Since(startTime))
+		tflogger.LoggerForJob(tfjob).Infof("Finished updating TFJobs Status %q (%v)",
+			tfjob.Name, time.Since(startTime))
 	}()
 	_, err := tc.tfJobClientSet.KubeflowV1().TFJobs(tfjob.Namespace).UpdateStatus(tfjob)
 	return err

--- a/pkg/controller.v1/tensorflow/status.go
+++ b/pkg/controller.v1/tensorflow/status.go
@@ -22,6 +22,7 @@ import (
 	common "github.com/kubeflow/tf-operator/pkg/apis/common/v1"
 	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
+	"github.com/labstack/gommon/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	v1 "k8s.io/api/core/v1"
@@ -172,6 +173,10 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1.TFJob, rtype tfv1.TFRepli
 
 // updateTFJobStatus updates the status of the given TFJob.
 func (tc *TFController) updateTFJobStatus(tfjob *tfv1.TFJob) error {
+	startTime := time.Now()
+	defer func() {
+		log.Infof("Finished updating TFJobs Status %q (%v)", tfjob.Name, time.Since(startTime))
+	}()
 	_, err := tc.tfJobClientSet.KubeflowV1().TFJobs(tfjob.Namespace).UpdateStatus(tfjob)
 	return err
 }

--- a/pkg/controller.v1beta2/tensorflow/controller.go
+++ b/pkg/controller.v1beta2/tensorflow/controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubeflow/tf-operator/pkg/common/jobcontroller"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
 	"github.com/kubeflow/tf-operator/pkg/util/k8sutil"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -457,7 +458,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1beta2.TFJob) error {
 	}
 
 	// no need to update the tfjob if the status hasn't changed since last time.
-	if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+	if !apiequality.Semantic.DeepEqual(*oldStatus, tfjob.Status) {
 		return tc.updateStatusHandler(tfjob)
 	}
 	return nil

--- a/pkg/controller.v1beta2/tensorflow/controller.go
+++ b/pkg/controller.v1beta2/tensorflow/controller.go
@@ -423,7 +423,10 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1beta2.TFJob) error {
 				tfjob.Status.ReplicaStatuses[rtype].Active = 0
 			}
 		}
-		return tc.updateStatusHandler(tfjob)
+		// no need to update the tfjob if the status hasn't changed since last time even the tfjob is not running.
+		if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+			return tc.updateStatusHandler(tfjob)
+		}
 	}
 
 	if tc.Config.EnableGangScheduling {

--- a/pkg/controller.v1beta2/tensorflow/controller.go
+++ b/pkg/controller.v1beta2/tensorflow/controller.go
@@ -17,7 +17,6 @@ package tensorflow
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 
@@ -425,7 +424,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1beta2.TFJob) error {
 			}
 		}
 		// no need to update the tfjob if the status hasn't changed since last time even the tfjob is not running.
-		if !reflect.DeepEqual(*oldStatus, tfjob.Status) {
+		if !apiequality.Semantic.DeepEqual(*oldStatus, tfjob.Status) {
 			return tc.updateStatusHandler(tfjob)
 		}
 	}

--- a/pkg/controller.v1beta2/tensorflow/status.go
+++ b/pkg/controller.v1beta2/tensorflow/status.go
@@ -22,7 +22,6 @@ import (
 	common "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2"
 	tfv1beta2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta2"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
-	"github.com/labstack/gommon/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -153,7 +152,8 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1beta2.TFJob, rtype tfv1bet
 func (tc *TFController) updateTFJobStatus(tfjob *tfv1beta2.TFJob) error {
 	startTime := time.Now()
 	defer func() {
-		log.Infof("Finished updating TFJobs Status %q (%v)", tfjob.Name, time.Since(startTime))
+		tflogger.LoggerForJob(tfjob).Infof("Finished updating TFJobs Status %q (%v)",
+			tfjob.Name, time.Since(startTime))
 	}()
 	_, err := tc.tfJobClientSet.KubeflowV1beta2().TFJobs(tfjob.Namespace).UpdateStatus(tfjob)
 	return err

--- a/pkg/controller.v1beta2/tensorflow/status.go
+++ b/pkg/controller.v1beta2/tensorflow/status.go
@@ -22,6 +22,7 @@ import (
 	common "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2"
 	tfv1beta2 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta2"
 	tflogger "github.com/kubeflow/tf-operator/pkg/logger"
+	"github.com/labstack/gommon/log"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -150,6 +151,10 @@ func (tc *TFController) updateStatusSingle(tfjob *tfv1beta2.TFJob, rtype tfv1bet
 
 // updateTFJobStatus updates the status of the given TFJob.
 func (tc *TFController) updateTFJobStatus(tfjob *tfv1beta2.TFJob) error {
+	startTime := time.Now()
+	defer func() {
+		log.Infof("Finished updating TFJobs Status %q (%v)", tfjob.Name, time.Since(startTime))
+	}()
 	_, err := tc.tfJobClientSet.KubeflowV1beta2().TFJobs(tfjob.Namespace).UpdateStatus(tfjob)
 	return err
 }


### PR DESCRIPTION
Updating status is unnecessary when the tfjob is done and no status is updated indeed. But it will introduce overhead by writing etcd. The commit is to avoid such operation.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1051)
<!-- Reviewable:end -->
