### PR TITLE
checkCRDExists func return true when k8s cluster is not connected

### DIFF
--- a/cmd/tf-operator.v1/app/server.go
+++ b/cmd/tf-operator.v1/app/server.go
@@ -221,6 +221,8 @@ func checkCRDExists(clientset tfjobclientset.Interface, namespace string) bool {
 			if errors.IsNotFound(err) {
 				return false
 			}
+		} else {
+			return false;
 		}
 	}
 	return true


### PR DESCRIPTION
when k8s cluster is not connected (may be any network issue), log message like this

{"filename":"app/server.go:219","level":"error","msg":"Get "https://10.107.104.120:6443/apis/kubeflow.org/v1/tfjobs\": dial tcp 10.107.104.120:6443: i/o timeout","time":"2020-12-30T16:35:14+08:00"}

checkCRDExists will return true , that is not the right way