### PR TITLE
Update swagger-codegen-cli URL

### DIFF
--- a/hack/python-sdk/gen-sdk.sh
+++ b/hack/python-sdk/gen-sdk.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SWAGGER_JAR_URL="http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar"
+SWAGGER_JAR_URL="http://search.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar"
 SWAGGER_CODEGEN_JAR="hack/python-sdk/swagger-codegen-cli.jar"
 SWAGGER_CODEGEN_CONF="hack/python-sdk/swagger_config.json"
 SWAGGER_CODEGEN_FILE="pkg/apis/tensorflow/v1/swagger.json"


### PR DESCRIPTION
fixes: #1166 

```
[root@jinchi1 ~]# wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar
--2020-06-14 19:39:27--  http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar
Resolving central.maven.org (central.maven.org)... failed: Name or service not known.
wget: unable to resolve host address 'central.maven.org'

[root@jinchi1 ~]# wget http://search.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar
--2020-06-14 20:03:53--  http://search.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.6/swagger-codegen-cli-2.4.6.jar
Resolving search.maven.org (search.maven.org)... 18.234.11.249, 3.227.158.232
Connecting to search.maven.org (search.maven.org)|18.234.11.249|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 14670887 (14M) [application/java-archive]
Saving to: 'swagger-codegen-cli-2.4.6.jar.1'

100%[=====================================================================================================>] 14,670,887  3.28MB/s   in 9.1s

2020-06-14 20:04:03 (1.53 MB/s) - 'swagger-codegen-cli-2.4.6.jar.1' saved [14670887/14670887]
```