### PR TITLE
Fix 1399: added pod matching label in service selector

### DIFF
--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8443"
   labels:
-    app: training-operator
+    control-plane: kubeflow-training-operator
   name: training-operator
 spec:
   ports:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8443"
   labels:
-    control-plane: kubeflow-training-operator
+    app: training-operator
   name: training-operator
 spec:
   ports:
@@ -15,5 +15,5 @@ spec:
     port: 8443
     targetPort: 8443
   selector:
-    name: training-operator
+    control-plane: kubeflow-training-operator
   type: ClusterIP


### PR DESCRIPTION
ref: #1399

Testing Details:
<pre>
k -n kubeflow get pod -o wide
...
training-operator-749dfc7446-ktmjk                           1/1     Running   0          65s   172.20.16.63    karbon-dm-demo-3-9b4ea8-k8s-worker-1   <none>           <none>
...
</pre>

<pre>
 k -n kubeflow describe service training-operator
...
Name:              training-operator
Namespace:         kubeflow
Labels:            app=training-operator
Annotations:       prometheus.io/path: /metrics
                   prometheus.io/port: 8443
                   prometheus.io/scrape: true
Selector:          control-plane=kubeflow-training-operator
Type:              ClusterIP
IP Families:       <none>
IP:                172.19.137.178
IPs:               <none>
Port:              monitoring-port  8443/TCP
TargetPort:        8443/TCP
Endpoints:         172.20.16.63:8443
...
</pre>