### PR TITLE
manifests: Use last known image from kubeflow/manifests

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -26,6 +26,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf-operator:v0.6.0
+        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-gda226016
         name: tf-job-operator
       serviceAccountName: tf-job-operator

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -14,6 +14,5 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: gcr.io/kubeflow-images-public/tf-operator
-  newName: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
-  newTag: "0.1"
+- name: gcr.io/kubeflow-images-public/tf_operator
+  newTag: vmaster-gda226016

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -9,5 +9,4 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
-  newTag: "0.1"
+- name: gcr.io/kubeflow-images-public/tf_operator

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -10,5 +10,4 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
-  newTag: "0.1"
+- name: gcr.io/kubeflow-images-public/tf_operator

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -33,7 +33,7 @@ aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
 
 echo "Update tf operator manifest with new name and tag"
 cd manifests/overlays/standalone
-kustomize edit set image 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator=${REGISTRY}/${REPO_NAME}:${VERSION}
+kustomize edit set image gcr.io/kubeflow-images-public/tf_operator=${REGISTRY}/${REPO_NAME}:${VERSION}
 
 echo "Installing tf operator manifests"
 kustomize build . | kubectl apply -f -


### PR DESCRIPTION
I hadn't realized that the images that are continuously built are not accessible.
I'm not sure what the status of publishing images to ECR is for wg-training.
Until it's sorted out, I have reverted manifests to use the last known good image from kubeflow/manifests.

CI still works with the latest images.

cc @kubeflow/wg-training-leads 