### PR TITLE
add total suffix in counter metrics

### DIFF
--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -58,32 +58,34 @@ tf_operator_is_leader
 
 ### Report TFJob metrics:
 
+*Note*: If you are using release v1 tf-operator, these TFJob metrics don't have suffix `total`. So you have to use metric name like `tf_operator_jobs_created` to get your metrics. See [PR](https://github.com/kubeflow/tf-operator/pull/1055) to get more information.
+
 **Job Creation**
 ```
-tf_operator_jobs_created
+tf_operator_jobs_created_total
 ```
 
 **Job Creation**
 ```
-sum (rate (tf_operator_jobs_created[60m]))
+sum (rate (tf_operator_jobs_created_total[60m]))
 ```
 
 **Job Deletion**
 ```
-tf_operator_jobs_deleted
+tf_operator_jobs_deleted_total
 ```
 
 **Successful Job Completions**
 ```
-tf_operator_jobs_successful
+tf_operator_jobs_successful_total
 ```
 
 **Failed Jobs**
 ```
-tf_operator_jobs_failed
+tf_operator_jobs_failed_total
 ```
 
 **Restarted Jobs**
 ```
-tf_operator_jobs_restarted
+tf_operator_jobs_restarted_total
 ```

--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -72,7 +72,7 @@ var (
 	}
 
 	tfJobsDeletedCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_deleted",
+		Name: "tf_operator_jobs_deleted_total",
 		Help: "Counts number of TF jobs deleted",
 	})
 )

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	tfJobsCreatedCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_created",
+		Name: "tf_operator_jobs_created_total",
 		Help: "Counts number of TF jobs created",
 	})
 )
@@ -50,7 +50,7 @@ func (tc *TFController) addTFJob(obj interface{}) {
 
 			status := common.JobStatus{
 				Conditions: []common.JobCondition{
-					common.JobCondition{
+					{
 						Type:               common.JobFailed,
 						Status:             v1.ConditionTrue,
 						LastUpdateTime:     metav1.Now(),

--- a/pkg/controller.v1/tensorflow/status.go
+++ b/pkg/controller.v1/tensorflow/status.go
@@ -44,15 +44,15 @@ const (
 
 var (
 	tfJobsSuccessCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_successful",
+		Name: "tf_operator_jobs_successful_total",
 		Help: "Counts number of TF jobs successful",
 	})
 	tfJobsFailureCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_failed",
+		Name: "tf_operator_jobs_failed_total",
 		Help: "Counts number of TF jobs failed",
 	})
 	tfJobsRestartCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_restarted",
+		Name: "tf_operator_jobs_restarted_total",
 		Help: "Counts number of TF jobs restarted",
 	})
 )

--- a/pkg/controller.v1beta2/tensorflow/job.go
+++ b/pkg/controller.v1beta2/tensorflow/job.go
@@ -41,7 +41,7 @@ func (tc *TFController) addTFJob(obj interface{}) {
 
 			status := common.JobStatus{
 				Conditions: []common.JobCondition{
-					common.JobCondition{
+					{
 						Type:               common.JobFailed,
 						Status:             v1.ConditionTrue,
 						LastUpdateTime:     metav1.Now(),


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

I am wondering if this pr will cause compatibility problem. But I think we should follow the [metrics naming](https://prometheus.io/docs/practices/naming/) . All counter metrics need add suffix `total`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1055)
<!-- Reviewable:end -->
