### PR TITLE
Fix: the "follow" of TFJobClient.get_logs

### DIFF
--- a/sdk/python/kubeflow/tfjob/api/tf_job_client.py
+++ b/sdk/python/kubeflow/tfjob/api/tf_job_client.py
@@ -397,7 +397,7 @@ class TFJobClient(object):
             for _ in range(50):
               try:
                 logline = next(stream)
-                logging.info("[Pod %s]: %s", pod, logline)
+                logging.info("[Pod %s]: %s", pod_names[index], logline)
               except StopIteration:
                 finished[index] = True
                 break


### PR DESCRIPTION
IMO, the `follow` parameter of `TFJobClient.get_logs` method should continually fetch and print the log stream of every listening pods. But the actual behavior is we can only get the log after pod's execution is finished.

As the discussion of this https://github.com/kubernetes-client/python/issues/199 the correct way to get the stream is to call `read_namespaced_pod_log` with `watch.Watch`.

This PR is an approach to fix this issue.

The output of `watch.stream` is a generator, so we could iterate over every pods's stream, group log lines and print them.

