### PR TITLE
Migrate to public ECR

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -24,6 +24,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf-operator:v0.6.0
+        image: public.ecr.aws/j1r0q0g6/training/tf-operator
         name: tf-job-operator
       serviceAccountName: tf-job-operator

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -14,9 +14,7 @@ spec:
     spec:
       containers:
       - args:
-        - --alsologtostderr
-        - -v=1
-        - --monitoring-port=8443
+        - -monitoring-port=8443
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -15,5 +15,5 @@ commonLabels:
   app.kubernetes.io/name: tf-job-operator
 images:
 - name: gcr.io/kubeflow-images-public/tf-operator
-  newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
+  newName: public.ecr.aws/j1r0q0g6/training/tf-operator
   newTag: "0.1"

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,4 +13,3 @@ commonLabels:
   kustomize.component: tf-job-operator
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
-

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -13,7 +13,4 @@ commonLabels:
   kustomize.component: tf-job-operator
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
-images:
-- name: gcr.io/kubeflow-images-public/tf-operator
-  newName: public.ecr.aws/j1r0q0g6/training/tf-operator
-  newTag: "0.1"
+

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -10,5 +10,5 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
-  newTag: "0.1"
+- name: gcr.io/kubeflow-images-public/tf-operator
+

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -10,5 +10,5 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: gcr.io/kubeflow-images-public/tf-operator
+- name: public.ecr.aws/j1r0q0g6/training/tf-operator
 

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -26,7 +26,7 @@ workflows:
     - sdk/*
     - examples/*
     params:
-      registry: "public.ecr.aws/j1r0q0g6/training/tf-operator"
+      registry: "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
       tfJobVersion: v1
       testWorkerImage: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
   - app_dir: kubeflow/tf-operator/test/workflows

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -26,7 +26,7 @@ workflows:
     - sdk/*
     - examples/*
     params:
-      registry: "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
+      registry: "public.ecr.aws/j1r0q0g6/training/tf-operator"
       tfJobVersion: v1
       testWorkerImage: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
   - app_dir: kubeflow/tf-operator/test/workflows

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -26,15 +26,15 @@ workflows:
     - sdk/*
     - examples/*
     params:
-      registry: "gcr.io/kubeflow-ci"
+      registry: "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
       tfJobVersion: v1
-      testWorkerImage: gcr.io/kubeflow-ci/test-worker:v20190421-fba47fe-e3b0c4
+      testWorkerImage: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest
   - app_dir: kubeflow/tf-operator/test/workflows
     component: workflows
     name: v1
     job_types:
       - postsubmit
     params:
-      registry: "gcr.io/kubeflow-images-public"
+      registry: "public.ecr.aws/j1r0q0g6/training/tf-operator"
       tfJobVersion: v1
-      testWorkerImage: gcr.io/kubeflow-ci/test-worker:v20190421-fba47fe-e3b0c4
+      testWorkerImage: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -24,7 +24,7 @@ set -o pipefail
 
 CLUSTER_NAME="${CLUSTER_NAME}"
 REGION="${AWS_REGION:-us-west-2}"
-REGISTRY="${ECR_REGISTRY:-public.ecr.aws/j1r0q0g6/training/tf-operator}"
+REGISTRY="${ECR_REGISTRY:-809251082950.dkr.ecr.us-west-2.amazonaws.com}"
 VERSION="${PULL_BASE_SHA}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -33,7 +33,7 @@ aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
 
 echo "Update tf operator manifest with new name $REGISTRY and tag $VERSION"
 cd manifests/overlays/standalone
-kustomize edit set image 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator=${REGISTRY}:${VERSION}
+kustomize edit set image gcr.io/kubeflow-images-public/tf-operator=${REGISTRY}:${VERSION}
 
 echo "Installing tf operator manifests"
 kustomize build . | kubectl apply -f -

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -33,7 +33,7 @@ aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
 
 echo "Update tf operator manifest with new name $REGISTRY and tag $VERSION"
 cd manifests/overlays/standalone
-kustomize edit set image gcr.io/kubeflow-images-public/tf-operator=${REGISTRY}:${VERSION}
+kustomize edit set image public.ecr.aws/j1r0q0g6/training/tf-operator=${REGISTRY}:${VERSION}
 
 echo "Installing tf operator manifests"
 kustomize build . | kubectl apply -f -

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -31,9 +31,9 @@ GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 echo "Configuring kubeconfig.."
 aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
 
-echo "Update tf operator manifest with new name and tag"
+echo "Update tf operator manifest with new name $REGISTRY and tag $VERSION"
 cd manifests/overlays/standalone
-kustomize edit set image 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator=${REGISTRY}/${REPO_NAME}:${VERSION}
+kustomize edit set image 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator=${REGISTRY}:${VERSION}
 
 echo "Installing tf operator manifests"
 kustomize build . | kubectl apply -f -

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -24,7 +24,7 @@ set -o pipefail
 
 CLUSTER_NAME="${CLUSTER_NAME}"
 REGION="${AWS_REGION:-us-west-2}"
-REGISTRY="${ECR_REGISTRY:-809251082950.dkr.ecr.us-west-2.amazonaws.com}"
+REGISTRY="${ECR_REGISTRY:-public.ecr.aws/j1r0q0g6/training/tf-operator}"
 VERSION="${PULL_BASE_SHA}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -118,7 +118,7 @@
                 value: cluster,
               },
               {
-                name: "GCP_REGISTRY",
+                name: "AWS_REGISTRY",
                 value: registry,
               },
               {
@@ -331,7 +331,7 @@
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/tf_operator/Dockerfile",
               "--context=dir://" + srcDir,
-              "--destination=" + "$(registry):$(PULL_BASE_SHA)",
+              "--destination=" + "$(AWS_REGISTRY):$(PULL_BASE_SHA)",
             ],
             # need to add volume mounts and extra env.
             volume_mounts=[

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -53,7 +53,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/tf-operator repo
       local srcDir = srcRootDir + "/kubeflow/tf-operator";
-      local testWorkerImage = params.testWorkerImage;
+      local testWorkerImage = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest";
 
       // value of KUBECONFIG environment variable. This should be  a full path.
       local kubeConfig = testDir + "/.kube/kubeconfig";

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -118,7 +118,7 @@
                 value: cluster,
               },
               {
-                name: "AWS_REGISTRY",
+                name: "ECR_REGISTRY",
                 value: registry,
               },
               {
@@ -331,7 +331,7 @@
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/tf_operator/Dockerfile",
               "--context=dir://" + srcDir,
-              "--destination=" + "$(AWS_REGISTRY):$(PULL_BASE_SHA)",
+              "--destination=" + "$(ECR_REGISTRY):$(PULL_BASE_SHA)",
             ],
             # need to add volume mounts and extra env.
             volume_mounts=[

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -28,7 +28,7 @@
   // default parameters.
   defaultParams:: {
     // Default registry to use.
-    registry:: "gcr.io/kubeflow-ci",
+    registry:: "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator",
 
     // The image tag to use.
     // Defaults to a value based on the name.
@@ -39,10 +39,6 @@
   parts(namespace, name, overrides):: {
     // Workflow to run the e2e test.
     e2e(prow_env, bucket):
-      local envVars = $.parseEnv;
-      local imageRegistry = if envVars["JOB_TYPE"] == "presubmit" then
-        "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
-      else "public.ecr.aws/j1r0q0g6/training/tf-operator";
       local params = $.defaultParams + overrides;
       // mountPath is the directory where the volume to store the test data
       // should be mounted.
@@ -57,15 +53,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/tf-operator repo
       local srcDir = srcRootDir + "/kubeflow/tf-operator";
-      local testWorkerImage = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest";
-
-      // The image should generally be overwritten in the prow_config.yaml file. This makes it easier
-      // to ensure a consistent image is used for all workflows.
-      // local image = if std.objectHas(params, "testWorkerImage") && std.length(params.testWorkerImage) > 0 then
-      //   params.testWorkerImage
-      // else
-      //   "gcr.io/kubeflow-ci/test-worker";
-
+      local testWorkerImage = params.testWorkerImage;
 
       // value of KUBECONFIG environment variable. This should be  a full path.
       local kubeConfig = testDir + "/.kube/kubeconfig";
@@ -343,7 +331,7 @@
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/tf_operator/Dockerfile",
               "--context=dir://" + srcDir,
-              "--destination=" + imageRegistry + ":$(PULL_BASE_SHA)",
+              "--destination=" + "$(registry):$(PULL_BASE_SHA)",
             ],
             # need to add volume mounts and extra env.
             volume_mounts=[

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -326,7 +326,7 @@
                 ],
               },
             },  // checkout
-            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build", "gcr.io/kaniko-project/executor:v1.0.0", [
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build", "gcr.io/kaniko-project/executor:v1.5.1", [
               #"scripts/build.sh",
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/tf_operator/Dockerfile",

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -39,6 +39,9 @@
   parts(namespace, name, overrides):: {
     // Workflow to run the e2e test.
     e2e(prow_env, bucket):
+      local imageRegistry = if $(JOB_TYPE) == "presubmit" then
+        "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
+      else "public.ecr.aws/j1r0q0g6/training/tf-operator";
       local params = $.defaultParams + overrides;
       // mountPath is the directory where the volume to store the test data
       // should be mounted.
@@ -339,7 +342,7 @@
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/tf_operator/Dockerfile",
               "--context=dir://" + srcDir,
-              "--destination=" + "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator:$(PULL_BASE_SHA)",
+              "--destination=" + imageRegistry + ":$(PULL_BASE_SHA)",
             ],
             # need to add volume mounts and extra env.
             volume_mounts=[

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -39,7 +39,8 @@
   parts(namespace, name, overrides):: {
     // Workflow to run the e2e test.
     e2e(prow_env, bucket):
-      local imageRegistry = if $(JOB_TYPE) == "presubmit" then
+      local envVars = $.parseEnv;
+      local imageRegistry = if envVars["JOB_TYPE"] == "presubmit" then
         "809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator"
       else "public.ecr.aws/j1r0q0g6/training/tf-operator";
       local params = $.defaultParams + overrides;


### PR DESCRIPTION
Resolves https://github.com/kubeflow/tf-operator/issues/1205

~~It's still WIP, not familiar with jsonnet syntax, and it's has been deprecated years...~~

There's requirement to migrate from jsonnet-generated workflow to python-generated workflow, otherwise, it's difficult to maintain. 

/hold
Hold until test succeed