### PR TITLE
Update training-operator image tag

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"
+    newTag: "557ba80eb03a7cd72c482bc9f4061fd7c72cabde"

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"
+    newTag: "557ba80eb03a7cd72c482bc9f4061fd7c72cabde"


### PR DESCRIPTION
Due to workflow failure https://argo.kubeflow-testing.com/workflows/kubeflow-test-infra/kubeflow-tf-operator-postsubmit-v1-e0b872e-2128-8fc4

I use corresponding master commit https://github.com/kubeflow/tf-operator/commit/557ba80eb03a7cd72c482bc9f4061fd7c72cabde

> Note: there's no code different between these two branches. In the future. we should fix https://github.com/kubeflow/tf-operator/issues/1429 and then we can alway get a image to use even there's flaky tests.