### PR TITLE
docs: Migrate adopters of all operators to this repo

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -1,10 +1,24 @@
-# TF Operator Adopters
+# Adopters of Kubeflow Training Operator
 
-This is a list of TF Operator adopters in various industries.
+This page contains a list of organizations who are using Kubeflow Training Operator. If you'd like to be included here, please send a pull request which modifies this file. Please keep the list in alphabetical order.
 
-| Company | Contact | Industry | Description of Use |
-| :--- | :--- | :--- | :--- |
-|[Ant Group](https://www.antgroup.com/)|[@terrytangyuan](https://github.com/terrytangyuan)|Cloud Computing| |
-|Bytedance Volcengine|[@codeflitting](https://github.com/codeflitting)|Cloud Computing|  |
-|[vip](https://www.vip.com/)|[@oikomi](https://github.com/oikomi)|E-commerce||
-|Tencent Cloud|[@gaocegege](https://github.com/gaocegege)|Cloud Computing||
+| Organization | Contact |
+| ------------ | ------- |
+| [Alibaba Cloud](https://us.alibabacloud.com/) | [Yang Che](https://github.com/cheyang) |
+| [Alibaba DAMO Academy](https://damo.alibaba.com/) | [Yanjun Huang](https://damo.alibaba.com/about/) |
+| [Amazon Web Services](https://aws.amazon.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
+| [Ant Group](https://www.antgroup.com/) | [Yuan Tang](https://github.com/terrytangyuan) |
+| [Atrio](https://www.atrio.io/) | [César Gómez](https://github.com/cesargomez) |
+| [Bloomberg](https://www.bloomberg.com/) | [Chengjian Zheng](https://github.com/czheng94) and [Dan Sun](https://github.com/yuzisun) |
+| [Bytedance](https://www.bytedance.com/) | [Jiaxin Shan](https://github.com/Jeffwan) |
+| [Huawei](https://www.huawei.com/) | [Lei Su](https://github.com/suleisl2000) and [Fei Xu](https://github.com/fisherxu) |
+| [Iguazio](https://www.iguazio.com/) | [Yaron Haviv](https://github.com/yaronha) |
+| [Mellanox Technologies](https://www.mellanox.com/) | [Vitaliy Razinkov](https://github.com/vtlrazin) |
+| [NVIDIA](https://www.nvidia.com/) | [Rong Ou](https://github.com/rongou) |
+| [Pinduoduo](https://en.pinduoduo.com/) | [Shuwen Wang](https://github.com/antshuwen) |
+| [Polyaxon](https://polyaxon.com/) | [Mourad Mourafiq](https://github.com/mouradmourafiq) |
+| [Qihoo 360](https://www.360.cn/) | [Xigang Wang](https://github.com/xigang) |
+| [Qutoutiao](https://www.qutoutiao.net/) | [Zhaojing Yu](https://github.com/yuzhaojing) |
+| [Tencent](http://tencent.com/en-us/) | [Ce Gao](https://github.com/gaocegege), [Wang Zhang](https://github.com/zw0610) and [Lei Xue](https://github.com/carmark)  |
+| [TuSimple](https://www.tusimple.com/) | [Hengliang He](https://github.com/henglianghe) |
+| [vip](https://www.vip.com/) | [Harold Miao](https://github.com/oikomi) |


### PR DESCRIPTION
These are from all the operator repos (mostly just merging the ones from MPI Operator and TF Operator).

@kubeflow/wg-training-leads 

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>