### PR TITLE
Fix sdk test issue that's caused by kubenertes Client bug.

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -3,5 +3,5 @@ six>=1.10
 python_dateutil>=2.5.3
 setuptools>=21.0.0
 urllib3>=1.15.1
-kubernetes>=10.0.1
+kubernetes==10.0.1
 table_logger>=0.3.5

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
   name='kubeflow-tfjob',
-  version='0.1.3',
+  version='0.1.4',
   author="Kubeflow Authors",
   author_email='hejinchi@cn.ibm.com',
   license="Apache License Version 2.0",


### PR DESCRIPTION
The PR is going to debug and fix the SDK CI tests problem below.
```
           obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
>                       for attr, _ in six.iteritems(obj.openapi_types)
                       if getattr(obj, attr) is not None}
E           AttributeError: 'V1TFJob' object has no attribute 'openapi_types'
/usr/local/lib/python3.5/dist-packages/kubernetes/client/api_client.py:230: AttributeError
```
This is caused by kubernetes Client bug: https://github.com/kubernetes-client/python/issues/1112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1143)
<!-- Reviewable:end -->
