### PR TITLE
Update include dirs in prow config

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -9,22 +9,17 @@ workflows:
     job_types:
       - presubmit
     include_dirs:
-    - build/*
-    - cmd/tf-operator.v1/*
-    - pkg/apis/common/v1/*
-    - pkg/apis/tensorflow/v1/*
-    - pkg/apis/tensorflow/validation/*
-    - pkg/common/*
-    - pkg/control/*
-    - pkg/controller.v1/*
-    - pkg/logger/*
-    - pkg/util/*
-    - pkg/version/*
-    - py/*
-    - test/*
-    - vendor/*
-    - sdk/*
-    - examples/*
+      - build/*
+      - cmd/*
+      - examples/*
+      - hack/*
+      - manifests/*
+      - pkg/*
+      - py/*
+      - scripts/*
+      - sdk/*
+      - test/*
+      - prow_config.yaml
     params:
       registry: "809251082950.dkr.ecr.us-west-2.amazonaws.com/training-operator"
       tfJobVersion: v1
@@ -35,22 +30,17 @@ workflows:
     job_types:
       - postsubmit
     include_dirs:
-    - build/*
-    - cmd/tf-operator.v1/*
-    - pkg/apis/common/v1/*
-    - pkg/apis/tensorflow/v1/*
-    - pkg/apis/tensorflow/validation/*
-    - pkg/common/*
-    - pkg/control/*
-    - pkg/controller.v1/*
-    - pkg/logger/*
-    - pkg/util/*
-    - pkg/version/*
-    - py/*
-    - test/*
-    - vendor/*
-    - sdk/*
-    - examples/*
+      - build/*
+      - cmd/*
+      - examples/*
+      - hack/*
+      - manifests/*
+      - pkg/*
+      - py/*
+      - scripts/*
+      - sdk/*
+      - test/*
+      - prow_config.yaml
     params:
       registry: "public.ecr.aws/j1r0q0g6/training/training-operator"
       tfJobVersion: v1


### PR DESCRIPTION
Related: https://github.com/kubeflow/tf-operator/issues/1323.

In order to trigger the CI AWS Pipeline we should update `include_dirs` with the latest folder structure.

cc @kubeflow/wg-training-leads @deepak-muley