### PR TITLE
Add job namespace to `tf_operator_jobs_*` counters

### DIFF
--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -248,7 +248,7 @@ func (tc *TFController) processNextWorkItem() bool {
 	if err != nil {
 		if err == errNotExists {
 			logger.Infof("TFJob has been deleted: %v", key)
-			tfJobsDeletedCount.Inc()
+			tfJobsDeletedCount.WithLabelValues(tfJob.Namespace).Inc()
 			return true
 		}
 
@@ -311,7 +311,7 @@ func (tc *TFController) syncTFJob(key string) (bool, error) {
 	if err != nil {
 		if err == errNotExists {
 			logger.Infof("TFJob has been deleted: %v", key)
-			tfJobsDeletedCount.Inc()
+			tfJobsDeletedCount.WithLabelValues(namespace).Inc()
 			return true, nil
 		}
 		return false, err

--- a/pkg/controller.v1/tensorflow/controller.go
+++ b/pkg/controller.v1/tensorflow/controller.go
@@ -65,10 +65,13 @@ var (
 	// key function but it should be just fine for non delete events.
 	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
 
-	tfJobsDeletedCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_deleted_total",
-		Help: "Counts number of TF jobs deleted",
-	})
+	tfJobsDeletedCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tf_operator_jobs_deleted_total",
+			Help: "Counts number of TF jobs deleted",
+		},
+		[]string{"job_namespace"},
+	)
 )
 
 // TFController is the type for TFJob Controller, which manages

--- a/pkg/controller.v1/tensorflow/job.go
+++ b/pkg/controller.v1/tensorflow/job.go
@@ -26,10 +26,13 @@ const (
 )
 
 var (
-	tfJobsCreatedCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_created_total",
-		Help: "Counts number of TF jobs created",
-	})
+	tfJobsCreatedCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tf_operator_jobs_created_total",
+			Help: "Counts number of TF jobs created",
+		},
+		[]string{"job_namespace"},
+	)
 )
 
 // DeleteJob implements ControllerInterface interface.
@@ -128,7 +131,7 @@ func (tc *TFController) addTFJob(obj interface{}) {
 		return
 	}
 	tc.enqueueTFJob(obj)
-	tfJobsCreatedCount.Inc()
+	tfJobsCreatedCount.WithLabelValues(tfJob.Namespace).Inc()
 }
 
 // updateTFJob enqueues the current tfjob.

--- a/pkg/controller.v1/tensorflow/pod.go
+++ b/pkg/controller.v1/tensorflow/pod.go
@@ -53,10 +53,13 @@ const (
 )
 
 var (
-	tfJobsRestartCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "tf_operator_jobs_restarted_total",
-		Help: "Counts number of TF jobs restarted",
-	})
+	tfJobsRestartCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tf_operator_jobs_restarted_total",
+			Help: "Counts number of TF jobs restarted",
+		},
+		[]string{"job_namespace"},
+	)
 )
 
 // reconcilePods checks and updates pods for each given TFReplicaSpec.
@@ -149,7 +152,7 @@ func (tc *TFController) ReconcilePods(
 						commonutil.LoggerForJob(tfJob).Infof("Append tfjob condition error: %v", err)
 						return err
 					}
-					tfJobsRestartCount.Inc()
+					tfJobsRestartCount.WithLabelValues(tfJob.Namespace).Inc()
 				}
 			}
 


### PR DESCRIPTION
This PR adds the job's namespace as a label to Prometheus metrics reported by the operator, making it possible to filter metrics per-namespaces as opposed to global counters.