### PR TITLE
Add more APIs for TFJob done

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -24,6 +24,7 @@ workflows:
     - py/*
     - test/*
     - vendor/*
+    - sdk/*
     params:
       registry: "gcr.io/kubeflow-ci"
       tfJobVersion: v1

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -39,6 +39,11 @@ Class | Method | Description
 [TFJobClient](docs/TFJobClient.md) | [get](docs/TFJobClient.md#get)    | Get or watch the specified TFJob or all TFJob in the namespace |
 [TFJobClient](docs/TFJobClient.md) | [patch](docs/TFJobClient.md#patch)  | Patch the specified TFJob|
 [TFJobClient](docs/TFJobClient.md) | [delete](docs/TFJobClient.md#delete) | Delete the specified TFJob |
+[TFJobClient](docs/TFJobClient.md)  | [wait_for_job](docs/TFJobClient.md#wait_for_job) | Wait for the specified job to finish |
+[TFJobClient](docs/TFJobClient.md)  | [wait_for_condition](docs/TFJobClient.md#wait_for_condition) | Waits until any of the specified conditions occur |
+[TFJobClient](docs/TFJobClient.md)  | [get_job_status](docs/TFJobClient.md#get_job_status) | Get the TFJob status|
+[TFJobClient](docs/TFJobClient.md)  | [if_job_running](docs/TFJobClient.md#if_job_running) | Check if the TFJob running |
+[TFJobClient](docs/TFJobClient.md)  | [if_job_succeeded](docs/TFJobClient.md#if_job_succeeded) | Check if the TFJob Succeeded |
 
 ## Documentation For Models
 

--- a/sdk/python/docs/TFJobClient.md
+++ b/sdk/python/docs/TFJobClient.md
@@ -20,7 +20,11 @@ TFJobClient| [create](#create) | Create TFJob|
 TFJobClient | [get](#get)    | Get the specified TFJob or all TFJob in the namespace |
 TFJobClient | [patch](#patch)  | Patch the specified TFJob|
 TFJobClient | [delete](#delete) | Delete the specified TFJob |
-
+TFJobClient | [wait_for_job](#wait_for_job) | Wait for the specified job to finish |
+TFJobClient | [wait_for_condition](#wait_for_condition) | Waits until any of the specified conditions occur |
+TFJobClient | [get_job_status](#get_job_status) | Get the TFJob status|
+TFJobClient | [if_job_running](#if_job_running) | Check if the TFJob running |
+TFJobClient | [if_job_succeeded](#if_job_succeeded) | Check if the TFJob Succeeded |s
 
 ## create
 > create(tfjob, namespace=None)
@@ -108,7 +112,7 @@ tfjob_client.get('mnist', namespace='kubeflow')
 ### Parameters
 Name | Type |  Description | Notes
 ------------ | ------------- | ------------- | -------------
-name  | str | tfjob name. If the `name` is not specified, it will get all tfjobs in the namespace.| Optional. |
+name  | str | The TFJob name. If the `name` is not specified, it will get all tfjobs in the namespace.| Optional. |
 namespace | str | The tfjob's namespace. Defaults to current or default namespace.| Optional |
 
 
@@ -164,8 +168,142 @@ tfjob_client.delete('mnist', namespace='kubeflow')
 ### Parameters
 Name | Type |  Description | Notes
 ------------ | ------------- | ------------- | -------------
-name  | str | tfjob name| |
+name  | str | The TFJob name.| |
 namespace | str | The tfjob's namespace. Defaults to current or default namespace. | Optional|
 
 ### Return type
 object
+
+
+## wait_for_job
+> wait_for_job(name,
+>              namespace=None,
+>              timeout_seconds=600,
+>              polling_interval=30,
+>              status_callback=None):
+
+Wait for the specified job to finish.
+
+### Example
+
+```python
+from kubeflow.tfjob import TFJobClient
+
+tfjob_client = TFJobClient()
+tfjob_client.wait_for_job('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The TFJob name.| |
+namespace | str | The tfjob's namespace. Defaults to current or default namespace. | Optional|
+timeout_seconds | int | How long to wait for the job, default wait for 600 seconds. | Optional|
+polling_interval | int | How often to poll for the status of the job.| Optional|
+status_callback | str | Callable. If supplied this callable is invoked after we poll the job. Callable takes a single argument which is the tfjob.| Optional|
+
+### Return type
+object
+
+
+## wait_for_condition
+> wait_for_condition(name,
+>                    expected_condition,
+>                    namespace=None,
+>                    timeout_seconds=600,
+>                    polling_interval=30,
+>                    status_callback=None):
+
+
+Waits until any of the specified conditions occur.
+
+### Example
+
+```python
+from kubeflow.tfjob import TFJobClient
+
+tfjob_client = TFJobClient()
+tfjob_client.wait_for_condition('mnist', expected_condition=["Succeeded", "Failed"], namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The TFJob name.| |
+expected_condition  |List |A list of conditions. Function waits until any of the supplied conditions is reached.| |
+namespace | str | The tfjob's namespace. Defaults to current or default namespace. | Optional|
+timeout_seconds | int | How long to wait for the job, default wait for 600 seconds. | Optional|
+polling_interval | int | How often to poll for the status of the job.| Optional|
+status_callback | str | Callable. If supplied this callable is invoked after we poll the job. Callable takes a single argument which is the tfjob.| Optional|
+
+### Return type
+object
+
+## get_job_status
+> get_job_status(name, namespace=None)
+
+Returns TFJob status, such as Running, Failed or Succeeded.
+
+### Example
+
+```python
+from kubeflow.tfjob import TFJobClient
+
+tfjob_client = TFJobClient()
+tfjob_client.get_job_status('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The TFJob name. | |
+namespace | str | The tfjob's namespace. Defaults to current or default namespace.| Optional |
+
+### Return type
+Str
+
+## if_job_running
+> if_job_running(name, namespace=None)
+
+Returns True if the TFJob running; false otherwise.
+
+### Example
+
+```python
+from kubeflow.tfjob import TFJobClient
+
+tfjob_client = TFJobClient()
+tfjob_client.if_job_running('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The TFJob name.| |
+namespace | str | The tfjob's namespace. Defaults to current or default namespace.| Optional |
+
+### Return type
+Bool
+
+## if_job_succeeded
+> if_job_succeeded(name, namespace=None)
+
+Returns True if the TFJob succeeded; false otherwise.
+
+### Example
+
+```python
+from kubeflow.tfjob import TFJobClient
+
+tfjob_client = TFJobClient()
+tfjob_client.if_job_succeeded('mnist', namespace='kubeflow')
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+name  | str | The TFJob name.| |
+namespace | str | The tfjob's namespace. Defaults to current or default namespace.| Optional |
+
+### Return type
+Bool

--- a/sdk/python/examples/kubeflow-tfjob-sdk.ipynb
+++ b/sdk/python/examples/kubeflow-tfjob-sdk.ipynb
@@ -13,12 +13,12 @@
    "source": [
     "This is a sample for Kubeflow TFJob SDK `kubeflow-tfjob`.\n",
     "\n",
-    "The notebook shows how to use Kubeflow TFJob SDK to create, get, update and delete tfjob."
+    "The notebook shows how to use Kubeflow TFJob SDK to create, get, wait, check and delete tfjob."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,12 +112,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'apiVersion': 'kubeflow.org/v1',\n",
+       " 'kind': 'TFJob',\n",
+       " 'metadata': {'creationTimestamp': '2019-12-17T05:40:26Z',\n",
+       "  'generation': 1,\n",
+       "  'name': 'mnist',\n",
+       "  'namespace': 'default',\n",
+       "  'resourceVersion': '13585452',\n",
+       "  'selfLink': '/apis/kubeflow.org/v1/namespaces/default/tfjobs/mnist',\n",
+       "  'uid': 'b9faefd7-208f-11ea-9e34-00000a1001ee'},\n",
+       " 'spec': {'cleanPodPolicy': 'None',\n",
+       "  'tfReplicaSpecs': {'Worker': {'replicas': 1,\n",
+       "    'restartPolicy': 'Never',\n",
+       "    'template': {'spec': {'containers': [{'command': ['python',\n",
+       "         '/var/tf_mnist/mnist_with_summaries.py',\n",
+       "         '--log_dir=/train/logs',\n",
+       "         '--learning_rate=0.01',\n",
+       "         '--batch_size=150'],\n",
+       "        'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',\n",
+       "        'name': 'tensorflow'}]}}}}}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "tfjob_client = TFJobClient()\n",
-    "tfjob_client.create(tfjob)"
+    "tfjob_client.create(tfjob, namespace=namespace)"
    ]
   },
   {
@@ -129,47 +158,168 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'apiVersion': 'kubeflow.org/v1',\n",
+       " 'kind': 'TFJob',\n",
+       " 'metadata': {'creationTimestamp': '2019-12-17T05:40:26Z',\n",
+       "  'generation': 1,\n",
+       "  'name': 'mnist',\n",
+       "  'namespace': 'default',\n",
+       "  'resourceVersion': '13585464',\n",
+       "  'selfLink': '/apis/kubeflow.org/v1/namespaces/default/tfjobs/mnist',\n",
+       "  'uid': 'b9faefd7-208f-11ea-9e34-00000a1001ee'},\n",
+       " 'spec': {'cleanPodPolicy': 'None',\n",
+       "  'tfReplicaSpecs': {'Worker': {'replicas': 1,\n",
+       "    'restartPolicy': 'Never',\n",
+       "    'template': {'spec': {'containers': [{'command': ['python',\n",
+       "         '/var/tf_mnist/mnist_with_summaries.py',\n",
+       "         '--log_dir=/train/logs',\n",
+       "         '--learning_rate=0.01',\n",
+       "         '--batch_size=150'],\n",
+       "        'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',\n",
+       "        'name': 'tensorflow'}]}}}}},\n",
+       " 'status': {'conditions': [{'lastTransitionTime': '2019-12-17T05:40:26Z',\n",
+       "    'lastUpdateTime': '2019-12-17T05:40:26Z',\n",
+       "    'message': 'TFJob mnist is created.',\n",
+       "    'reason': 'TFJobCreated',\n",
+       "    'status': 'True',\n",
+       "    'type': 'Created'}],\n",
+       "  'replicaStatuses': {'Worker': {}},\n",
+       "  'startTime': '2019-12-17T05:40:26Z'}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "tfjob_client.get('mnist')"
+    "tfjob_client.get('mnist', namespace=namespace)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Update the created TFJob"
+    "### Get the TFJob status, check if the TFJob has been started."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Running'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "worker = V1ReplicaSpec(\n",
-    "    replicas=1,\n",
-    "    restart_policy=\"Running\",\n",
-    "    template=V1PodTemplateSpec(\n",
-    "        spec=V1PodSpec(\n",
-    "            containers=[container]\n",
-    "        )\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "tfjob = V1TFJob(\n",
-    "    api_version=\"kubeflow.org/v1\",\n",
-    "    kind=\"TFJob\",\n",
-    "    metadata=V1ObjectMeta(name=\"mnist\",namespace=namespace),\n",
-    "    spec=V1TFJobSpec(\n",
-    "        clean_pod_policy=\"None\",\n",
-    "        tf_replica_specs={\"Worker\": worker}\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "tfjob_client.patch('mnist', tfjob)"
+    "tfjob_client.get_job_status('mnist', namespace=namespace)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Wait for the specified job to finish"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'apiVersion': 'kubeflow.org/v1',\n",
+       " 'kind': 'TFJob',\n",
+       " 'metadata': {'creationTimestamp': '2019-12-17T05:40:26Z',\n",
+       "  'generation': 1,\n",
+       "  'name': 'mnist',\n",
+       "  'namespace': 'default',\n",
+       "  'resourceVersion': '13586024',\n",
+       "  'selfLink': '/apis/kubeflow.org/v1/namespaces/default/tfjobs/mnist',\n",
+       "  'uid': 'b9faefd7-208f-11ea-9e34-00000a1001ee'},\n",
+       " 'spec': {'cleanPodPolicy': 'None',\n",
+       "  'tfReplicaSpecs': {'Worker': {'replicas': 1,\n",
+       "    'restartPolicy': 'Never',\n",
+       "    'template': {'spec': {'containers': [{'command': ['python',\n",
+       "         '/var/tf_mnist/mnist_with_summaries.py',\n",
+       "         '--log_dir=/train/logs',\n",
+       "         '--learning_rate=0.01',\n",
+       "         '--batch_size=150'],\n",
+       "        'image': 'gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0',\n",
+       "        'name': 'tensorflow'}]}}}}},\n",
+       " 'status': {'completionTime': '2019-12-17T05:42:19Z',\n",
+       "  'conditions': [{'lastTransitionTime': '2019-12-17T05:40:26Z',\n",
+       "    'lastUpdateTime': '2019-12-17T05:40:26Z',\n",
+       "    'message': 'TFJob mnist is created.',\n",
+       "    'reason': 'TFJobCreated',\n",
+       "    'status': 'True',\n",
+       "    'type': 'Created'},\n",
+       "   {'lastTransitionTime': '2019-12-17T05:40:36Z',\n",
+       "    'lastUpdateTime': '2019-12-17T05:40:36Z',\n",
+       "    'message': 'TFJob mnist is running.',\n",
+       "    'reason': 'TFJobRunning',\n",
+       "    'status': 'False',\n",
+       "    'type': 'Running'},\n",
+       "   {'lastTransitionTime': '2019-12-17T05:42:19Z',\n",
+       "    'lastUpdateTime': '2019-12-17T05:42:19Z',\n",
+       "    'message': 'TFJob mnist successfully completed.',\n",
+       "    'reason': 'TFJobSucceeded',\n",
+       "    'status': 'True',\n",
+       "    'type': 'Succeeded'}],\n",
+       "  'replicaStatuses': {'Worker': {'succeeded': 1}},\n",
+       "  'startTime': '2019-12-17T05:40:26Z'}}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tfjob_client.wait_for_job('mnist', namespace=namespace)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check if the TFJob succeeded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tfjob_client.if_job_succeeded('mnist', namespace=namespace)"
    ]
   },
   {
@@ -181,11 +331,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'kind': 'Status',\n",
+       " 'apiVersion': 'v1',\n",
+       " 'metadata': {},\n",
+       " 'status': 'Success',\n",
+       " 'details': {'name': 'mnist',\n",
+       "  'group': 'kubeflow.org',\n",
+       "  'kind': 'tfjobs',\n",
+       "  'uid': 'b9faefd7-208f-11ea-9e34-00000a1001ee'}}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "tfjob_client.delete('mnist')"
+    "tfjob_client.delete('mnist', namespace=namespace)"
    ]
   },
   {
@@ -218,4 +386,3 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
-

--- a/sdk/python/kubeflow/tfjob/api/tf_job_client.py
+++ b/sdk/python/kubeflow/tfjob/api/tf_job_client.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import multiprocessing
+import time
 
 from kubernetes import client, config
 
@@ -77,28 +79,52 @@ class TFJobClient(object):
       namespace = utils.get_default_target_namespace()
 
     if name:
+      thread = self.api_instance.get_namespaced_custom_object(
+        constants.TFJOB_GROUP,
+        constants.TFJOB_VERSION,
+        namespace,
+        constants.TFJOB_PLURAL,
+        name,
+        async_req=True)
+
+      tfjobs = None
       try:
-        return self.api_instance.get_namespaced_custom_object(
-            constants.TFJOB_GROUP,
-            constants.TFJOB_VERSION,
-            namespace,
-            constants.TFJOB_PLURAL,
-            name)
+        tfjobs = thread.get(constants.APISERVER_TIMEOUT)
+      except multiprocessing.TimeoutError:
+        raise RuntimeError("Timeout trying to get TFJob.")
       except client.rest.ApiException as e:
         raise RuntimeError(
           "Exception when calling CustomObjectsApi->get_namespaced_custom_object:\
-            %s\n" % e)
+          %s\n" % e)
+      except Exception as e:
+        raise RuntimeError(
+          "There was a problem to get TFJob {0} in namespace {1}. Exception: \
+          {2} ".format(name, namespace, e))
+
     else:
+      thread = self.api_instance.list_namespaced_custom_object(
+        constants.TFJOB_GROUP,
+        constants.TFJOB_VERSION,
+        namespace,
+        constants.TFJOB_PLURAL,
+        async_req=True)
+
+      tfjobs = None
       try:
-        return self.api_instance.list_namespaced_custom_object(
-          constants.TFJOB_GROUP,
-          constants.TFJOB_VERSION,
-          namespace,
-          constants.TFJOB_PLURAL)
+        tfjobs = thread.get(constants.APISERVER_TIMEOUT)
+      except multiprocessing.TimeoutError:
+        raise RuntimeError("Timeout trying to get TFJob.")
       except client.rest.ApiException as e:
         raise RuntimeError(
           "Exception when calling CustomObjectsApi->list_namespaced_custom_object:\
           %s\n" % e)
+      except Exception as e:
+        raise RuntimeError(
+          "There was a problem to List TFJob in namespace {0}. \
+          Exception: {1} ".format(namespace, e))
+
+    return tfjobs
+
 
   def patch(self, name, tfjob, namespace=None):
     """
@@ -149,3 +175,115 @@ class TFJobClient(object):
       raise RuntimeError(
         "Exception when calling CustomObjectsApi->delete_namespaced_custom_object:\
          %s\n" % e)
+
+
+  def wait_for_job(self, name,
+                   namespace=None,
+                   timeout_seconds=600,
+                   polling_interval=30,
+                   status_callback=None):
+    """Wait for the specified job to finish.
+
+    Args:
+      name: Name of the TfJob.
+      namespace: defaults to current or default namespace.
+      timeout_seconds: How long to wait for the job.
+      polling_interval: How often to poll for the status of the job.
+      status_callback: (Optional): Callable. If supplied this callable is
+        invoked after we poll the job. Callable takes a single argument which
+        is the job.
+    """
+    if namespace is None:
+      namespace = utils.get_default_target_namespace()
+
+    return self.wait_for_condition(
+      name,
+      ["Succeeded", "Failed"],
+      namespace=namespace,
+      timeout_seconds=timeout_seconds,
+      polling_interval=polling_interval,
+      status_callback=status_callback)
+
+
+  def wait_for_condition(self, name,
+                         expected_condition,
+                         namespace=None,
+                         timeout_seconds=600,
+                         polling_interval=30,
+                         status_callback=None):
+    """Waits until any of the specified conditions occur.
+
+    Args:
+      name: Name of the job.
+      expected_condition: A list of conditions. Function waits until any of the
+        supplied conditions is reached.
+      namespace: defaults to current or default namespace.
+      timeout_seconds: How long to wait for the job.
+      polling_interval: How often to poll for the status of the job.
+      status_callback: (Optional): Callable. If supplied this callable is
+        invoked after we poll the job. Callable takes a single argument which
+        is the job.
+    """
+
+    if namespace is None:
+      namespace = utils.get_default_target_namespace()
+
+    for _ in range(round(timeout_seconds/polling_interval)):
+
+      tfjob = None
+      tfjob = self.get(name, namespace=namespace)
+
+      if tfjob:
+        if status_callback:
+          status_callback(tfjob)
+
+        # If we poll the CRD quick enough status won't have been set yet.
+        conditions = tfjob.get("status", {}).get("conditions", [])
+        # Conditions might have a value of None in status.
+        conditions = conditions or []
+        for c in conditions:
+          if c.get("type", "") in expected_condition:
+            return tfjob
+
+      time.sleep(polling_interval)
+
+    raise RuntimeError(
+      "Timeout waiting for TFJob {0} in namespace {1} to enter one of the "
+      "conditions {2}.".format(name, namespace, expected_condition), tfjob)
+
+
+  def get_job_status(self, name, namespace=None):
+    """Returns TFJob status, such as Running, Failed or Succeeded.
+
+    Args:
+      name: The TFJob name.
+      namespace: defaults to current or default namespace.
+    """
+    if namespace is None:
+      namespace = utils.get_default_target_namespace()
+
+    tfjob = self.get(name, namespace=namespace)
+    last_condition = tfjob.get("status", {}).get("conditions", [])[-1]
+    return last_condition.get("type", "")
+
+
+  def if_job_running(self, name, namespace=None):
+    """Returns true if the TFJob running; false otherwise.
+
+    Args:
+      name: The TFJob name.
+      namespace: defaults to current or default namespace.
+    """
+    tfjob_status = self.get_job_status(name, namespace=namespace)
+    return tfjob_status.lower() == "running"
+
+
+  def if_job_succeeded(self, name, namespace=None):
+    """Returns true if the TFJob succeeded; false otherwise.
+
+    Args:
+      name: The TFJob name.
+      namespace: defaults to current or default namespace.
+    """
+    tfjob_status = self.get_job_status(name, namespace=namespace)
+    return tfjob_status.lower() == "succeeded"

--- a/sdk/python/kubeflow/tfjob/constants/constants.py
+++ b/sdk/python/kubeflow/tfjob/constants/constants.py
@@ -15,9 +15,12 @@
 import os
 
 # TFJob K8S constants
-TFJOB_GROUP = "kubeflow.org"
-TFJOB_KIND = "TFJob"
-TFJOB_PLURAL = "tfjobs"
-TFJOB_VERSION = "v1"
+TFJOB_GROUP = 'kubeflow.org'
+TFJOB_KIND = 'TFJob'
+TFJOB_PLURAL = 'tfjobs'
+TFJOB_VERSION = os.environ.get('TFJOB_VERSION', 'v1')
 
 TFJOB_LOGLEVEL = os.environ.get('TFJOB_LOGLEVEL', 'INFO').upper()
+
+# How long to wait in seconds for requests to the ApiServer
+APISERVER_TIMEOUT = 120

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
   name='kubeflow-tfjob',
-  version='0.1',
+  version='0.1.1',
   author="Kubeflow Authors",
   author_email='hejinchi@cn.ibm.com',
   license="Apache License Version 2.0",


### PR DESCRIPTION
From feedback of the `kubeflow-tfjob` SDK, add more APIs (some of them are ehanced from `py/kubeflow/tf_operator/tf_job_client.py`):

- `wait_for_job`: Wait for the specified job to finish 
- `wait_for_condition`: Waits until any of the specified conditions occur
- `get_job_status`: Quick way to get the TFJob status
- `if_job_running`: Quick way to check if the TFJob running
- `if_job_succeeded`:  Quick way to check if the TFJob Succeeded

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1116)
<!-- Reviewable:end -->
