### PR TITLE
Fix XGBoost container name in log message

### DIFF
--- a/pkg/apis/xgboost/validation/validation.go
+++ b/pkg/apis/xgboost/validation/validation.go
@@ -20,8 +20,6 @@ import (
 	xgboostv1 "github.com/kubeflow/tf-operator/pkg/apis/xgboost/v1"
 
 	commonv1 "github.com/kubeflow/common/pkg/apis/common/v1"
-
-	torchv1 "github.com/kubeflow/tf-operator/pkg/apis/pytorch/v1"
 )
 
 func ValidateV1XGBoostJobSpec(c *xgboostv1.XGBoostJobSpec) error {
@@ -59,9 +57,9 @@ func ValidateV1XGBoostJobSpec(c *xgboostv1.XGBoostJobSpec) error {
 				defaultContainerPresent = true
 			}
 		}
-		//Make sure there has at least one container named "pytorch"
+		//Make sure there has at least one container named "xgboost"
 		if !defaultContainerPresent {
-			msg := fmt.Sprintf("XGBoostReplicaType is not valid: There is no container named %s in %v", torchv1.DefaultContainerName, rType)
+			msg := fmt.Sprintf("XGBoostReplicaType is not valid: There is no container named %s in %v", xgboostv1.DefaultContainerName, rType)
 			return fmt.Errorf(msg)
 		}
 		if rType == xgboostv1.XGBoostReplicaTypeMaster {


### PR DESCRIPTION
I fixed name in XGBoostJob validation.
Btw, is it fine that we don't run this validation before Job submission ?

As I can see, user can detect that Job is not valid only from the controller logs, even if YAML is incorrect: https://github.com/kubeflow/tf-operator/blob/master/pkg/controller.v1/xgboost/xgboostjob_controller.go#L146-L148.
Do we have any method to detect that YAML is valid other than validation webhook ?

cc @kubeflow/wg-training-leads 