### PR TITLE
support tfjob on exit handler

### DIFF
--- a/examples/v1/dist-mnist/tf_job_mnist_with_exithandler.yaml
+++ b/examples/v1/dist-mnist/tf_job_mnist_with_exithandler.yaml
@@ -1,0 +1,30 @@
+apiVersion: "kubeflow.org/v1"
+kind: "TFJob"
+metadata:
+  name: "dist-mnist-with-exithandler-for-e2e-test"
+spec:
+  tfReplicaSpecs:
+    PS:
+      replicas: 2
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: tensorflow
+              image: kubeflow/tf-dist-mnist-test:1.0
+    Worker:
+      replicas: 4
+      restartPolicy: Never
+      template:
+        spec:
+          containers:
+            - name: tensorflow
+              image: kubeflow/tf-dist-mnist-test:1.0
+  onExit:
+    spec:
+      containers:
+        - name: exit-handler
+          image: busybox:latest
+          command: [sh, -c]
+          # $TFJOB_RESULT: Succeeded or Failed
+          args: ["echo $TFJOB_RESULT && echo $TFJOB_START_TIME && echo $TFJOB_COMPLETION_TIME && sleep 10"]

--- a/pkg/apis/tensorflow/v1/types.go
+++ b/pkg/apis/tensorflow/v1/types.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	common "github.com/kubeflow/common/job_controller/api/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -69,6 +70,9 @@ type TFJobSpec struct {
 	//     "Worker": ReplicaSpec,
 	//   }
 	TFReplicaSpecs map[TFReplicaType]*common.ReplicaSpec `json:"tfReplicaSpecs"`
+
+	// at the end of the tensorflow training, OnExit always executes irrespective of success or failure
+	OnExit *v1.PodTemplateSpec  `json:"onExit,omitempty"`
 }
 
 // TFReplicaType is the type for TFReplica. Can be one of: "Chief"/"Master" (semantically equivalent),

--- a/pkg/common/jobcontroller/pod.go
+++ b/pkg/common/jobcontroller/pod.go
@@ -2,6 +2,7 @@ package jobcontroller
 
 import (
 	"fmt"
+	common "github.com/kubeflow/common/job_controller/api/v1"
 	"reflect"
 	"strconv"
 
@@ -216,6 +217,26 @@ func (jc *JobController) FilterPodsForReplicaType(pods []*v1.Pod, replicaType st
 		result = append(result, pod)
 	}
 	return result, nil
+}
+
+func (jc *JobController) FilterPodsForOnExit(pods []*v1.Pod) (*v1.Pod, error) {
+	onExitSelector := &metav1.LabelSelector{
+		MatchLabels: make(map[string]string),
+	}
+
+	onExitSelector.MatchLabels[common.JobRoleLabel] = "onexit"
+	for _, pod := range pods {
+		selector, err := metav1.LabelSelectorAsSelector(onExitSelector)
+		if err != nil {
+			return nil, err
+		}
+		if !selector.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+		return pod, nil
+	}
+
+	return nil, nil
 }
 
 // getPodSlices returns a slice, which element is the slice of pod.

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -160,7 +160,7 @@ func (tc *TFController) deletePodsAndServices(tfJob *tfv1.TFJob, pods []*v1.Pod)
 	}
 
 	for _, pod := range pods {
-		if *tfJob.Spec.CleanPodPolicy == common.CleanPodPolicyRunning && pod.Status.Phase != v1.PodRunning {
+		if pod.Labels[common.JobRoleLabel] != "onexit" && *tfJob.Spec.CleanPodPolicy == common.CleanPodPolicyRunning && pod.Status.Phase != v1.PodRunning {
 			continue
 		}
 		if err := tc.PodControl.DeletePod(pod.Namespace, pod.Name, tfJob); err != nil {

--- a/vendor/github.com/kubeflow/common/job_controller/api/v1/types.go
+++ b/vendor/github.com/kubeflow/common/job_controller/api/v1/types.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // JobStatus represents the current observed state of the training Job.
 type JobStatus struct {
@@ -27,6 +28,9 @@ type JobStatus struct {
 	// ReplicaStatuses is map of ReplicaType and ReplicaStatus,
 	// specifies the status of each replica.
 	ReplicaStatuses map[ReplicaType]*ReplicaStatus `json:"replicaStatuses"`
+
+	// OnExitStatus is tfjob on exit handler status
+	OnExitStatus *OnExitStatus `json:"OnExitStatus"`
 
 	// Represents time when the job was acknowledged by the job controller.
 	// It is not guaranteed to be set in happens-before order across separate operations.
@@ -44,10 +48,19 @@ type JobStatus struct {
 	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`
 }
 
+type OnExitStatus string
+
+const (
+	OnExitRunning OnExitStatus = "Running"
+	OnExitCompleted OnExitStatus = "Completed"
+)
+
+// +k8s:openapi-gen=true
 // ReplicaType represents the type of the replica. Each operator needs to define its
 // own set of ReplicaTypes.
 type ReplicaType string
 
+// +k8s:openapi-gen=true
 // ReplicaStatus represents the current observed state of the replica.
 type ReplicaStatus struct {
 	// The number of actively running pods.
@@ -60,6 +73,7 @@ type ReplicaStatus struct {
 	Failed int32 `json:"failed,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // ReplicaSpec is a description of the replica
 type ReplicaSpec struct {
@@ -78,6 +92,7 @@ type ReplicaSpec struct {
 	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 }
 
+// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=true
 // JobCondition describes the state of the job at a certain point.
 type JobCondition struct {
@@ -124,8 +139,16 @@ const (
 	// reached phase failed with no restarting.
 	// The training has failed its execution.
 	JobFailed JobConditionType = "Failed"
+
+
+	// OnExitRunning means tfjob ps/worker pods finish, on exit handler is running
+	JobOnExitRunning JobConditionType = "OnExitRunning"
+
+	// JobOnExitCompleted means on exit handler completed
+	JobOnExitCompleted JobConditionType = "OnExitCompleted"
 )
 
+// +k8s:openapi-gen=true
 // CleanPodPolicy describes how to deal with pods when the job is finished.
 type CleanPodPolicy string
 


### PR DESCRIPTION
sometimes, we need tfjob exit handler to do something once the training completed(succeeded or failed). such as sending an email to users to notify them the training result. it can be done simply specify an exit handler like this:

```
apiVersion: "kubeflow.org/v1"
kind: "TFJob"
metadata:
  name: "dist-mnist-with-exithandler-for-e2e-test"
spec:
  tfReplicaSpecs:
    PS:
      replicas: 2
      restartPolicy: Never
      template:
        spec:
          containers:
            - name: tensorflow
              image: kubeflow/tf-dist-mnist-test:1.0
    Worker:
      replicas: 4
      restartPolicy: Never
      template:
        spec:
          containers:
            - name: tensorflow
              image: kubeflow/tf-dist-mnist-test:1.0
  onExit:
    spec:
      containers:
        - name: exit-handler
          image: busybox:latest
          command: [sh, -c]
          # $TFJOB_RESULT: Succeeded or Failed
          args: ["echo $TFJOB_RESULT && echo $TFJOB_START_TIME && echo $TFJOB_COMPLETION_TIME && echo send a email & sleep 10"]
```

we can use following environent variables to get information about tfjob:

 - $TFJOB_RESULT: Succeeded or Failed
 - $TFJOB_START_TIME: tfjob start time
 - $TFJOB_COMPLETION_TIME: tfjob completion time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1125)
<!-- Reviewable:end -->
