### PR TITLE
Set completion time when job exceed specified deadline.

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -425,6 +425,12 @@ func (tc *TFController) reconcileTFJobs(tfjob *tfv1.TFJob) error {
 	}
 
 	if tfJobExceedsLimit {
+		// Set job completion time if it has not set yet.
+		if tfjob.Status.CompletionTime == nil {
+			now := metav1.Now()
+			tfjob.Status.CompletionTime = &now
+		}
+
 		// If the TFJob exceeds backoff limit or is past active deadline
 		// delete all pods and services, then set the status to failed
 		if err := tc.deletePodsAndServices(tfjob, pods); err != nil {


### PR DESCRIPTION
If job stays in `Created` and all its controlled pods waits in `Pending` state, util it exceed its ActiveDeadline(if `job.spec.ActiveDeadlineSeconds` has been set), this job will be reconciled as past active deadline and be cleaned up, however, `job.status.completionTime` remains a nil pointer, and it will absolutely panic in `JobController.cleanupJob` func.