### PR TITLE
Set tfjob defaults in test utils

### DIFF
--- a/pkg/common/util/v1/testutil/tfjob.go
+++ b/pkg/common/util/v1/testutil/tfjob.go
@@ -115,6 +115,7 @@ func NewTFJob(worker, ps int) *tfv1.TFJob {
 			TFReplicaSpecs: make(map[tfv1.TFReplicaType]*common.ReplicaSpec),
 		},
 	}
+	tfv1.SetObjectDefaults_TFJob(tfJob)
 
 	if worker > 0 {
 		worker := int32(worker)

--- a/pkg/common/util/v1beta2/testutil/tfjob.go
+++ b/pkg/common/util/v1beta2/testutil/tfjob.go
@@ -115,6 +115,7 @@ func NewTFJob(worker, ps int) *tfv1beta2.TFJob {
 			TFReplicaSpecs: make(map[tfv1beta2.TFReplicaType]*common.ReplicaSpec),
 		},
 	}
+	tfv1beta2.SetObjectDefaults_TFJob(tfJob)
 
 	if worker > 0 {
 		worker := int32(worker)


### PR DESCRIPTION
When creating a tfjob object for testing, the default values should also be filled in using the same defaulter function in the scheme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1071)
<!-- Reviewable:end -->
