### PR TITLE
Make tf_operator use static compilation in container

### DIFF
--- a/build/images/tf_operator/Dockerfile
+++ b/build/images/tf_operator/Dockerfile
@@ -4,7 +4,11 @@ ADD . /go/src/github.com/kubeflow/tf-operator
 
 WORKDIR /go/src/github.com/kubeflow/tf-operator
 
-RUN go build -o tf-operator.v1 ./cmd/tf-operator.v1
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o tf-operator.v1 ./cmd/tf-operator.v1; \
+    else \
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o tf-operator.v1 ./cmd/tf-operator.v1; \
+    fi
 
 FROM gcr.io/distroless/base-debian10
 


### PR DESCRIPTION
As tf_operator uses distroless image as base image now, running container image after `docker build` on arm64 will lead to error:
`standard_init_linux.go:211: exec user process caused "no such file or directory"`.
Using static compilation will fix this error.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>