### PR TITLE
chore: Remove useless expectation

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -307,7 +307,6 @@ func (tc *TFController) syncTFJob(key string) (bool, error) {
 		if err == errNotExists {
 			logger.Infof("TFJob has been deleted: %v", key)
 			tfJobsDeletedCount.Inc()
-			// jm.expectations.DeleteExpectations(key)
 			return true, nil
 		}
 		return false, err

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -32,6 +32,7 @@ var (
 	})
 )
 
+// DeleteJob implements ControllerInterface interface.
 func (tc *TFController) DeleteJob(job interface{}) error {
 	tfJob, ok := job.(*tfv1.TFJob)
 	if !ok {
@@ -50,7 +51,7 @@ func (tc *TFController) DeleteJob(job interface{}) error {
 	return nil
 }
 
-// When a pod is added, set the defaults and enqueue the current tfjob.
+// addTFJob sets the defaults and enqueue the current tfjob.
 func (tc *TFController) addTFJob(obj interface{}) {
 	// Convert from unstructured object.
 	tfJob, err := tfJobFromUnstructured(obj)
@@ -114,8 +115,6 @@ func (tc *TFController) addTFJob(obj interface{}) {
 	logger.Info(msg)
 
 	// Add a created condition.
-	//[Jack]
-	// err = updateTFJobConditions(tfJob, common.JobCreated, tfJobCreatedReason, msg)
 	err = commonutil.UpdateJobConditions(&tfJob.Status, commonv1.JobCreated, tfJobCreatedReason, msg)
 	if err != nil {
 		logger.Errorf("Append tfJob condition error: %v", err)
@@ -132,7 +131,7 @@ func (tc *TFController) addTFJob(obj interface{}) {
 	tfJobsCreatedCount.Inc()
 }
 
-// When a pod is updated, enqueue the current tfjob.
+// updateTFJob enqueues the current tfjob.
 func (tc *TFController) updateTFJob(old, cur interface{}) {
 	oldTFJob, err := tfJobFromUnstructured(old)
 	if err != nil {


### PR DESCRIPTION
Now we do not have such an expectation key for tfjob, thus we can remove the comment.

/assign @ChanYiLin 

Signed-off-by: cegao <cegao@tencent.com>