### PR TITLE
Fix postsubmit job using PULL_BASE_SHA

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -52,6 +52,6 @@ workflows:
     - sdk/*
     - examples/*
     params:
-      registry: "public.ecr.aws/j1r0q0g6/training/tf-operator"
+      registry: "public.ecr.aws/j1r0q0g6/training/training-operator"
       tfJobVersion: v1
       testWorkerImage: public.ecr.aws/j1r0q0g6/kubeflow-testing:latest

--- a/scripts/setup-tf-operator.sh
+++ b/scripts/setup-tf-operator.sh
@@ -25,7 +25,7 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 REGION="${AWS_REGION:-us-west-2}"
 REGISTRY="${ECR_REGISTRY:-public.ecr.aws/j1r0q0g6/training/tf-operator}"
-VERSION="${PULL_PULL_SHA}"
+VERSION="${PULL_BASE_SHA}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Configuring kubeconfig.."

--- a/scripts/setup-training-operator.sh
+++ b/scripts/setup-training-operator.sh
@@ -25,7 +25,7 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 REGION="${AWS_REGION:-us-west-2}"
 REGISTRY="${ECR_REGISTRY:-public.ecr.aws/j1r0q0g6/training/training-operator}"
-VERSION="${PULL_PULL_SHA}"
+VERSION="${PULL_BASE_SHA}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Configuring kubeconfig.."

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -331,7 +331,7 @@
               "/kaniko/executor",
               "--dockerfile=" + srcDir + "/build/images/training-operator/Dockerfile",
               "--context=dir://" + srcDir,
-              "--destination=" + "$(ECR_REGISTRY):$(PULL_PULL_SHA)",
+              "--destination=" + "$(ECR_REGISTRY):$(PULL_BASE_SHA)",
             ],
             # need to add volume mounts and extra env.
             volume_mounts=[


### PR DESCRIPTION
Address #1343 

We change to use PULL_PULL_SHA in earlier PR but post-submit doesn't have PULL_PULL_SHA which will fail the pipeline. 

presubmit and postsubmit share the same pipeline. This PR changes to use PULL_PULL_SHA as preferred option and it will fall back to PULL_BASE_SHA in post-submit jobs. 

/cc @PatrickXYS @terrytangyuan 