### PR TITLE
Add simple verification jobs

### DIFF
--- a/examples/pytorch/simple.yaml
+++ b/examples/pytorch/simple.yaml
@@ -1,0 +1,33 @@
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: pytorch-simple
+  namespace: kubeflow
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              imagePullPolicy: Always
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"
+    Worker:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              imagePullPolicy: Always
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"

--- a/examples/tensorflow/simple.yaml
+++ b/examples/tensorflow/simple.yaml
@@ -1,0 +1,18 @@
+apiVersion: "kubeflow.org/v1"
+kind: TFJob
+metadata:
+  name: tfjob-simple
+  namespace: kubeflow
+spec:
+   tfReplicaSpecs:
+     Worker:
+       replicas: 2
+       restartPolicy: OnFailure
+       template:
+         spec:
+           containers:
+             - name: tensorflow
+               image: gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0
+               command:
+                 - "python"
+                 - "/var/tf_mnist/mnist_with_summaries.py"


### PR DESCRIPTION
Add for operator verification. These jobs are simple and ready to run. No volumes, no GPUs and they are just used for manual testing.