### PR TITLE
Comment lines in tf_operator/Dockerfile

### DIFF
--- a/build/images/tf_operator/Dockerfile
+++ b/build/images/tf_operator/Dockerfile
@@ -11,8 +11,8 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 # TODO(jlewi): We should probably change the directory to /opt/kubeflow.
 RUN mkdir -p /opt/kubeflow/samples
 
-COPY tf_smoke.py /opt/kubeflow/samples/
-RUN chmod a+x /opt/kubeflow/samples/*
+#COPY tf_smoke.py /opt/kubeflow/samples/
+#RUN chmod a+x /opt/kubeflow/samples/*
 
 COPY --from=build-image /go/src/github.com/kubeflow/tf-operator/tf-operator.v1 /opt/kubeflow
 


### PR DESCRIPTION
- Build on power fails with the below error : 
```
Step 7/11 : COPY tf_smoke.py /opt/kubeflow/samples/
COPY failed: stat /var/lib/docker/tmp/docker-builder306018796/tf_smoke.py: no such file or directory
```
- Command used : 
`docker build -f build/images/tf_operator/Dockerfile .`

- The build is successful after commenting out the below lines in build/images/tf_operator/Dockerfile
```
COPY tf_smoke.py /opt/kubeflow/samples/
RUN chmod a+x /opt/kubeflow/samples/*
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1123)
<!-- Reviewable:end -->
