### PR TITLE
feat: Add adopters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Please refer to the [developer_guide](developer_guide.md)
 
 Please refer to [CHANGELOG](CHANGELOG.md)
 
+## Adopters
+
+Please refer to [adopters list](./docs/adopters.md).
+
 ## Community
 
 This is a part of Kubeflow, so please see [readme in kubeflow/kubeflow](https://github.com/kubeflow/kubeflow#get-involved) to get in touch with the community.

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -1,0 +1,7 @@
+# TF Operator Adopters
+
+This is a list of TF Operator adopters in various industries.
+
+| Company | Industry | Success Story |
+| :--- | :--- | :--- |
+|[Caicloud](https://intl.caicloud.io/)|Cloud Computing||


### PR DESCRIPTION
Ref https://github.com/kubeflow/tf-operator/issues/1076

This is the PR to add adopters section in README.

/assign @johnugeorge @richardsliu 

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1092)
<!-- Reviewable:end -->
