### PR TITLE
TFJob Operator: Move manifests development upstream

### DIFF
--- a/manifests/tf-job-crds/base/crd.yaml
+++ b/manifests/tf-job-crds/base/crd.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tfjobs.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    kind: TFJob
+    plural: tfjobs
+    singular: tfjob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            tfReplicaSpecs:
+              properties:
+                Chief:
+                  properties:
+                    replicas:
+                      maximum: 1
+                      minimum: 1
+                      type: integer
+                PS:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+                Worker:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/manifests/tf-job-crds/base/kustomization.yaml
+++ b/manifests/tf-job-crds/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- crd.yaml

--- a/manifests/tf-job-crds/overlays/application/application.yaml
+++ b/manifests/tf-job-crds/overlays/application/application.yaml
@@ -1,0 +1,42 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: tf-job-crds
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tf-job-crds
+      app.kubernetes.io/instance: tf-job-crds-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: tfjob
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: TFJob
+  descriptor:
+    type: "tf-job-crds"
+    version: "v1"
+    description: "Tf-job-crds contains the \"TFJob\" custom resource definition."
+    maintainers:
+    - name: Richard Liu
+      email: ricliu@google.com
+    owners:
+    - name: Richard Liu
+      email: ricliu@google.com
+    keywords:
+    - "tfjob"
+    - "tf-operator"
+    - "tf-training"
+    links:
+    - description: About
+      url: "https://github.com/kubeflow/tf-operator"
+    - description: Docs
+      url: "https://www.kubeflow.org/docs/reference/tfjob/v1/tensorflow/"
+  addOwnerRef: true

--- a/manifests/tf-job-crds/overlays/application/kustomization.yaml
+++ b/manifests/tf-job-crds/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: tfjob
+  app.kubernetes.io/name: tf-job-crds
+kind: Kustomization
+resources:
+- application.yaml

--- a/manifests/tf-job-operator/base/cluster-role-binding.yaml
+++ b/manifests/tf-job-operator/base/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tf-job-operator
+subjects:
+- kind: ServiceAccount
+  name: tf-job-operator

--- a/manifests/tf-job-operator/base/cluster-role.yaml
+++ b/manifests/tf-job-operator/base/cluster-role.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  - tfjobs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - '*'
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tfjobs-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tfjobs-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tfjobs-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/tf-job-operator/base/deployment.yaml
+++ b/manifests/tf-job-operator/base/deployment.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tf-job-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: tf-job-operator
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - args:
+        - --alsologtostderr
+        - -v=1
+        - --monitoring-port=8443
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: gcr.io/kubeflow-images-public/tf_operator:kubeflow-tf-operator-postsubmit-v1-5adee6f-6109-a25c
+        name: tf-job-operator
+      serviceAccountName: tf-job-operator

--- a/manifests/tf-job-operator/base/kustomization.yaml
+++ b/manifests/tf-job-operator/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+commonLabels:
+  kustomize.component: tf-job-operator
+images:
+- name: gcr.io/kubeflow-images-public/tf_operator
+  newName: gcr.io/kubeflow-images-public/tf_operator
+  newTag: vmaster-gda226016

--- a/manifests/tf-job-operator/base/params.env
+++ b/manifests/tf-job-operator/base/params.env
@@ -1,0 +1,1 @@
+namespace=

--- a/manifests/tf-job-operator/base/service-account.yaml
+++ b/manifests/tf-job-operator/base/service-account.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tf-job-dashboard
+  name: tf-job-dashboard
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator

--- a/manifests/tf-job-operator/base/service.yaml
+++ b/manifests/tf-job-operator/base/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8443"
+  labels:
+    app: tf-job-operator
+  name: tf-job-operator
+spec:
+  ports:
+  - name: monitoring-port
+    port: 8443
+    targetPort: 8443
+  selector:
+    name: tf-job-operator
+  type: ClusterIP

--- a/manifests/tf-job-operator/overlays/application/application.yaml
+++ b/manifests/tf-job-operator/overlays/application/application.yaml
@@ -1,0 +1,42 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: tf-job-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tf-job-operator
+      app.kubernetes.io/instance: tf-job-operator-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: tfjob
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: TFJob
+  descriptor:
+    type: "tf-job-operator"
+    version: "v1"
+    description: "Tf-operator allows users to create and manage the \"TFJob\" custom resource."
+    maintainers:
+    - name: Richard Liu
+      email: ricliu@google.com
+    owners:
+    - name: Richard Liu
+      email: ricliu@google.com
+    keywords:
+    - "tfjob"
+    - "tf-operator"
+    - "tf-training"
+    links:
+    - description: About
+      url: "https://github.com/kubeflow/tf-operator"
+    - description: Docs
+      url: "https://www.kubeflow.org/docs/reference/tfjob/v1/tensorflow/"
+  addOwnerRef: true

--- a/manifests/tf-job-operator/overlays/application/kustomization.yaml
+++ b/manifests/tf-job-operator/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: tfjob
+  app.kubernetes.io/name: tf-job-operator
+kind: Kustomization
+resources:
+- application.yaml


### PR DESCRIPTION

### Issue Resolved

Resolves: https://github.com/kubeflow/tf-operator/issues/1246
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `TFJob Operator`
from path `apps/tf-training/upstream` of kubeflow/manifests to path
`deploy/v1` of the upstream repo (https://github.com/kubeflow/tf-operator).

cc @kubeflow/wg-training-leads