### PR TITLE
Update checking status API name

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -42,8 +42,8 @@ Class | Method | Description
 [TFJobClient](docs/TFJobClient.md)  | [wait_for_job](docs/TFJobClient.md#wait_for_job) | Wait for the specified job to finish |
 [TFJobClient](docs/TFJobClient.md)  | [wait_for_condition](docs/TFJobClient.md#wait_for_condition) | Waits until any of the specified conditions occur |
 [TFJobClient](docs/TFJobClient.md)  | [get_job_status](docs/TFJobClient.md#get_job_status) | Get the TFJob status|
-[TFJobClient](docs/TFJobClient.md)  | [if_job_running](docs/TFJobClient.md#if_job_running) | Check if the TFJob running |
-[TFJobClient](docs/TFJobClient.md)  | [if_job_succeeded](docs/TFJobClient.md#if_job_succeeded) | Check if the TFJob Succeeded |
+[TFJobClient](docs/TFJobClient.md)  | [is_job_running](docs/TFJobClient.md#is_job_running) | Check if the TFJob status is Running |
+[TFJobClient](docs/TFJobClient.md)  | [is_job_succeeded](docs/TFJobClient.md#is_job_succeeded) | Check if the TFJob status is Succeeded |
 
 ## Documentation For Models
 

--- a/sdk/python/docs/TFJobClient.md
+++ b/sdk/python/docs/TFJobClient.md
@@ -23,8 +23,8 @@ TFJobClient | [delete](#delete) | Delete the specified TFJob |
 TFJobClient | [wait_for_job](#wait_for_job) | Wait for the specified job to finish |
 TFJobClient | [wait_for_condition](#wait_for_condition) | Waits until any of the specified conditions occur |
 TFJobClient | [get_job_status](#get_job_status) | Get the TFJob status|
-TFJobClient | [if_job_running](#if_job_running) | Check if the TFJob running |
-TFJobClient | [if_job_succeeded](#if_job_succeeded) | Check if the TFJob Succeeded |s
+TFJobClient | [is_job_running](#is_job_running) | Check if the TFJob status is running |
+TFJobClient | [is_job_succeeded](#is_job_succeeded) | Check if the TFJob status is Succeeded |
 
 ## create
 > create(tfjob, namespace=None)
@@ -262,8 +262,8 @@ namespace | str | The tfjob's namespace. Defaults to current or default namespac
 ### Return type
 Str
 
-## if_job_running
-> if_job_running(name, namespace=None)
+## is_job_running
+> is_job_running(name, namespace=None)
 
 Returns True if the TFJob running; false otherwise.
 
@@ -273,7 +273,7 @@ Returns True if the TFJob running; false otherwise.
 from kubeflow.tfjob import TFJobClient
 
 tfjob_client = TFJobClient()
-tfjob_client.if_job_running('mnist', namespace='kubeflow')
+tfjob_client.is_job_running('mnist', namespace='kubeflow')
 ```
 
 ### Parameters
@@ -285,8 +285,8 @@ namespace | str | The tfjob's namespace. Defaults to current or default namespac
 ### Return type
 Bool
 
-## if_job_succeeded
-> if_job_succeeded(name, namespace=None)
+## is_job_succeeded
+> is_job_succeeded(name, namespace=None)
 
 Returns True if the TFJob succeeded; false otherwise.
 
@@ -296,7 +296,7 @@ Returns True if the TFJob succeeded; false otherwise.
 from kubeflow.tfjob import TFJobClient
 
 tfjob_client = TFJobClient()
-tfjob_client.if_job_succeeded('mnist', namespace='kubeflow')
+tfjob_client.is_job_succeeded('mnist', namespace='kubeflow')
 ```
 
 ### Parameters

--- a/sdk/python/examples/kubeflow-tfjob-sdk.ipynb
+++ b/sdk/python/examples/kubeflow-tfjob-sdk.ipynb
@@ -319,7 +319,7 @@
     }
    ],
    "source": [
-    "tfjob_client.if_job_succeeded('mnist', namespace=namespace)"
+    "tfjob_client.is_job_succeeded('mnist', namespace=namespace)"
    ]
   },
   {

--- a/sdk/python/kubeflow/tfjob/api/tf_job_client.py
+++ b/sdk/python/kubeflow/tfjob/api/tf_job_client.py
@@ -267,7 +267,7 @@ class TFJobClient(object):
     return last_condition.get("type", "")
 
 
-  def if_job_running(self, name, namespace=None):
+  def is_job_running(self, name, namespace=None):
     """Returns true if the TFJob running; false otherwise.
 
     Args:
@@ -278,7 +278,7 @@ class TFJobClient(object):
     return tfjob_status.lower() == "running"
 
 
-  def if_job_succeeded(self, name, namespace=None):
+  def is_job_succeeded(self, name, namespace=None):
     """Returns true if the TFJob succeeded; false otherwise.
 
     Args:

--- a/sdk/python/test/test_e2e.py
+++ b/sdk/python/test/test_e2e.py
@@ -64,7 +64,7 @@ def test_sdk_e2e():
   TFJOB_CLIENT.create(tfjob, namespace=SDK_TEST_NAMESPACE)
 
   TFJOB_CLIENT.wait_for_job("mnist-ci-test", namespace=SDK_TEST_NAMESPACE)
-  if not TFJOB_CLIENT.if_job_succeeded("mnist-ci-test", namespace=SDK_TEST_NAMESPACE):
+  if not TFJOB_CLIENT.is_job_succeeded("mnist-ci-test", namespace=SDK_TEST_NAMESPACE):
     raise RuntimeError("The TFJob is not succeeded.")
 
   TFJOB_CLIENT.delete("mnist-ci-test", namespace=SDK_TEST_NAMESPACE)


### PR DESCRIPTION
As @johnugeorge commented in https://github.com/kubeflow/pytorch-operator/pull/240, the PR is update the API name as well for tfjob python client. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1117)
<!-- Reviewable:end -->
