### PR TITLE
Fix kubeflow overlay

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -10,3 +10,4 @@ commonLabels:
   app.kubernetes.io/name: tf-job-operator
 images:
 - name: public.ecr.aws/j1r0q0g6/training/tf-operator
+  newTag: cd2fc1ff397b1f349f68524f4abd5013a32e3033

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -9,5 +9,4 @@ commonLabels:
   app.kubernetes.io/component: tfjob
   app.kubernetes.io/name: tf-job-operator
 images:
-- name: 809251082950.dkr.ecr.us-west-2.amazonaws.com/tf-operator
-  newTag: "0.1"
+- name: public.ecr.aws/j1r0q0g6/training/tf-operator

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -11,4 +11,5 @@ commonLabels:
   app.kubernetes.io/name: tf-job-operator
 images:
 - name: public.ecr.aws/j1r0q0g6/training/tf-operator
+  newTag: cd2fc1ff397b1f349f68524f4abd5013a32e3033
 

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -34,6 +34,23 @@ workflows:
     name: v1
     job_types:
       - postsubmit
+    include_dirs:
+    - build/*
+    - cmd/tf-operator.v1/*
+    - pkg/apis/common/v1/*
+    - pkg/apis/tensorflow/v1/*
+    - pkg/apis/tensorflow/validation/*
+    - pkg/common/*
+    - pkg/control/*
+    - pkg/controller.v1/*
+    - pkg/logger/*
+    - pkg/util/*
+    - pkg/version/*
+    - py/*
+    - test/*
+    - vendor/*
+    - sdk/*
+    - examples/*
     params:
       registry: "public.ecr.aws/j1r0q0g6/training/tf-operator"
       tfJobVersion: v1


### PR DESCRIPTION
This is the final fix for tf-operator manifests, the tf-operator has already onboarded public ECR.

E2E test passes with CI pushing to private ECR, CD pushing to public ECR.

Tf-operator is ready for manifest sync 

/cc @yanniszark 

Let me know if any other issue