### PR TITLE
feat: Support pprof when monitoring is specified

### DIFF
--- a/cmd/tf-operator.v1/app/options/options.go
+++ b/cmd/tf-operator.v1/app/options/options.go
@@ -73,7 +73,9 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.GangSchedulerName, "gang-scheduler-name", "volcano", "The scheduler to gang-schedule tfjobs, defaults to volcano")
 
 	fs.IntVar(&s.MonitoringPort, "monitoring-port", 8443,
-		`Endpoint port for displaying monitoring metrics`)
+		`Endpoint port for displaying monitoring metrics. 
+It can be set to "0" to disable the metrics serving.`)
+
 	fs.DurationVar(&s.ResyncPeriod, "resyc-period", DefaultResyncPeriod, "Resync interval of the tf-operator")
 
 	fs.IntVar(&s.QPS, "qps", 5, "QPS indicates the maximum QPS to the master from this client.")

--- a/cmd/tf-operator.v1/main.go
+++ b/cmd/tf-operator.v1/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"strconv"
 
 	"github.com/onrik/logrus/filename"
@@ -36,14 +37,16 @@ func init() {
 }
 
 func startMonitoring(monitoringPort int) {
-	go func() {
-		log.Infof("Setting up client for monitoring on port: %s", strconv.Itoa(monitoringPort))
-		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(monitoringPort)), nil)
-		if err != nil {
-			log.Error("Monitoring endpoint setup failure.")
-		}
-	}()
+	if monitoringPort != 0 {
+		go func() {
+			log.Infof("Setting up client for monitoring on port: %s", strconv.Itoa(monitoringPort))
+			http.Handle("/metrics", promhttp.Handler())
+			err := http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(monitoringPort)), nil)
+			if err != nil {
+				log.Error("Monitoring endpoint setup failure.", err)
+			}
+		}()
+	}
 }
 
 func main() {


### PR DESCRIPTION
Reuse the Prometheus metrics port to expose golang pprof info.

/assign @johnugeorge @hougangliu 

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1102)
<!-- Reviewable:end -->
