### PR TITLE
fix(controller): calculate satisfied with && instead of ||

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -491,7 +491,7 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1.TFJob) error {
 // Add/del counts are established by the controller at sync time, and updated as controllees are observed by the controller
 // manager.
 func (tc *TFController) satisfiedExpectations(tfjob *tfv1.TFJob) bool {
-	satisfied := false
+	satisfied := true
 	tfjobKey, err := KeyFunc(tfjob)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for tfjob object %#v: %v", tfjob, err))
@@ -501,11 +501,11 @@ func (tc *TFController) satisfiedExpectations(tfjob *tfv1.TFJob) bool {
 	for rtype := range tfjob.Spec.TFReplicaSpecs {
 		// Check the expectations of the pods.
 		expectationPodsKey := jobcontroller.GenExpectationPodsKey(tfjobKey, string(rtype))
-		satisfied = satisfied || tc.Expectations.SatisfiedExpectations(expectationPodsKey)
+		satisfied = satisfied && tc.Expectations.SatisfiedExpectations(expectationPodsKey)
 
 		// Check the expectations of the services.
 		expectationServicesKey := jobcontroller.GenExpectationServicesKey(tfjobKey, string(rtype))
-		satisfied = satisfied || tc.Expectations.SatisfiedExpectations(expectationServicesKey)
+		satisfied = satisfied && tc.Expectations.SatisfiedExpectations(expectationServicesKey)
 	}
 
 	return satisfied


### PR DESCRIPTION
If calculating satisfied with '||',  it only guarantee some replicaTypes not all replicaTypes are satisfied. There will be some problems. So it should be changed to '&&'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1120)
<!-- Reviewable:end -->
