### PR TITLE
Disable istio sidecar injection in simple tfjob test

### DIFF
--- a/test/workflows/components/simple_tfjob_v1.jsonnet
+++ b/test/workflows/components/simple_tfjob_v1.jsonnet
@@ -22,7 +22,7 @@ local parts(namespace, name, image) = {
           template: {
             metadata: {
               annotations: {
-                "sidecar.istio.io/inject": "false"
+                "sidecar.istio.io/inject": "false",
               },
             },
             spec: {
@@ -41,7 +41,7 @@ local parts(namespace, name, image) = {
           template: {
             metadata: {
               annotations: {
-                "sidecar.istio.io/inject": "false"
+                "sidecar.istio.io/inject": "false",
               },
             },
             spec: {
@@ -60,7 +60,7 @@ local parts(namespace, name, image) = {
           template: {
             metadata: {
               annotations: {
-                "sidecar.istio.io/inject": "false"
+                "sidecar.istio.io/inject": "false",
               },
             },
             spec: {

--- a/test/workflows/components/simple_tfjob_v1.jsonnet
+++ b/test/workflows/components/simple_tfjob_v1.jsonnet
@@ -20,6 +20,11 @@ local parts(namespace, name, image) = {
           replicas: 1,
           restartPolicy: "Never",
           template: {
+            metadata: {
+              annotations: {
+                "sidecar.istio.io/inject": "false"
+              },
+            },
             spec: {
               containers: [
                 {
@@ -34,6 +39,11 @@ local parts(namespace, name, image) = {
           replicas: 2,
           restartPolicy: "Never",
           template: {
+            metadata: {
+              annotations: {
+                "sidecar.istio.io/inject": "false"
+              },
+            },
             spec: {
               containers: [
                 {
@@ -48,6 +58,11 @@ local parts(namespace, name, image) = {
           replicas: 4,
           restartPolicy: "Never",
           template: {
+            metadata: {
+              annotations: {
+                "sidecar.istio.io/inject": "false"
+              },
+            },
             spec: {
               containers: [
                 {


### PR DESCRIPTION
Unblocks https://github.com/kubeflow/kfctl/pull/131, because kfctl uses tf-operator head for presubmit test.
After enabling istio sidecar injection in `kubeflow` namespace, tfjob-smoke-test is the only test timing out.

I haven't been able to look at pod log/info because there were permission issues, but I've found other people mentioning tfjob cannot work with istio sidecar: https://github.com/kubeflow/kubeflow/issues/3935

/cc @jlewi 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/tf-operator/1148)
<!-- Reviewable:end -->
