### PR TITLE
chore: Update manifest image tag

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: kubeflow/training-operator
-    newName: kubeflow/training-operator
-    newTag: "46c586463e3c13b0d4f2d534aae84a46329dc4ef"
+    newName: public.ecr.aws/j1r0q0g6/training/training-operator
+    newTag: "fb013e4faf6e8c2741829bf6941b99697f219a30"

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - namespace.yaml
 images:
   - name: kubeflow/training-operator
-    newName: kubeflow/training-operator
-    newTag: "46c586463e3c13b0d4f2d534aae84a46329dc4ef"
+    newName: public.ecr.aws/j1r0q0g6/training/training-operator
+    newTag: "fb013e4faf6e8c2741829bf6941b99697f219a30"


### PR DESCRIPTION
Post submit job has been fixed. 
fb013e4faf6e8c2741829bf6941b99697f219a30 is the last commit.  

![image](https://user-images.githubusercontent.com/4739316/129488454-e3b207c7-0c8f-4447-ae09-7721b68957ab.png)


This image includes two bug fixes and we can release a new alpha version later
