### PR TITLE
Move TF Operator e2e tests to AWS Prow

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tfjobs.kubeflow.org
+spec:
+  group: kubeflow.org
+  scope: Namespaced
+  names:
+    kind: TFJob
+    singular: tfjob
+    plural: tfjobs
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            tfReplicaSpecs:
+              properties:
+                # The validation works when the configuration contains
+                # `Worker`, `PS` , `Chief` or `Evaluator`. Otherwise it will not be validated.
+                Worker:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                PS:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                Chief:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 1
+                Evaluator:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 0

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tf-job-operator
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: tf-job-operator
+  template:
+    metadata:
+      labels:
+        name: tf-job-operator
+    spec:
+      containers:
+      - args:
+        - --monitoring-port=8443
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: gcr.io/kubeflow-images-public/tf-operator:v0.6.0
+        name: tf-job-operator
+      serviceAccountName: tf-job-operator

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- crd.yaml
+- namespace.yaml
+- rbac.yaml
+- deployment.yaml
+- service.yaml
+commonLabels:
+  kustomize.component: tf-job-operator
+images:
+- name: gcr.io/kubeflow-images-public/tf-operator
+  newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
+  newTag: "0.1"

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow

--- a/manifests/podgroup.yaml
+++ b/manifests/podgroup.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: podgroups.scheduling.incubator.k8s.io
+spec:
+  group: scheduling.incubator.k8s.io
+  names:
+    kind: PodGroup
+    plural: podgroups
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            minMember:
+              format: int32
+              type: integer
+          type: object
+        status:
+          properties:
+            succeeded:
+              format: int32
+              type: integer
+            failed:
+              format: int32
+              type: integer
+            running:
+              format: int32
+              type: integer
+          type: object
+      type: object
+  version: v1alpha1

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  - tfjobs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tf-job-operator
+subjects:
+- kind: ServiceAccount
+  name: tf-job-operator
+  namespace: kubeflow
+---

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8443"
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow
+spec:
+  ports:
+  - name: monitoring-port
+    port: 8443
+    targetPort: 8443
+  selector:
+    name: tf-job-operator
+  type: ClusterIP

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -114,8 +114,6 @@ func (tc *TFController) addTFJob(obj interface{}) {
 	logger.Info(msg)
 
 	// Add a created condition.
-	//[Jack]
-	// err = updateTFJobConditions(tfJob, common.JobCreated, tfJobCreatedReason, msg)
 	err = commonutil.UpdateJobConditions(&tfJob.Status, commonv1.JobCreated, tfJobCreatedReason, msg)
 	if err != nil {
 		logger.Errorf("Append tfJob condition error: %v", err)

--- a/py/kubeflow/tf_operator/cleanpod_policy_tests.py
+++ b/py/kubeflow/tf_operator/cleanpod_policy_tests.py
@@ -3,6 +3,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import k8s_util, test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 CLEANPOD_ALL_COMPONENT_NAME = "clean_pod_all"
@@ -23,11 +24,12 @@ class CleanPodPolicyTests(test_util.TestCase):
       class_name="CleanPodPolicyTests", name=name)
 
   def run_tfjob_with_cleanpod_policy(self, component, clean_pod_policy):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
     ks_cmd = ks_util.get_ksonnet_cmd(self.app_dir)
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/deploy.py
+++ b/py/kubeflow/tf_operator/deploy.py
@@ -90,7 +90,7 @@ def ks_deploy(app_dir, component, params, env=None, account=None):
     if not re.search(".*environment.*already exists.*", e.output):
       raise
 
-  for k, v in params.iteritems():
+  for k, v in params.items():
     util.run([ks_cmd, "param", "set", "--env=" + env, component, k, v],
              cwd=app_dir)
 

--- a/py/kubeflow/tf_operator/distributed_training_tests.py
+++ b/py/kubeflow/tf_operator/distributed_training_tests.py
@@ -3,6 +3,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 TFJOB_COMPONENT_NAME = "distributed_training"
@@ -23,10 +24,11 @@ class DistributedTrainingJobTests(test_util.TestCase):
   # Run a distributed training TFJob, wait for it to complete, and check for pod/service
   # creation errors.
   def run_distributed_training_job(self, component):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/estimator_runconfig_tests.py
+++ b/py/kubeflow/tf_operator/estimator_runconfig_tests.py
@@ -115,12 +115,13 @@ class EstimatorRunconfigTests(test_util.TestCase):
 
   # Run a TFJob, verify that the TensorFlow runconfig specs are set correctly.
   def test_tfjob_and_verify_runconfig(self):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
     masterHost = api_client.configuration.host
     component = COMPONENT_NAME + "_" + self.tfjob_version
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/invalid_tfjob_tests.py
+++ b/py/kubeflow/tf_operator/invalid_tfjob_tests.py
@@ -4,6 +4,7 @@ import re
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 INVALID_TFJOB_COMPONENT_NAME = "invalid_tfjob"
@@ -22,11 +23,12 @@ class InvalidTfJobTests(test_util.TestCase):
       class_name="InvalidTfJobTests", name=name)
 
   def test_invalid_tfjob_spec(self):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
     component = INVALID_TFJOB_COMPONENT_NAME + "_" + self.tfjob_version
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/pod_names_validation_tests.py
+++ b/py/kubeflow/tf_operator/pod_names_validation_tests.py
@@ -7,6 +7,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 COMPONENT_NAME = "pod_names_validation"
@@ -22,7 +23,7 @@ def extract_job_specs(replica_specs):
   """
   specs = dict()
   for job_type in replica_specs:
-    specs[job_type.encode("ascii").lower()] = int(
+    specs[job_type.lower()] = int(
       replica_specs.get(job_type, {}).get("replicas", 0))
   return specs
 
@@ -44,10 +45,11 @@ class PodNamesValidationTest(test_util.TestCase):
       class_name="PodNamesValidationTest", name=name)
 
   def test_pod_names(self):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
     component = COMPONENT_NAME + "_" + self.tfjob_version
     ks_cmd = ks_util.get_ksonnet_cmd(self.app_dir)
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
     util.run([ks_cmd, "apply", self.env, "-c", component], cwd=self.app_dir)
     logging.info("Created job %s in namespaces %s", self.name, self.namespace)

--- a/py/kubeflow/tf_operator/replica_restart_policy_tests.py
+++ b/py/kubeflow/tf_operator/replica_restart_policy_tests.py
@@ -3,6 +3,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 REPLICA_RESTART_POLICY_ALWAYS_COMPONENT_NAME = "replica_restart_policy_always"
@@ -25,10 +26,11 @@ class ReplicaRestartPolicyTests(test_util.TestCase):
 
   def run_tfjob_with_replica_restart_policy(self, component,
                                             replica_restart_policy, exit_code):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/shutdown_policy_tests.py
+++ b/py/kubeflow/tf_operator/shutdown_policy_tests.py
@@ -3,6 +3,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 MASTER_IS_CHIEF_COMPONENT_NAME = "master_is_chief"
@@ -22,10 +23,11 @@ class ShutdownPolicyTests(test_util.TestCase):
       class_name="ShutdownPolicyTests", name=name)
 
   def run_tfjob_with_shutdown_policy(self, component, shutdown_policy):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/simple_tfjob_tests.py
+++ b/py/kubeflow/tf_operator/simple_tfjob_tests.py
@@ -3,6 +3,7 @@ import logging
 
 from kubeflow.testing import ks_util, test_util, util
 from kubeflow.tf_operator import test_runner, tf_job_client
+from kubeflow.tf_operator import util as tf_operator_util
 from kubernetes import client as k8s_client
 
 CPU_TFJOB_COMPONENT_NAME = "simple_tfjob"
@@ -23,10 +24,11 @@ class SimpleTfJobTests(test_util.TestCase):
 
   # Run a generic TFJob, wait for it to complete, and check for pod/service creation errors.
   def run_simple_tfjob(self, component):
+    tf_operator_util.load_kube_config()
     api_client = k8s_client.ApiClient()
 
     # Setup the ksonnet app
-    ks_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
+    tf_operator_util.setup_ks_app(self.app_dir, self.env, self.namespace, component,
                          self.params)
 
     # Create the TF job

--- a/py/kubeflow/tf_operator/test_runner.py
+++ b/py/kubeflow/tf_operator/test_runner.py
@@ -22,20 +22,6 @@ from kubeflow.tf_operator import util as tf_operator_util
   stop_max_attempt_number=10, wait_random_min=1000, wait_random_max=10000)
 def run_test(test_case, test_func, args):  # pylint: disable=too-many-branches,too-many-statements
   """Run a test."""
-  gcs_client = storage.Client(project=args.project)
-  project = args.project
-  cluster_name = args.cluster
-  zone = args.zone
-  # TODO(jlewi): When using GKE we should copy the .kube config and any other
-  # files to the test directory. We should then set the environment variable
-  # KUBECONFIG to point at that file. This should prevent us from having
-  # to rerun util.configure_kubectl on each step. Instead we could run it once
-  # as part of GKE cluster creation and store the config in the NFS directory.
-  # This would make the handling of credentials
-  # and KUBECONFIG more consistent between GKE and minikube and eventually
-  # this could be extended to other K8s deployments.
-  if cluster_name:
-    util.configure_kubectl(project, zone, cluster_name)
   util.load_kube_config()
 
   start = time.time()
@@ -78,8 +64,7 @@ def run_test(test_case, test_func, args):  # pylint: disable=too-many-branches,t
     if args.artifacts_path:
       test_util.create_junit_xml_file(
         [test_case],
-        args.artifacts_path + "/junit_" + test_func.__name__ + ".xml",
-        gcs_client)
+        args.artifacts_path + "/junit_" + test_func.__name__ + ".xml")
 
 
 def parse_runtime_params(args):
@@ -182,7 +167,7 @@ def main(module=None):  # pylint: disable=too-many-locals
     datefmt='%Y-%m-%dT%H:%M:%S',
   )
 
-  util.maybe_activate_service_account()
+  # util.maybe_activate_service_account()
 
   parser = argparse.ArgumentParser(description="Run a TFJob test.")
   add_common_args(parser)

--- a/py/kubeflow/tf_operator/tf_job_client.py
+++ b/py/kubeflow/tf_operator/tf_job_client.py
@@ -72,7 +72,7 @@ def delete_tf_job(client, namespace, name, version="v1"):
       namespace,
       TF_JOB_PLURAL,
       name,
-      body,
+      body=body,
       async_req=True)
     api_response = thread.get(TIMEOUT)
     logging.info("Deleting job %s.%s returned: %s", namespace, name,
@@ -265,7 +265,7 @@ def get_labels(name, replica_type=None, replica_index=None):
 
 def to_selector(labels):
   parts = []
-  for k, v in labels.iteritems():
+  for k, v in labels.items():
     parts.append("{0}={1}".format(k, v))
 
   return ",".join(parts)

--- a/scripts/copy-to-gopath.sh
+++ b/scripts/copy-to-gopath.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build an image from our argo workflow
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
+GO_DIR=${GOPATH}/src/github.com/kubeflow/${REPO_NAME}
+
+# e2e test will run in go_dir. this is a required step.
+echo "Create symlink to GOPATH"
+# TODO(@Jeffwan): it should be ${REPO_OWNER}. Change it back later.
+mkdir -p ${GOPATH}/src/github.com/kubeflow
+ln -s ${PWD} ${GO_DIR}
+cd ${GO_DIR}

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build a cluster and create a namespace from our
+# argo workflow
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME}"
+REGION="${AWS_REGION:-us-west-2}"
+REGISTRY="${ECR_REGISTRY:-809251082950.dkr.ecr.us-west-2.amazonaws.com}"
+VERSION="${PULL_BASE_SHA}"
+GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
+
+echo "Configuring kubeconfig.."
+aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
+
+echo "Update tf operator manifest with new name and tag"
+cd manifests/
+kustomize edit set image gcr.io/kubeflow-images-public/tf-operator=${REGISTRY}/${REPO_NAME}:${VERSION}
+
+echo "Installing tf operator manifests"
+kubectl apply -k .
+
+TIMEOUT=30
+until kubectl get pods -n kubeflow | grep tf-job-operator | grep 1/1 || [[ $TIMEOUT -eq 1 ]]; do
+  sleep 10
+  TIMEOUT=$(( TIMEOUT - 1 ))
+done
+kubectl describe all -n kubeflow
+kubectl describe pods -n kubeflow

--- a/sdk/python/test/test_e2e.py
+++ b/sdk/python/test/test_e2e.py
@@ -25,7 +25,7 @@ from kubeflow.tfjob import TFJobClient
 
 
 TFJOB_CLIENT = TFJobClient(config_file=os.getenv('KUBECONFIG'))
-SDK_TEST_NAMESPACE = 'default'
+SDK_TEST_NAMESPACE = 'kubeflow'
 
 def test_sdk_e2e():
 


### PR DESCRIPTION
This PR moves TF Operator e2e tests to AWS

- remove GCP related credentials, volume and command
- add AWS credentials and registry
- use Kaniko to build image
- change the way of setup-cluster and tear-down-cluster
