### PR TITLE
2010: fix to expose correct monitoring port 

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -21,6 +21,8 @@ spec:
             - /manager
           image: kubeflow/training-operator
           name: training-operator
+          ports:
+            - containerPort: 8080
           env:
             - name: MY_POD_NAMESPACE
               valueFrom:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/scrape: "true"
-    prometheus.io/port: "8443"
+    prometheus.io/port: "8080"
   labels:
     app: training-operator
   name: training-operator

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -15,5 +15,5 @@ spec:
     port: 8080
     targetPort: 8080
   selector:
-    control-plane: kubeflow-training-operator
+    name: training-operator
   type: ClusterIP

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8443"
   labels:
-    app: training-operator
+    control-plane: kubeflow-training-operator
   name: training-operator
 spec:
   ports:

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8443"
   labels:
-    control-plane: kubeflow-training-operator
+    app: training-operator
   name: training-operator
 spec:
   ports:
@@ -15,5 +15,5 @@ spec:
     port: 8443
     targetPort: 8443
   selector:
-    name: training-operator
+    control-plane: kubeflow-training-operator
   type: ClusterIP

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -12,8 +12,8 @@ metadata:
 spec:
   ports:
   - name: monitoring-port
-    port: 8443
-    targetPort: 8443
+    port: 8080
+    targetPort: 8080
   selector:
     control-plane: kubeflow-training-operator
   type: ClusterIP


### PR DESCRIPTION
ref: https://github.com/kubeflow/manifests/issues/2010 

training-operator exposes 8080 per logs
2021-09-14T19:31:49.294Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": ":8080"}
hence when we do local testing, it works fine
but when we expose it using make deploy then inside k8s, its not exposed

Steps:
- make deploy
- kubectl port-forward -n kubeflow svc/training-operator 8080:8080
![Screen Shot 2021-09-14 at 12 39 03 PM](https://user-images.githubusercontent.com/780387/133323722-8ed646f4-b8d1-490c-a82e-4e343950b166.png)
