### PR TITLE
Feature/support pytorchjob set queue of volcano

### DIFF
--- a/pkg/controller.v1/mxnet/mxjob_controller.go
+++ b/pkg/controller.v1/mxnet/mxjob_controller.go
@@ -166,17 +166,8 @@ func (r *MXJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		replicas[commonv1.ReplicaType(k)] = v
 	}
 
-	// Construct RunPolicy based on MXJob.Spec
-	runPolicy := &commonv1.RunPolicy{
-		CleanPodPolicy:          mxjob.Spec.RunPolicy.CleanPodPolicy,
-		TTLSecondsAfterFinished: mxjob.Spec.RunPolicy.TTLSecondsAfterFinished,
-		ActiveDeadlineSeconds:   mxjob.Spec.RunPolicy.ActiveDeadlineSeconds,
-		BackoffLimit:            mxjob.Spec.RunPolicy.BackoffLimit,
-		SchedulingPolicy:        nil,
-	}
-
 	// Use common to reconcile the job related pod and service
-	err = r.ReconcileJobs(mxjob, replicas, mxjob.Status, runPolicy)
+	err = r.ReconcileJobs(mxjob, replicas, mxjob.Status, &mxjob.Spec.RunPolicy)
 	if err != nil {
 		logrus.Warnf("Reconcile MX Job error %v", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -155,17 +155,8 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Set default priorities to pytorch job
 	r.Scheme.Default(pytorchjob)
 
-	// Construct RunPolicy based on PyTorchJob.Spec
-	runPolicy := &commonv1.RunPolicy{
-		CleanPodPolicy:          pytorchjob.Spec.RunPolicy.CleanPodPolicy,
-		TTLSecondsAfterFinished: pytorchjob.Spec.RunPolicy.TTLSecondsAfterFinished,
-		ActiveDeadlineSeconds:   pytorchjob.Spec.RunPolicy.ActiveDeadlineSeconds,
-		BackoffLimit:            pytorchjob.Spec.RunPolicy.BackoffLimit,
-		SchedulingPolicy:        pytorchjob.Spec.RunPolicy.SchedulingPolicy,
-	}
-
 	// Use common to reconcile the job related pod and service
-	err = r.ReconcileJobs(pytorchjob, pytorchjob.Spec.PyTorchReplicaSpecs, pytorchjob.Status, runPolicy)
+	err = r.ReconcileJobs(pytorchjob, pytorchjob.Spec.PyTorchReplicaSpecs, pytorchjob.Status, &pytorchjob.Spec.RunPolicy)
 	if err != nil {
 		logrus.Warnf("Reconcile PyTorch Job error %v", err)
 		return ctrl.Result{}, err

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	podgroupv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned"
 )
 
@@ -156,18 +155,13 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Set default priorities to pytorch job
 	r.Scheme.Default(pytorchjob)
 
-	// parse volcano Queue from pytorchjob Annotation
-	schedulingPolicy := &commonv1.SchedulingPolicy{
-		Queue: pytorchjob.Annotations[podgroupv1beta1.QueueNameAnnotationKey],
-	}
-
 	// Construct RunPolicy based on PyTorchJob.Spec
 	runPolicy := &commonv1.RunPolicy{
 		CleanPodPolicy:          pytorchjob.Spec.RunPolicy.CleanPodPolicy,
 		TTLSecondsAfterFinished: pytorchjob.Spec.RunPolicy.TTLSecondsAfterFinished,
 		ActiveDeadlineSeconds:   pytorchjob.Spec.RunPolicy.ActiveDeadlineSeconds,
 		BackoffLimit:            pytorchjob.Spec.RunPolicy.BackoffLimit,
-		SchedulingPolicy:        schedulingPolicy,
+		SchedulingPolicy:        pytorchjob.Spec.RunPolicy.SchedulingPolicy,
 	}
 
 	// Use common to reconcile the job related pod and service

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -156,7 +156,7 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Set default priorities to pytorch job
 	r.Scheme.Default(pytorchjob)
 
-	// parse Queue from pytorchjob Annotation
+	// parse volcano Queue from pytorchjob Annotation
 	schedulingPolicy := &commonv1.SchedulingPolicy{
 		Queue: pytorchjob.Annotations[podgroupv1beta1.QueueNameAnnotationKey],
 	}

--- a/pkg/controller.v1/pytorch/pytorchjob_controller.go
+++ b/pkg/controller.v1/pytorch/pytorchjob_controller.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	podgroupv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 	volcanoclient "volcano.sh/apis/pkg/client/clientset/versioned"
 )
 
@@ -155,13 +156,18 @@ func (r *PyTorchJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Set default priorities to pytorch job
 	r.Scheme.Default(pytorchjob)
 
+	// parse Queue from pytorchjob Annotation
+	schedulingPolicy := &commonv1.SchedulingPolicy{
+		Queue: pytorchjob.Annotations[podgroupv1beta1.QueueNameAnnotationKey],
+	}
+
 	// Construct RunPolicy based on PyTorchJob.Spec
 	runPolicy := &commonv1.RunPolicy{
 		CleanPodPolicy:          pytorchjob.Spec.RunPolicy.CleanPodPolicy,
 		TTLSecondsAfterFinished: pytorchjob.Spec.RunPolicy.TTLSecondsAfterFinished,
 		ActiveDeadlineSeconds:   pytorchjob.Spec.RunPolicy.ActiveDeadlineSeconds,
 		BackoffLimit:            pytorchjob.Spec.RunPolicy.BackoffLimit,
-		SchedulingPolicy:        nil,
+		SchedulingPolicy:        schedulingPolicy,
 	}
 
 	// Use common to reconcile the job related pod and service


### PR DESCRIPTION
I want set queue of podgroup created by pytorchjob, but there is not SchedulingPolicy in pytorchjob struct, so I try to set queue name in annotation `scheduling.volcano.sh/queue-name` of pytorchjob.

it is related with  issue #1414 