### PR TITLE
fix: runPolicy validation error in the examples

### DIFF
--- a/examples/tensorflow/distribution_strategy/estimator-API/distributed_tfjob.yaml
+++ b/examples/tensorflow/distribution_strategy/estimator-API/distributed_tfjob.yaml
@@ -4,7 +4,8 @@ metadata:
   name: "distributed-training"
   namespace: "kf-latest"
 spec:
-  cleanPodPolicy: None
+  runPolicy:
+    cleanPodPolicy: None
   tfReplicaSpecs:
     Worker:
       replicas: 3

--- a/examples/tensorflow/distribution_strategy/keras-API/multi_worker_tfjob.yaml
+++ b/examples/tensorflow/distribution_strategy/keras-API/multi_worker_tfjob.yaml
@@ -3,7 +3,8 @@ kind: TFJob
 metadata:
   name: multi-worker
 spec:
-  cleanPodPolicy: None
+  runPolicy:
+    cleanPodPolicy: None
   tfReplicaSpecs:
     Worker:
       replicas: 2

--- a/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
+++ b/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
@@ -4,7 +4,8 @@ metadata:
   name: "mnist"
   namespace: kubeflow 
 spec:
-  cleanPodPolicy: None 
+  runPolicy:
+    cleanPodPolicy: None
   tfReplicaSpecs:
     Worker:
       replicas: 1 


### PR DESCRIPTION
Since we move "cleanPodPolicy" to `runPolicy` umbrella and enable CRD validation. some examples can not be submitted. 

This PR helps update the examples still using the old pattern.

```
kubectl apply -f tf_job_mnist.yaml
error: error validating "tf_job_mnist.yaml": error validating data: ValidationError(TFJob.spec): unknown field "cleanPodPolicy" in org.kubeflow.v1.TFJob.spec; if you choose to ignore these errors, turn validation off with --validate=false
```