### PR TITLE
Add qps and burst options

### DIFF
--- a/cmd/tf-operator.v1/app/options/options.go
+++ b/cmd/tf-operator.v1/app/options/options.go
@@ -34,6 +34,12 @@ type ServerOption struct {
 	Namespace            string
 	MonitoringPort       int
 	ResyncPeriod         time.Duration
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS int
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -66,4 +72,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&s.MonitoringPort, "monitoring-port", 8443,
 		`Endpoint port for displaying monitoring metrics`)
 	fs.DurationVar(&s.ResyncPeriod, "resyc-period", DefaultResyncPeriod, "Resync interval of the tf-operator")
+
+	fs.IntVar(&s.QPS, "qps", 5, "QPS indicates the maximum QPS to the master from this client.")
+	fs.IntVar(&s.Burst, "burst", 10, "Maximum burst for throttle.")
 }

--- a/cmd/tf-operator.v1/app/server.go
+++ b/cmd/tf-operator.v1/app/server.go
@@ -101,8 +101,13 @@ func Run(opt *options.ServerOption) error {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
+	// Set client qps and burst by opt.
+	kcfg.QPS = float32(opt.QPS)
+	kcfg.Burst = opt.Burst
+
 	// Create clients.
-	kubeClientSet, leaderElectionClientSet, tfJobClientSet, kubeBatchClientSet, err := createClientSets(kcfg)
+	kubeClientSet, leaderElectionClientSet, tfJobClientSet,
+		kubeBatchClientSet, err := createClientSets(kcfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/tf-operator.v1beta2/app/options/options.go
+++ b/cmd/tf-operator.v1beta2/app/options/options.go
@@ -29,6 +29,12 @@ type ServerOption struct {
 	JSONLogFormat        bool
 	EnableGangScheduling bool
 	Namespace            string
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS int
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -46,7 +52,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 		 will overrides any value in kubeconfig, only required if out-of-cluster.`)
 
 	fs.StringVar(&s.Namespace, "namespace", v1.NamespaceAll,
-		`The namespace to monitor tfjobs. If unset, it monitors all namespaces cluster-wide. 
+		`The namespace to monitor tfjobs. If unset, it monitors all namespaces cluster-wide.
                 If set, it only monitors tfjobs in the given namespace.`)
 
 	fs.IntVar(&s.Threadiness, "threadiness", 1,
@@ -57,4 +63,7 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.JSONLogFormat, "json-log-format", true,
 		"Set true to use json style log format. Set false to use plaintext style log format")
 	fs.BoolVar(&s.EnableGangScheduling, "enable-gang-scheduling", false, "Set true to enable gang scheduling by kube-batch.")
+
+	fs.IntVar(&s.QPS, "qps", 5, "QPS indicates the maximum QPS to the master from this client.")
+	fs.IntVar(&s.Burst, "burst", 10, "Maximum burst for throttle.")
 }

--- a/cmd/tf-operator.v1beta2/app/server.go
+++ b/cmd/tf-operator.v1beta2/app/server.go
@@ -92,8 +92,13 @@ func Run(opt *options.ServerOption) error {
 		log.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
+	// Set client qps and burst by opt.
+	kcfg.QPS = float32(opt.QPS)
+	kcfg.Burst = opt.Burst
+
 	// Create clients.
-	kubeClientSet, leaderElectionClientSet, tfJobClientSet, kubeBatchClientSet, err := createClientSets(kcfg)
+	kubeClientSet, leaderElectionClientSet, tfJobClientSet,
+		kubeBatchClientSet, err := createClientSets(kcfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When many jobs created as the same time, pods are created slowly, increase qps and burst of kube client will bring effective improvements.

@gaocegege @richardsliu @johnugeorge PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1063)
<!-- Reviewable:end -->
