### PR TITLE
[WIP] Allow TF Job Dashboard to run on namespace scope

### DIFF
--- a/dashboard/backend/main.go
+++ b/dashboard/backend/main.go
@@ -19,8 +19,12 @@ const (
 func main() {
 	var frontendDir string
 	var port int
+	var namespace string
 	flag.StringVar(&frontendDir, "frontend-dir", DefaultFrontendDir,
 		`directory of the dashboard frontend`)
+	flag.StringVar(&namespace, "namespace", "",
+		`The namespace to monitor tfjobs. If unset, it monitors all namespaces cluster-wide.
+		 If set, it only monitors tfjobs in the given namespace.`)
 	flag.IntVar(&port, "port", DefaultBackendPort,
 		`port this program will listen`)
 	flag.Parse()
@@ -29,7 +33,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error while initializing connection to Kubernetes apiserver: %v", err)
 	}
-	apiHandler, err := handler.CreateHTTPAPIHandler(cm)
+	apiHandler, err := handler.CreateHTTPAPIHandler(cm, namespace)
 	if err != nil {
 		log.Fatalf("Error while creating the API Handler: %v", err)
 	}

--- a/dashboard/frontend/src/components/Home.js
+++ b/dashboard/frontend/src/components/Home.js
@@ -46,13 +46,17 @@ class Home extends Component {
 
   fetchNamespaces() {
     getNamespaces()
-      .then(b =>
+      .then(b => {
+        let namespaces_list = b.items.map(ns => ns.metadata.name);
+        if (namespaces_list.length > 1) {
+          namespaces_list = namespaces_list.concat(allNamespacesKey);
+        } else {
+          this.setState({ selectedNamespace: namespaces_list[0] });
+        }
         this.setState({
-          namespaces: b.items
-            .map(ns => ns.metadata.name)
-            .concat(allNamespacesKey)
-        })
-      )
+          namespaces: namespaces_list
+        });
+      })
       .catch(console.error);
   }
 


### PR DESCRIPTION
We hit the issue #923 when we started working on TF Job Operator and Dashboard deployment on OpenShift, so I decided to try to come up with a solution.

The specific reason why we'd like to have this feature is that we want to use `Role` instead of `ClusterRole` and only deploy on namespace scope to make sure users in multitenant clusters do not get into security issues (like user `A` deploying jobs to user `B` via the dashboard)

This PR makes 2 changes in TF Job Dashboard code:

* Backend
  * Allow `--namespace` specification which will then used as the only namespace returned on `getnamespaces` call
* Frontend
  * It is unnecessary to add `All namespaces` to the select box
  * If there is only one namespace returned from `backend` we'd like that to be pre-selected automatically

As this is my first PR into TF Job Operator and Kubeflow generally, I'd like to get some guidance if the approach sounds reasonable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1100)
<!-- Reviewable:end -->
