### PR TITLE
bugfix for multi_worker_strategy-with-keras.py

### DIFF
--- a/examples/v1/distribution_strategy/keras-API/multi_worker_strategy-with-keras.py
+++ b/examples/v1/distribution_strategy/keras-API/multi_worker_strategy-with-keras.py
@@ -99,7 +99,7 @@ def main(args):
   # Callback for printing the LR at the end of each epoch.
   class PrintLR(tf.keras.callbacks.Callback):
 
-    def on_epoch_end(self, epoch): #pylint: disable=no-self-use
+    def on_epoch_end(self, epoch, logs=None): #pylint: disable=no-self-use
       print('\nLearning rate for epoch {} is {}'.format(
         epoch + 1, multi_worker_model.optimizer.lr.numpy()))
 


### PR DESCRIPTION
Bugfix: `TypeError: on_epoch_end() takes 2 positional arguments but 3 were given` will be occured when run this demo in TF2.x
You can see the details at  
https://github.com/tensorflow/tensorflow/blob/9697081dac25ef5c3e95b98b6e1113261611a4b9/tensorflow/python/keras/callbacks.py#L414