### PR TITLE
Fix setup cluster issue and Pylint issue in CI tests

### DIFF
--- a/examples/v1/distribution_strategy/keras-API/multi_worker_strategy-with-keras.py
+++ b/examples/v1/distribution_strategy/keras-API/multi_worker_strategy-with-keras.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubeflow Authors. All Rights Reserved.
+# Copyright 2020 The Kubeflow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import argparse
 import json
 import os
 
-import tensorflow as tf
 import tensorflow_datasets as tfds
-from tensorflow.keras import datasets, layers, models
+import tensorflow as tf
+from tensorflow.keras import layers, models
 
 
 def make_datasets_unbatched():
@@ -34,7 +34,7 @@ def make_datasets_unbatched():
     image /= 255
     return image, label
 
-  datasets, info = tfds.load(name='mnist', with_info=True, as_supervised=True)
+  datasets, _ = tfds.load(name='mnist', with_info=True, as_supervised=True)
 
   return datasets['train'].map(scale).cache().shuffle(BUFFER_SIZE)
 
@@ -61,7 +61,7 @@ def build_and_compile_cnn_model():
 
 
 def decay(epoch):
-  if epoch < 3:
+  if epoch < 3: #pylint: disable=no-else-return
     return 1e-3
   elif epoch >= 3 and epoch < 7:
     return 1e-4
@@ -100,7 +100,7 @@ def main(args):
   # Callback for printing the LR at the end of each epoch.
   class PrintLR(tf.keras.callbacks.Callback):
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_epoch_end(self, epoch): #pylint: disable=no-self-use
       print('\nLearning rate for epoch {} is {}'.format(
         epoch + 1, multi_worker_model.optimizer.lr.numpy()))
 
@@ -125,7 +125,7 @@ def main(args):
   # current task type and returns True if the worker is the chief and False
   # otherwise.
   def is_chief():
-    return (TASK_INDEX == 0)
+    return TASK_INDEX == 0
 
   if is_chief():
     model_path = args.saved_model_dir
@@ -157,5 +157,5 @@ if __name__ == '__main__':
                       required=True,
                       help='Tensorflow checkpoint directory.')
 
-  args = parser.parse_args()
-  main(args)
+  parsed_args = parser.parse_args()
+  main(parsed_args)

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -24,6 +24,7 @@ workflows:
     - test/*
     - vendor/*
     - sdk/*
+    - examples/*
     params:
       registry: "gcr.io/kubeflow-ci"
       tfJobVersion: v1

--- a/py/kubeflow/tf_operator/deploy.py
+++ b/py/kubeflow/tf_operator/deploy.py
@@ -112,12 +112,14 @@ def setup_cluster(args):
   cluster_name = args.cluster
   zone = args.zone
   machine_type = "n1-standard-8"
+  cluster_version = "1.14.10-gke.42"
 
   cluster_request = {
     "cluster": {
       "name": cluster_name,
       "description": "A GKE cluster for TF.",
       "initialNodeCount": 1,
+      "initialClusterVersion": cluster_version,
       "nodeConfig": {
         "machineType": machine_type,
         "oauthScopes": [


### PR DESCRIPTION
The PR is going to fix below two problems:

1. `No Major.Minor.Patch elements found` in set up kubeflow steps of CI tests.

```
INFO:root:Using ksonnet cmd: ks-13
INFO:root:Running: ks-13 env add e2e-0806-0218-abe0
cwd=/mnt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1171-232e11d-7216-b6d9/src/kubeflow/tf-operator/test/test-app
INFO:root:Subprocess output:
INFO:root:level=info msg="Using context \"gke_kubeflow-ci_us-east1-d_ztor-presubmit-v1-1171-232e11d-7216-b6d9\" from kubeconfig file \"/m
nt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1171-232e11d-7216-b6d9/.kube/kubeconfig\""
INFO:root:level=info msg="Creating environment \"e2e-0806-0218-abe0\" with namespace \"default\", pointing to \"version:v1.15.12\" cluste
r at address \"https://35.185.20.182\""
INFO:root:level=error msg="No Major.Minor.Patch elements found"
```

2. Pylint issue below in CI tests:

```
INFO|2020-06-27T11:31:33|util.py:46| Running: pylint --rcfile=/mnt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1178-567bfcd-0578-359b/src/kubeflow/tf-operator/.pylintrc /mnt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1178-567bfcd-0578-359b/src/kubeflow/tf-operator/examples/v1/distribution_strategy/keras-API/multi_worker_strategy-with-keras.py 
cwd=/mnt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1178-567bfcd-0578-359b/src/kubeflow/tf-operator
INFO|2020-06-27T11:31:33|util.py:61| Subprocess output:

INFO|2020-06-27T11:31:33|util.py:72| Using config file /mnt/test-data-volume/kubeflow-tf-operator-presubmit-v1-1178-567bfcd-0578-359b/src/kubeflow/tf-operator/.pylintrc
INFO|2020-06-27T11:31:35|util.py:72| ************* Module multi_worker_strategy-with-keras
INFO|2020-06-27T11:31:35|util.py:72| C:128, 0: Unnecessary parens after 'return' keyword (superfluous-parens)
INFO|2020-06-27T11:31:35|util.py:72| W: 37, 2: Redefining name 'datasets' from outer scope (line 25) (redefined-outer-name)
INFO|2020-06-27T11:31:35|util.py:72| W: 37,12: Unused variable 'info' (unused-variable)
INFO|2020-06-27T11:31:35|util.py:72| R: 64, 2: Unnecessary "else" after "return" (no-else-return)
INFO|2020-06-27T11:31:35|util.py:72| W: 72, 9: Redefining name 'args' from outer scope (line 160) (redefined-outer-name)
INFO|2020-06-27T11:31:35|util.py:72| W:103,34: Unused argument 'logs' (unused-argument)
INFO|2020-06-27T11:31:35|util.py:72| R:103, 4: Method could be a function (no-self-use)
INFO|2020-06-27T11:31:35|util.py:72| W: 25, 0: Unused datasets imported from tensorflow.keras (unused-import)
INFO|2020-06-27T11:31:35|util.py:72| C: 25, 0: Imports from package tensorflow are not grouped (ungrouped-imports)
INFO|2020-06-27T11:31:35|util.py:72| 
INFO|2020-06-27T11:31:35|util.py:72| -----------------------------------
INFO|2020-06-27T11:31:35|util.py:72| Your code has been rated at 8.66/10
```