### PR TITLE
Update container image for v1.1.1

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -10,4 +10,5 @@ commonLabels:
   app.kubernetes.io/name: tf-job-operator
 images:
 - name: public.ecr.aws/j1r0q0g6/training/tf-operator
-  newTag: cd2fc1ff397b1f349f68524f4abd5013a32e3033
+  newTag: 47a74b738920edbf4207160cec7e1dff9cdab3f2
+

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -11,5 +11,5 @@ commonLabels:
   app.kubernetes.io/name: tf-job-operator
 images:
 - name: public.ecr.aws/j1r0q0g6/training/tf-operator
-  newTag: cd2fc1ff397b1f349f68524f4abd5013a32e3033
+  newTag: 47a74b738920edbf4207160cec7e1dff9cdab3f2
 


### PR DESCRIPTION
Resolve part of #1321 

/cc @terrytangyuan @PatrickXYS 

This image comes from latest master commit and it is built from CI 

```
commit 47a74b738920edbf4207160cec7e1dff9cdab3f2 (upstream/master, master)
Author: jazzsir <jazzsir@gmail.com>
Date:   Tue Jul 20 16:10:15 2021 +0900

    add a specific version of tensorflow_datasets (#1305)

    re-push with signed email
```